### PR TITLE
fix empty rule

### DIFF
--- a/pkg/vulstruct/scanner.go
+++ b/pkg/vulstruct/scanner.go
@@ -79,6 +79,11 @@ func ReadVersionVulSingFile(filename string) (*VersionVul, error) {
 	advisory.Info.Details = strings.TrimSpace(advisory.Info.Details)
 	advisory.Info.References = advisory.References
 
+	if advisory.Rule == "" {
+		advisory.RuleCompile = nil
+		return &advisory, nil
+	}
+
 	// Parse rule string into tokens
 	// 将规则字符串解析为词法单元
 	tokens, err := parser.ParseAdvisorTokens(advisory.Rule)


### PR DESCRIPTION
如果漏洞yaml文件中 rule字段为 ""， 工具执行时解析yaml会报错”token index great token's length “。
增加修改代码，如果规则为空，则RuleCompile保持为nil