### PR TITLE
Fix out-of-bounds panic when quoted string ends with a backslash

### DIFF
--- a/common/fingerprints/parser/token.go
+++ b/common/fingerprints/parser/token.go
@@ -104,6 +104,9 @@ func parseQuotedText(s []rune, start int) (Token, int, error) {
 	i := start + 1
 	for i < len(s) {
 		if s[i] == '\\' { // skip escape '\"'
+			if i+1 >= len(s) { // string ends with \, missing escape character
+				return Token{}, 0, errors.New("invalid escape at end of input: " + string(s[start:]))
+			}
 			n = append(n, s[i+1])
 			i += 2
 		} else if s[i] == '"' { // end of quoted
@@ -113,7 +116,7 @@ func parseQuotedText(s []rune, start int) (Token, int, error) {
 			i++
 		}
 	}
-	return Token{}, 0, errors.New("unknown text:" + string(s[start:]))
+	return Token{}, 0, errors.New("unterminated quoted text: " + string(s[start:]))
 }
 
 // 辅助函数：解析操作符

--- a/common/fingerprints/parser/token_test.go
+++ b/common/fingerprints/parser/token_test.go
@@ -3,21 +3,16 @@ package parser
 import "testing"
 
 func TestParseTokens(t *testing.T) {
-	s := `body="href=\"http://www.thinkphp.cn\">thinkphp</a>" || body="thinkphp_show_page_trace" || icon="f49c4a4bde1eec6c0b80c2277c76e3dbs"`
-	tokens, err := ParseTokens(s)
-	if err != nil {
-		t.Fatal(err)
+	for _, s := range []string{
+		`body="href=\"http://www.thinkphp.cn\">thinkphp</a>" || body="thinkphp_show_page_trace" || icon="f49c4a4bde1eec6c0b80c2277c76e3dbs"`,
+		"body~=\"(<center><strong>EZCMS ([\\d\\.]+) )\"",
+	} {
+		tokens, err := ParseTokens(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(tokens)
 	}
-	t.Log(tokens)
-}
-
-func TestParseTokens2(t *testing.T) {
-	s := "body~=\"(<center><strong>EZCMS ([\\d\\.]+) )\""
-	tokens, err := ParseTokens(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(tokens)
 }
 
 func TestParseTokensInvalidOperator(t *testing.T) {
@@ -33,6 +28,15 @@ func TestParseTokensInvalidOperator(t *testing.T) {
 			t.Logf("parse token `%s` error: %s", s, err)
 		}
 	}
+}
+
+func TestParseStrangeTokens(t *testing.T) {
+	s := `"\`
+	tokens, err := ParseTokens(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(tokens)
 }
 
 func TestParseAdvisorTokens2(t *testing.T) {

--- a/common/fingerprints/parser/token_test.go
+++ b/common/fingerprints/parser/token_test.go
@@ -31,12 +31,19 @@ func TestParseTokensInvalidOperator(t *testing.T) {
 }
 
 func TestParseStrangeTokens(t *testing.T) {
-	s := `"\`
-	tokens, err := ParseTokens(s)
-	if err != nil {
-		t.Fatal(err)
+	for _, s := range []string{
+		`"\`,
+		`"abc\`,
+		`"abc\"`,
+		`"abc\""`,
+	} {
+		tokens, err := ParseTokens(s)
+		if err == nil {
+			t.Log(tokens)
+		} else {
+			t.Logf("parse token `%s` error: %v", s, err)
+		}
 	}
-	t.Log(tokens)
 }
 
 func TestParseAdvisorTokens2(t *testing.T) {


### PR DESCRIPTION
This PR fixes a bug in `parseQuotedText` where a quoted string ending with a single backslash (`\`) would cause an out-of-bounds panic due to unsafe indexing (`s[i+1]`).

### How
- Added a boundary check before accessing `s[i+1]`.