### PR TITLE
一些规则格式的增强和修复

### DIFF
--- a/data/fingerprints/jupyter-lab.yaml
+++ b/data/fingerprints/jupyter-lab.yaml
@@ -17,4 +17,4 @@ version:
     extractor:  
       part: body  
       group: 1  
-      regex: 'appVersion["\']:\s*["\'](\d+\.\d+\.\d+)["\']'
+      regex: "appVersion[\"']:\\s*[\"'](\\d+\\.\\d+\\.\\d+)[\"']"

--- a/data/fingerprints/jupyter-lab.yaml
+++ b/data/fingerprints/jupyter-lab.yaml
@@ -10,7 +10,7 @@ http:
   - method: GET
     path: '/'
     matchers:
-      - body="<title>JupyterLab</title>"
+      - body="<title>JupyterLab</title>" || icon="-895963602"
 version:  
   - method: GET  
     path: '/lab'  

--- a/data/vuln/llamafactory/CVE-2025-53002.yaml
+++ b/data/vuln/llamafactory/CVE-2025-53002.yaml
@@ -14,9 +14,9 @@ info:
     1. 升级到 Llama Factory 版本 > 0.9.3
     2. 确保调用 `torch.load()` 时使用 `weights_only=True` 以防止任意代码执行
     3. 验证并清理 WebUI 中所有的 `Checkpoint path` 输入
-  rule: version <= "0.9.3"
-  references:
-    - https://github.com/hiyouga/LLaMA-Factory/security/advisories/GHSA-xj56-p8mm-qmxj
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-53002
-    - https://github.com/hiyouga/LLaMA-Factory/commit/bb7bf51554d4ba8432333c35a5e3b52705955ede
-    - https://github.com/hiyouga/LLaMA-Factory
+rule: version <= "0.9.3"
+references:
+  - https://github.com/hiyouga/LLaMA-Factory/security/advisories/GHSA-xj56-p8mm-qmxj
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-53002
+  - https://github.com/hiyouga/LLaMA-Factory/commit/bb7bf51554d4ba8432333c35a5e3b52705955ede
+  - https://github.com/hiyouga/LLaMA-Factory


### PR DESCRIPTION
1、在data/fingerprints/jupyter-lab.yaml的regex字段的转义问题，直接编译项目运行会报错
<img width="852" height="98" alt="image" src="https://github.com/user-attachments/assets/b689b0fb-f4ac-4b64-8f08-814ca3f32db9" />
2、data/vuln/llamafactory/CVE-2025-53002.yaml的rule和references字段需要缩进
<img width="763" height="48" alt="image" src="https://github.com/user-attachments/assets/1144ca66-d672-4342-b05f-88b0071662d8" />
修改后则正常匹配jupyter-lab不会出现报错
<img width="702" height="214" alt="image" src="https://github.com/user-attachments/assets/242e89b1-9956-44fa-9785-7bf059cdd46f" />
