### PR TITLE
修复一个数据类型问题

### DIFF
--- a/AIG-PromptSecurity/cli_run.py
+++ b/AIG-PromptSecurity/cli_run.py
@@ -95,7 +95,7 @@ def main():
     if len(set(lengths)) != 1:
         raise ValueError("base_url, api_key, model, max_concurrent must have same number of parameters")
     for base_url, api_key, model_name, max_concurrent  in zip(args.base_url, args.api_key, args.model, args.max_concurrent):
-        model = create_model(model_name, base_url, api_key, max_concurrent)
+        model = create_model(model_name, base_url, api_key[0], max_concurrent)
         models.append(model)
         
     if any(param is None for param in (args.evaluate_model, args.eval_base_url, args.eval_api_key, args.eval_max_concurrent)):


### PR DESCRIPTION
不同于之前版本中api_key为一维列表，当argparse中同时指定nargs=1, action='append'会导致参数类型为二维列表结构