### PR TITLE
Mask model tokens in APIs and preserve key/base_url when editing configs

### DIFF
--- a/common/websocket/model_api.go
+++ b/common/websocket/model_api.go
@@ -108,13 +108,13 @@ func HandleGetModelList(c *gin.Context, mm *ModelManager) {
 
 	// 1. 首先添加系统模型（public_user的模型），永远排在前面
 	for _, model := range publicModels {
-		// 系统模型对外不暴露真实 token，但应返回真实的并发配置 limit，
-		// 方便前端在编辑弹窗中展示和复用当前的并发设置。
+		// 系统模型同样对外不暴露真实 token，但如果存在 token，
+		// 通过掩码串告知“已配置密钥”，方便前端交互。
 		item := map[string]interface{}{
 			"model_id": model.ModelID,
 			"model": map[string]interface{}{
 				"model":    model.ModelName,
-				"token":    "", // 系统模型token置空
+				"token":    maskToken(model.Token),
 				"base_url": model.BaseURL,
 				"note":     model.Note,
 				"limit":    model.Limit,


### PR DESCRIPTION
## Summary

This PR improves the model configuration API behavior for LLM connection configs:

1. **Token masking in responses**
   - `GET /api/v1/app/models` and `GET /api/v1/app/models/:id` no longer return raw API tokens.
   - Both **user models** and **public_user (system) models** now return a fixed mask string (`"********"`) when a token exists, or `""` when no token is stored.
   - This prevents accidental exposure of secrets in the UI or logs while still indicating to users that a key has been configured.

2. **Editing models without re-entering secrets**
   - Split DTOs for creation and update:
     - `ModelInfo` (with `binding:"required"`) is used for **CreateModel**.
     - `UpdateModelInfo` (no `binding:"required"` on `token/base_url`) is used for **UpdateModel**.
   - `PUT /api/v1/app/models/:id` now behaves as:
     - `model_name/note/limit` are always updated from the request.
     - `token` is updated **only if**:
       - the client sends a non-empty value, and
       - the value is **not** the mask string (`"********"`).
     - `base_url` is updated **only if** the client sends a non-empty value.
   - This allows users to:
     - change model name/note/limit without re-entering key/base_url,
     - avoid accidentally overwriting the real token with the mask value,
     - only rotate keys when they explicitly provide a new token.

## Rationale

Previously:

- The same struct with `binding:"required"` was used for both create and update.
- GET APIs returned the **real token**.
- On update, `token` and `base_url` were always overwritten from the request body.

This caused two UX/security issues:

1. Users had to re-enter key/base_url even when they only wanted to change the model name or notes.
2. Returning raw tokens in API responses risks leaking secrets to the UI or logs.

The new design keeps creation strict (all fields required) while making updates more PATCH-like (only fields provided are changed), and masks all tokens consistently in read APIs.

## Implementation details

- File: `common/websocket/model_api.go`
  - Introduce `UpdateModelInfo` and `UpdateModelRequest`.
  - Add `maskedToken` and `maskToken()` helper.
  - Apply `maskToken()` in:
    - `HandleGetModelList` for both `public_user` and user models.
    - `HandleGetModelDetail`.
  - Update semantics in `HandleUpdateModel` to:
    - preserve existing `token/base_url` when omitted,
    - only apply non-empty, non-masked token values.

No changes to database schema or storage format are required.