### PR TITLE
Fix IndexError when chunk.choices is empty in LLM streaming

### DIFF
--- a/mcp-scan/utils/llm.py
+++ b/mcp-scan/utils/llm.py
@@ -44,19 +44,17 @@ class LLM:
         )
 
         for chunk in response:
-            # Skip chunks without choices (e.g. keep-alive or heartbeat)
             choices = getattr(chunk, "choices", None)
-            if not choices:
-                continue
 
+            # Ensure choices is a non-empty list
+            if not isinstance(choices, list) or not choices:
+                continue
             choice = choices[0]
 
-            # Skip chunks without delta (role-only, tool-only, finish_reason)
             delta = getattr(choice, "delta", None)
             if not delta:
                 continue
 
-            # Only yield if there is actual content
             content = getattr(delta, "content", None)
             if content:
                 yield content


### PR DESCRIPTION
### Background

The current streaming parsing logic assumes that every chunk contains
`choices[0].delta.content`.

In practice, OpenAI-compatible streaming responses may include non-text
chunks such as keep-alive, role-only, or tool-only deltas.

### What’s changed

- Safely skip chunks without `choices`
- Ignore non-text deltas
- Avoid assumptions about `delta.content` presence

### Testing

This change was not validated against all real MCP / LLM implementations
due to environment limitations (internal network, holiday period).

The logic follows documented streaming response patterns and does not
alter behavior for standard text streaming cases.

### Scope & Risk

- No API changes
- Low risk, defensive improvement only
