### PR TITLE
评分runner.py中CalcSecScore方法修正（如果危害等级为中文仍能正确计算分数），已提issue

### DIFF
--- a/common/runner/runner.go
+++ b/common/runner/runner.go
@@ -724,9 +724,9 @@ func (r *Runner) CalcSecScore(advisories []vulstruct.Info) CallbackReportInfo {
 	var total, high, middle, low int = 0, 0, 0, 0
 	total = len(advisories)
 	for _, item := range advisories {
-		if item.Severity == "HIGH" || item.Severity == "CRITICAL" {
+		if item.Severity == "HIGH" || item.Severity == "CRITICAL" || item.RiskType == "高危" || item.RiskType == "严重" {
 			high++
-		} else if item.Severity == "MEDIUM" {
+		} else if item.Severity == "MEDIUM" || item.RiskType == "中危" {
 			middle++
 		} else {
 			low++


### PR DESCRIPTION
```
// CalcSecScore 计算安全分数
func (r *Runner) CalcSecScore(advisories []vulstruct.Info) CallbackReportInfo {
	var total, high, middle, low int = 0, 0, 0, 0
	total = len(advisories)
	for _, item := range advisories {
  		if ite m.Severity == "HIGH" || item.Severity == "CRITICAL" {
  			high++
  		} else if item.Severity == "MEDIUM" {
  			middle++
  		} else {
			low++
		}
	}
	if total == 0 {
		return CallbackReportInfo{
			SecScore:   100,
			HighRisk:   0,
			MediumRisk: 0,
			LowRisk:    0,
		}
	}
	// 计算加权风险比例
	weightedRisk := (float64(high)/float64(total))*0.7 +
		(float64(middle)/float64(total))*0.5 +
		(float64(low)/float64(total))*0.3

	// 计算安全评分（百分制）
	safetyScore := 100 - weightedRisk*100

	// 确保评分在0-100范围内
	if safetyScore < 0 {
		safetyScore = 0
	}
	if safetyScore >= 100 {
		safetyScore = 100
	}

	ret := CallbackReportInfo{
		SecScore:   int(math.Round(safetyScore)),
		HighRisk:   high,
		MediumRisk: middle,
		LowRisk:    low,
	}
	return ret
}
```
原代码有问题，没有考虑到当item.Severity为中文时的情况；
实际应该按照common\agent中的utils.go中的CalcMcpScore方法来修正，已提交issue。
修正后：
```
// CalcSecScore 计算安全分数
func (r *Runner) CalcSecScore(advisories []vulstruct.Info) CallbackReportInfo {
	var total, high, middle, low int = 0, 0, 0, 0
	total = len(advisories)
	for _, item := range advisories {
		if item.Severity == "HIGH" || item.Severity == "CRITICAL" || item.RiskType == "高危" || item.RiskType == "严重" {
			high++
		} else if item.Severity == "MEDIUM" || item.RiskType == "中危" {
			middle++
		} else {
			low++
		}
	}
	if total == 0 {
		return CallbackReportInfo{
			SecScore:   100,
			HighRisk:   0,
			MediumRisk: 0,
			LowRisk:    0,
		}
	}
	// 计算加权风险比例
	weightedRisk := (float64(high)/float64(total))*0.7 +
		(float64(middle)/float64(total))*0.5 +
		(float64(low)/float64(total))*0.3

	// 计算安全评分（百分制）
	safetyScore := 100 - weightedRisk*100

	// 确保评分在0-100范围内
	if safetyScore < 0 {
		safetyScore = 0
	}
	if safetyScore >= 100 {
		safetyScore = 100
	}

	ret := CallbackReportInfo{
		SecScore:   int(math.Round(safetyScore)),
		HighRisk:   high,
		MediumRisk: middle,
		LowRisk:    low,
	}
	return ret
}
```
