### PR TITLE
评分runner.py中CalcSecScore方法修正（更正item.RiskType为item.Severity）

### DIFF
--- a/common/runner/runner.go
+++ b/common/runner/runner.go
@@ -724,9 +724,9 @@ func (r *Runner) CalcSecScore(advisories []vulstruct.Info) CallbackReportInfo {
 	var total, high, middle, low int = 0, 0, 0, 0
 	total = len(advisories)
 	for _, item := range advisories {
-		if item.Severity == "HIGH" || item.Severity == "CRITICAL" || item.RiskType == "高危" || item.RiskType == "严重" {
+		if item.Severity == "HIGH" || item.Severity == "CRITICAL" || item.Severity == "高危" || item.Severity == "严重" {
 			high++
-		} else if item.Severity == "MEDIUM" || item.RiskType == "中危" {
+		} else if item.Severity == "MEDIUM" || item.Severity == "中危" {
 			middle++
 		} else {
 			low++


### PR DESCRIPTION
抱歉，之前push的版本有误，现将代码更正至正确版本