### PR TITLE
fix: handle chmod failures in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,15 +5,18 @@
 
 set -e
 
+# 权限修改失败时提示并继续（例如挂载卷上无法改权限）
+warn_or_continue() { echo "Warning: $1" >&2; }
+
 echo 正在初始化 AI-Infra-Guard 服务...
 # 创建必要的目录
 mkdir -p /ai-infra-guard/db /ai-infra-guard/uploads /ai-infra-guard/logs
 
 # 设置文件权限
 echo 设置文件权限...
-chmod 755 /ai-infra-guard/db || error_exit "Skip permission change on mounted volume"
-chmod 755 /ai-infra-guard/uploads || error_exit "Skip permission change on mounted volume"
-chmod 755 /ai-infra-guard/logs || error_exit "Skip permission change on mounted volume"
+chmod 755 /ai-infra-guard/db || warn_or_continue "Skip permission change on mounted volume"
+chmod 755 /ai-infra-guard/uploads || warn_or_continue "Skip permission change on mounted volume"
+chmod 755 /ai-infra-guard/logs || warn_or_continue "Skip permission change on mounted volume"
 
 # 创建日志文件
 echo 初始化日志文件...


### PR DESCRIPTION
This fixes a small bug in `start.sh` where `error_exit` is called but not defined. If `chmod` fails, the script currently throws a command-not-found style error instead of showing a clear message. This change makes the failure path predictable and easier to debug.