### PR TITLE
[AIG-Bot] 新增漏洞规则 2026-03-16（32 条 CVE + 11 条指纹）

### DIFF
--- a/data/fingerprints/apache-livy.yaml
+++ b/data/fingerprints/apache-livy.yaml
@@ -1,0 +1,20 @@
+info:
+  name: apache-livy
+  author: A.I.G bot
+  severity: info
+  desc: Apache Livy is a service that enables easy interaction with a Spark cluster over a REST interface. It enables programmatic, fault-tolerant, multi-tenant submission of Spark jobs from web/mobile apps, widely used in ML/AI training pipelines.
+  metadata:
+    product: apache-livy
+    vendor: apache
+http:
+  - method: GET
+    path: '/sessions'
+    matchers:
+      - body='"sessions"' && body='"total"' && body='"from"'
+  version:
+    - method: GET
+      path: '/version'
+      extractor:
+        part: body
+        group: 1
+        regex: '"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)"'

--- a/data/fingerprints/claudecodeui.yaml
+++ b/data/fingerprints/claudecodeui.yaml
@@ -1,0 +1,13 @@
+info:
+  name: claudecodeui
+  author: A.I.G bot
+  severity: info
+  desc: Claude Code UI (claudecodeui) is a desktop and mobile UI for Claude Code, Cursor CLI, Codex, and Gemini-CLI.
+  metadata:
+    product: claudecodeui
+    vendor: siteboon
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>Claude Code</title>" || body="claudecodeui" || body="app-name=\"ClaudeCodeUI\""

--- a/data/fingerprints/fastgpt.yaml
+++ b/data/fingerprints/fastgpt.yaml
@@ -1,0 +1,13 @@
+info:
+  name: fastgpt
+  author: A.I.G bot
+  severity: info
+  desc: FastGPT is an AI knowledge base Q&A platform and AI Agent building platform built on LLMs.
+  metadata:
+    product: fastgpt
+    vendor: labring
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>FastGPT</title>" || body="fastgpt"

--- a/data/fingerprints/flowise.yaml
+++ b/data/fingerprints/flowise.yaml
@@ -1,0 +1,20 @@
+info:
+  name: flowise
+  author: A.I.G bot
+  severity: info
+  desc: Flowise is an open-source low-code platform for building AI agents and LLM-powered chatflows with a visual drag-and-drop interface.
+  metadata:
+    product: flowise
+    vendor: flowiseai
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>Flowise</title>"
+version:
+  - method: GET
+    path: '/api/v1/version'
+    extractor:
+      part: body
+      group: 1
+      regex: '"version"\s*:\s*"(\d+\.\d+\.?\d*?)"'

--- a/data/fingerprints/hyperterse.yaml
+++ b/data/fingerprints/hyperterse.yaml
@@ -1,0 +1,13 @@
+info:
+  name: hyperterse
+  author: A.I.G bot
+  severity: info
+  desc: Hyperterse is a tool-first MCP framework for building AI-ready backend surfaces from declarative config, exposing database tools to LLMs via MCP protocol.
+  metadata:
+    product: hyperterse
+    vendor: hyperterse
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>Hyperterse</title>" || body="hyperterse"

--- a/data/fingerprints/librechat.yaml
+++ b/data/fingerprints/librechat.yaml
@@ -1,0 +1,20 @@
+info:
+  name: librechat
+  author: A.I.G bot
+  severity: info
+  desc: LibreChat is an open-source, self-hosted AI chat platform supporting multiple AI providers (OpenAI, Anthropic, Google, etc.), agents, MCP, and code execution. It provides a ChatGPT-like interface for enterprise and personal use.
+  metadata:
+    product: librechat
+    vendor: danny-avila
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="LibreChat" || header="librechat"
+  version:
+    - method: GET
+      path: '/api/health'
+      extractor:
+        part: body
+        group: 1
+        regex: '"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+[^"]*)"'

--- a/data/fingerprints/openchatbi.yaml
+++ b/data/fingerprints/openchatbi.yaml
@@ -1,0 +1,13 @@
+info:
+  name: openchatbi
+  author: A.I.G bot
+  severity: info
+  desc: OpenChatBI是基于大语言模型的智能对话式BI分析工具，支持自然语言查询数据和可视化，提供Web服务接口。
+  metadata:
+    product: openchatbi
+    vendor: zhongyu09
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>OpenChatBI</title>" || body="openchatbi"

--- a/data/fingerprints/openclaw.yaml
+++ b/data/fingerprints/openclaw.yaml
@@ -1,0 +1,13 @@
+info:
+  name: openclaw
+  author: A.I.G bot
+  severity: info
+  desc: OpenClaw is a personal AI assistant platform with tool-use, skill management, and gateway service.
+  metadata:
+    product: openclaw
+    vendor: openclaw
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<openclaw-app>" || body="<title>OpenClaw Control</title>" || body="<title>Clawdbot Control</title>"

--- a/data/fingerprints/sglang.yaml
+++ b/data/fingerprints/sglang.yaml
@@ -1,0 +1,24 @@
+info:
+  name: sglang
+  author: A.I.G bot
+  severity: info
+  desc: SGLang is a fast serving framework for large language models and vision-language models, providing OpenAI-compatible API endpoints.
+  metadata:
+    product: sglang
+    vendor: sgl-project
+http:
+  - method: GET
+    path: '/v1/models'
+    matchers:
+      - body="sglang" || body="SGLang"
+  - method: GET
+    path: '/get_server_info'
+    matchers:
+      - body="sglang" || body="version"
+version:
+  - method: GET
+    path: '/get_server_info'
+    extractor:
+      part: body
+      group: 1
+      regex: '"version"\s*:\s*"([0-9]+\.[0-9]+\.[0-9]+)"'

--- a/data/fingerprints/weknora.yaml
+++ b/data/fingerprints/weknora.yaml
@@ -1,0 +1,13 @@
+info:
+  name: weknora
+  author: A.I.G bot
+  severity: info
+  desc: WeKnora是腾讯开源的基于大语言模型的文档深度理解与语义检索框架，提供Web服务接口，支持文档导入、语义搜索和MCP配置。
+  metadata:
+    product: weknora
+    vendor: tencent
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>WeKnora</title>" || body="weknora"

--- a/data/fingerprints/zeptoclaw.yaml
+++ b/data/fingerprints/zeptoclaw.yaml
@@ -1,0 +1,13 @@
+info:
+  name: zeptoclaw
+  author: A.I.G bot
+  severity: info
+  desc: ZeptoClaw is a personal AI assistant platform supporting multi-channel integrations including webhooks, with agent orchestration and session management capabilities.
+  metadata:
+    product: zeptoclaw
+    vendor: qhkm
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>ZeptoClaw</title>" || body="zeptoclaw"

--- a/data/vuln/apache-livy/CVE-2025-60012.yaml
+++ b/data/vuln/apache-livy/CVE-2025-60012.yaml
@@ -1,0 +1,22 @@
+info:
+  name: Apache Livy
+  cve: CVE-2025-60012
+  summary: Apache Livy 恶意 Spark 配置导致未授权文件访问漏洞
+  details: >-
+    Apache Livy 0.7.0 和 0.8.0 版本在连接 Apache Spark 3.1 或更高版本时存在未授权文件访问漏洞。
+    攻击者可以通过 REST 或 JDBC 接口发送包含特定 Spark 配置参数的请求，使其访问到本无权限访问的文件。
+    该漏洞的利用条件为：攻击者须能访问 Apache Livy 的 REST 或 JDBC 接口，并可发送包含任意
+    Spark 配置值的请求。漏洞根本原因是对通过 REST API 传入的 Spark 配置参数未做充分的输入验证
+    （CWE-20）。发布时暂无公开 PoC 或主动利用案例。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级 Apache Livy 至 0.9.0 或更高版本以修复此漏洞。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-60012
+    - https://lists.apache.org/thread/gpc85fwrgrbglpk9gm8tmcjzqnctx64w
+    - http://www.openwall.com/lists/oss-security/2026/03/12/1
+rule: version == "0.7.0" || version == "0.8.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-60012
+  - https://lists.apache.org/thread/gpc85fwrgrbglpk9gm8tmcjzqnctx64w
+  - http://www.openwall.com/lists/oss-security/2026/03/12/1

--- a/data/vuln/apache-livy/CVE-2025-66249.yaml
+++ b/data/vuln/apache-livy/CVE-2025-66249.yaml
@@ -1,0 +1,23 @@
+info:
+  name: Apache Livy
+  cve: CVE-2025-66249
+  summary: Apache Livy 在非默认 local-dir-whitelist 配置下存在路径遍历漏洞
+  details: >-
+    Apache Livy 0.3.0 至 0.9.0（不含）版本存在路径限制不当漏洞（CWE-22）。
+    当配置项 "livy.file.local-dir-whitelist" 被设置为非默认值时，目录检查逻辑可被绕过，
+    允许经过认证的用户执行路径遍历攻击，访问预期目录之外的文件。该漏洞需要
+    非默认服务器配置才可被利用。发布时暂无公开 PoC 或在野利用记录。
+    强烈建议用户升级至 0.9.0 或更高版本。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: >-
+    升级 Apache Livy 至 0.9.0 或更高版本。临时缓解措施：确保
+    "livy.file.local-dir-whitelist" 未被设置为非默认值，或将 API 访问限制为受信任用户。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-66249
+    - https://lists.apache.org/thread/1xwphsfn4jbtym4k4o0zlvwfogwqwwc3
+    - http://www.openwall.com/lists/oss-security/2026/03/12/2
+rule: version >= "0.3.0" && version < "0.9.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-66249
+  - https://lists.apache.org/thread/1xwphsfn4jbtym4k4o0zlvwfogwqwwc3

--- a/data/vuln/claudecodeui/CVE-2026-31861.yaml
+++ b/data/vuln/claudecodeui/CVE-2026-31861.yaml
@@ -1,0 +1,27 @@
+info:
+  name: claudecodeui
+  cve: CVE-2026-31861
+  summary: 'Cloud CLI claudecodeui git-config 端点 gitName/gitEmail 参数 shell 命令注入'
+  details: >-
+    Cloud CLI（又名 Claude Code UI）1.24.0 版本之前，/api/user/git-config 端点
+    （server/routes/user.js 第 58-59 行）存在 shell 命令注入漏洞。该端点将用户
+    提供的 gitName 和 gitEmail 值直接拼接进传递给 child_process.exec() 的命令字
+    符串中。输入被放置于双引号内，仅转义了双引号字符，而反引号命令替换、$()
+    命令替换及反斜杠序列均未被过滤。持有有效 JWT token 的攻击者（可通过伴生的
+    认证绕过漏洞 VULN-01 获取）可通过 gitName 或 gitEmail 注入任意 OS 命令，以
+    Node.js 进程用户权限实现任意代码执行。CVSS 8.8 评分假设需要认证；若与认证绕
+    过漏洞链式利用，实际影响可升级至严重级别。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 立即将 claudecodeui 升级至 1.24.0 或更高版本。补丁对 /api/user/git-config 端点的 gitName 和 gitEmail 参数进行了严格净化，防止 shell 元字符注入。
+  references:
+  - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-7fv4-fmmc-86g2
+  - https://github.com/siteboon/claudecodeui/commit/86c33c1c0cb34176725a38f46960213714fc3e04
+  - https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31861
+rule: version <= "1.23.0"
+references:
+- https://github.com/siteboon/claudecodeui/security/advisories/GHSA-7fv4-fmmc-86g2
+- https://github.com/siteboon/claudecodeui/commit/86c33c1c0cb34176725a38f46960213714fc3e04
+- https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-31861

--- a/data/vuln/claudecodeui/CVE-2026-31862.yaml
+++ b/data/vuln/claudecodeui/CVE-2026-31862.yaml
@@ -1,0 +1,29 @@
+info:
+  name: claudecodeui
+  cve: CVE-2026-31862
+  summary: 'Cloud CLI claudecodeui Git API 端点 shell 元字符命令注入导致 RCE'
+  details: >-
+    Cloud CLI（又名 Claude Code UI）是 Claude Code、Cursor CLI、Codex 和
+    Gemini-CLI 的 Web 管理界面。1.24.0 版本之前，server/routes/git.js 中多个
+    Git 相关 API 端点使用 execAsync() 对用户可控参数（file、branch、message、
+    commit）进行字符串直接拼接。应用虽尝试转义双引号，但防护可被轻易绕过——攻击
+    者可利用命令替换 $(command)、反引号执行、分号命令链接及换行符注入等 shell
+    元字符绕过过滤。受影响端点包括 GET /api/git/diff、GET /api/git/status、POST
+    /api/git/commit（files 数组和 message）、POST /api/git/checkout、POST
+    /api/git/create-branch、GET /api/git/commits 和 GET
+    /api/git/commit-diff。已认证攻击者可以 Node.js 进程用户权限实现任意命令执行，
+    进而导致服务器完全失陷、数据泄露及供应链攻击。修复方案将所有
+    execAsync() 调用替换为 spawnAsync()（shell: false），以数组方式直接传参给
+    OS，使 shell 元字符失效。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 立即将 claudecodeui 升级至 1.24.0 或更高版本。补丁将 server/routes/git.js 中所有 Git 路由处理函数的 execAsync() 替换为 spawnAsync()（shell: false），从根本上消除命令注入风险。
+  references:
+  - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-f2fc-vc88-6w7q
+  - https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31862
+rule: version <= "1.23.0"
+references:
+- https://github.com/siteboon/claudecodeui/security/advisories/GHSA-f2fc-vc88-6w7q
+- https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-31862

--- a/data/vuln/claudecodeui/CVE-2026-31975.yaml
+++ b/data/vuln/claudecodeui/CVE-2026-31975.yaml
@@ -1,0 +1,22 @@
+info:
+  name: claudecodeui
+  cve: CVE-2026-31975
+  summary: Claude Code UI WebSocket Shell 参数未过滤导致的 OS 命令注入漏洞
+  details: >-
+    Cloud CLI（即 Claude Code UI）1.25.0 之前版本的 WebSocket Shell 处理程序（server/index.js）
+    中存在 OS 命令注入漏洞。从 WebSocket 消息载荷中获取的 projectPath 和 initialCommand
+    参数被直接插入 bash 命令字符串而未进行任何过滤，可导致任意 OS 命令执行。此外，
+    未经过滤的 sessionId 也是一个次级注入向量。任何能够访问 WebSocket 端点的攻击者
+    都可注入以服务器进程权限执行的任意 OS 命令。这是一个严重的远程代码执行漏洞，
+    影响所有将 Claude Code UI 服务器暴露于网络访问的用户。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 Claude Code UI 至 1.25.0 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31975
+    - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-gv8f-wpm2-m5wr
+    - https://github.com/siteboon/claudecodeui/releases/tag/v1.25.0
+rule: version < "1.25.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31975
+  - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-gv8f-wpm2-m5wr

--- a/data/vuln/fastgpt/CVE-2026-32128.yaml
+++ b/data/vuln/fastgpt/CVE-2026-32128.yaml
@@ -1,0 +1,21 @@
+info:
+  name: fastgpt
+  cve: CVE-2026-32128
+  summary: FastGPT Python 沙箱 seccomp 绕过漏洞（stdout 文件描述符重映射）
+  details: >-
+    FastGPT 4.14.7 及之前版本的 Python 沙箱（fastgpt-sandbox）包含旨在防止文件写入的
+    安全机制，结合静态检测和 seccomp 系统调用过滤。这些防护措施可通过使用 fcntl 系统调用
+    将 stdout（文件描述符 1）重映射到任意可写文件描述符来绕过。重映射后，通过
+    sys.stdout.write() 写入仍满足 seccomp 规则 write(fd==1)，即可在沙箱容器内
+    实现任意文件创建或覆盖，绕过"禁止文件写入"的限制。恶意用户提供的 Python 代码
+    可借此逃逸沙箱的写入限制，可能导致容器逃逸或数据外泄。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级 FastGPT 至 4.14.7 以上版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32128
+    - https://github.com/labring/FastGPT/security/advisories/GHSA-6hw6-mxrm-v6wj
+rule: version <= "4.14.7"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32128
+  - https://github.com/labring/FastGPT/security/advisories/GHSA-6hw6-mxrm-v6wj

--- a/data/vuln/flowise/CVE-2026-30820.yaml
+++ b/data/vuln/flowise/CVE-2026-30820.yaml
@@ -1,0 +1,29 @@
+info:
+  name: Flowise
+  cve: CVE-2026-30820
+  summary: Flowise 通过伪造 x-request-from 请求头实现授权绕过（权限提升）
+  details: >-
+    Flowise 3.0.13 之前的版本存在授权绕过漏洞（CWE-863：授权验证不当）。
+    负责保护 /api/v1/** 路由的全局中间件会盲目信任任何携带
+    `x-request-from: internal` 头部的 HTTP 请求，绕过所有 /api/v1/** 的授权检查。
+    低权限租户只需持有有效的浏览器 Cookie，附加该伪造请求头即可访问内部管理端点，
+    包括 API 密钥管理（/api/v1/apikey）、凭证存储（/api/v1/credentials）、
+    自定义函数执行（/api/v1/node-custom-function）等高权限接口，实现权限提升。
+    若与自定义函数 RCE 等其他漏洞链式利用，可能导致服务器完全失陷。
+    官方安全公告（GHSA-wvhq-wp8g-c7vq）中已包含公开的 PoC 验证步骤。
+    所有依赖默认中间件的自托管 Flowise 3.0.13 之前部署均受影响。
+    CVSS 4.0 评分反映了网络可达、低权限、高保密性/完整性/可用性影响的攻击特征。
+  cvss: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+  severity: CRITICAL
+  security_advise: >-
+    将 Flowise 升级至 3.0.13 或更高版本。补丁移除了对 `x-request-from: internal`
+    请求头的盲目信任逻辑，对所有 /api/v1/** 路由强制执行正确的授权检查，不再受请求头影响。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+    - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13

--- a/data/vuln/flowise/CVE-2026-30823.yaml
+++ b/data/vuln/flowise/CVE-2026-30823.yaml
@@ -1,0 +1,24 @@
+info:
+  name: Flowise
+  cve: CVE-2026-30823
+  summary: Flowise IDOR 漏洞导致账户接管及企业 SSO 功能鉴权绕过
+  details: >-
+    Flowise 是一款拖拽式低代码大语言模型工作流构建平台。3.0.13 版本之前，PUT
+    /api/v1/loginmethod 接口存在不安全的直接对象引用（IDOR）漏洞。服务端从请求
+    体中接收 organizationId 参数，但未校验当前认证用户是否拥有对目标组织的所有权
+    或管理员权限。任意低权限认证用户（包括免费计划用户）均可利用此缺陷：覆盖其他
+    组织的 SSO 配置、在无有效许可证的情况下启用企业级功能（SSO/SAML），并通过将
+    认证流重定向至攻击者控制的 OAuth 凭据来实施账户接管。官方安全公告中已包含完整
+    的分步利用 PoC，利用仅需一个有效 JWT Token 以及目标 organizationId。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: 立即将 Flowise 升级至 3.0.13 或更高版本。补丁在 PUT /api/v1/loginmethod 接口增加了归属校验，确保用户只能修改自己组织的 SSO 配置。
+  references:
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30823
+rule: version <= "3.0.12"
+references:
+- https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+- https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30823

--- a/data/vuln/flowise/CVE-2026-31829.yaml
+++ b/data/vuln/flowise/CVE-2026-31829.yaml
@@ -1,0 +1,27 @@
+info:
+  name: Flowise
+  cve: CVE-2026-31829
+  summary: Flowise HTTP 节点服务端请求伪造（SSRF）漏洞，攻击者可访问内部网络
+  details: >-
+    Flowise 3.0.13 之前版本在 AgentFlow 和 Chatflow 中暴露了 HTTP 节点，该节点使用用户
+    可控的 URL 执行服务端 HTTP 请求，且默认不限制目标主机。私有/内网 IP 地址段
+    （RFC 1918）、localhost 以及云元数据接口（如 AWS IMDSv1 169.254.169.254）均未被
+    过滤。这使得任何与公开暴露的 chatflow 交互的用户均可触发服务端请求伪造（SSRF），
+    强制 Flowise 服务器向内网资源发起请求。该漏洞危害尤为严重，原因是 Flowise 实例常在
+    未启用认证（默认未设置 FLOWISE_USERNAME/PASSWORD）的情况下公开部署。HTTP 节点支持
+    所有标准 HTTP 方法（GET/POST/PUT/PATCH/DELETE），可对内部服务实施读写操作。危害包括：
+    从云元数据接口获取 IAM 凭证、访问内部管理面板（Jenkins、Kubernetes API）、对内网
+    服务进行端口扫描及横向移动。漏洞公告中附有完整攻击概念验证（PoC），利用成熟度为高。
+  cvss: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:L
+  severity: HIGH
+  security_advise: 升级 Flowise 至 3.0.13 或更高版本。修复版本在 HTTP 节点中新增了安全
+    控制选项，包括"阻止私有 IP 范围和 localhost"开关及允许域名白名单。在升级前，建议
+    限制 Flowise 实例的网络访问权限，并通过设置 FLOWISE_USERNAME 和 FLOWISE_PASSWORD
+    环境变量启用身份认证。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7

--- a/data/vuln/hyperterse/CVE-2026-31841.yaml
+++ b/data/vuln/hyperterse/CVE-2026-31841.yaml
@@ -1,0 +1,24 @@
+info:
+  name: hyperterse
+  cve: CVE-2026-31841
+  summary: Hyperterse MCP 框架 search 工具响应中暴露原始 SQL 数据库语句给 LLM
+  details: >-
+    Hyperterse 是基于声明式配置构建 AI 就绪后端接口的 MCP 优先框架，自 2.0.0 版本起
+    对外暴露 search 和 execute 两个工具。2.2.0 版本之前，search 工具允许 LLM 通过自
+    然语言搜索可用工具，但其响应中包含了本应在底层执行、不对外公开的原始 SQL 查询语
+    句。这些内部数据库语句被暴露在 search 工具的输出结果中，泄露了应当保护的后端查询
+    逻辑。在 LLM 集成部署场景中，此类信息泄露可被用于提示词注入攻击，或帮助攻击者通
+    过了解底层查询结构来构造更具针对性的 SQL 注入载荷。该漏洞被归类为 CWE-433（未经
+    解析的原始 Web 内容传输）。目前无公开 PoC，利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N
+  severity: MEDIUM
+  security_advise: 将 hyperterse 升级至 2.2.0 或更高版本。修复版本从 search 工具响应中移除了原始 SQL 语句的暴露，并添加了回归测试。
+  references:
+  - https://github.com/hyperterse/hyperterse/security/advisories/GHSA-92gp-jfgx-9qpv
+  - https://github.com/hyperterse/hyperterse/releases/tag/v2.2.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31841
+rule: version >= "2.0.0" && version < "2.2.0"
+references:
+- https://github.com/hyperterse/hyperterse/security/advisories/GHSA-92gp-jfgx-9qpv
+- https://github.com/hyperterse/hyperterse/releases/tag/v2.2.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-31841

--- a/data/vuln/librechat/CVE-2026-31944.yaml
+++ b/data/vuln/librechat/CVE-2026-31944.yaml
@@ -1,0 +1,25 @@
+info:
+  name: LibreChat
+  cve: CVE-2026-31944
+  summary: LibreChat MCP OAuth 回调会话绑定缺失，导致 OAuth 令牌窃取与账户接管
+  details: >-
+    LibreChat 0.8.2 至 0.8.2-rc3 版本在 MCP（Model Context Protocol）OAuth 回调端点
+    存在严重认证缺陷（CWE-306）。回调端点在接受身份提供商重定向后，将 OAuth 令牌存储到
+    发起流程的会话中，但未验证完成重定向的浏览器是否以相同用户身份登录。攻击者可构造
+    授权 URL 并发送给受害者；当受害者完成 OAuth 流程后，受害者的 OAuth 令牌将被存储在
+    攻击者的 LibreChat 账户中，从而实现对受害者 MCP 关联服务（如 Atlassian、Outlook、
+    GitHub）的账户接管。攻击要求攻击者拥有已认证的 LibreChat 账户且受害者点击构造链接。
+    发布时漏洞利用成熟度为 LOW，暂无公开 PoC。由于可能造成 MCP 关联第三方服务的账户
+    接管，严重性评级为 HIGH。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: >-
+    升级 LibreChat 至 0.8.3-rc1 或更高版本。临时缓解措施：在完成升级前禁用 MCP OAuth
+    集成。若怀疑存在未授权访问，应立即撤销 MCP 关联服务的 OAuth 令牌。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g
+rule: version == "0.8.2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g

--- a/data/vuln/librechat/CVE-2026-31949.yaml
+++ b/data/vuln/librechat/CVE-2026-31949.yaml
@@ -1,0 +1,24 @@
+info:
+  name: LibreChat
+  cve: CVE-2026-31949
+  summary: LibreChat DELETE /api/convos 端点未处理的 TypeError 导致 Node.js 服务器进程崩溃（DoS）
+  details: >-
+    LibreChat 0.8.3-rc1 之前版本在 DELETE /api/convos 端点存在拒绝服务（DoS）漏洞
+    （CWE-248）。路由处理器在未验证 req.body 是否存在或非空的情况下直接对
+    req.body.arg 进行解构赋值。当经过认证的攻击者发送格式错误的 DELETE 请求（如请求体
+    为空或缺失）时，服务器抛出未处理的 TypeError，该异常绕过 Express.js 错误处理中间件
+    并触发 process.exit(1)，导致整个 Node.js 服务进程崩溃。这将造成所有用户的完全服务中断，
+    直至服务器重启。该漏洞需要经过认证的攻击者，且此端点无速率限制保护。发布时漏洞
+    利用成熟度为 LOW，暂无公开 PoC。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+  severity: MEDIUM
+  security_advise: >-
+    升级 LibreChat 至 0.8.3-rc1 或更高版本。临时缓解措施：将 API 访问限制为
+    受信任的认证用户，并监控异常的 DELETE /api/convos 请求模式。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p
+rule: version < "0.8.3-rc1"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p

--- a/data/vuln/llama-cpp/CVE-2026-27940.yaml
+++ b/data/vuln/llama-cpp/CVE-2026-27940.yaml
@@ -1,0 +1,25 @@
+info:
+  name: llama-cpp
+  cve: CVE-2026-27940
+  summary: llama.cpp mem_size 计算整数溢出导致堆缓冲区溢出，可通过恶意 GGUF 文件触发任意代码执行
+  details: >-
+    llama.cpp 是基于 C/C++ 的 LLM 模型推理引擎。b8146 构建版本之前，gguf.cpp 中的
+    gguf_init_from_file_impl() 函数在 mem_size 计算中存在整数溢出漏洞。CVE-2025-53630
+    虽然为 ctx->size 的逐次累加添加了溢出检查，但最终的 mem_size 计算公式
+    (n_tensors+1)*ggml_tensor_overhead() + ctx->size 未加防护。当 ctx->size 接近
+    SIZE_MAX 时（可通过两个大型 I8 张量实现，各次累加均通过 CVE-2025-53630 检查），
+    最终加法产生整数回绕，导致堆分配大小偏小。后续的 fread() 调用将 528+ 字节的攻击
+    者可控数据写入缓冲区边界之外。通过将分配大小调整到 glibc tcache 范围内，可将此漏
+    洞升级为完整的任意代码执行（通过 system(/bin/sh) 获取 root shell）。攻击向量为本
+    地（AV:L），需诱导用户加载恶意 GGUF 模型文件。该漏洞是对同一函数中 CVE-2025-53630
+    修复的绕过。目前无公开 PoC，利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 将 llama.cpp 升级至 b8146 或更高构建版本。修复版本在 gguf_init_from_file_impl() 的 mem_size 计算中增加了溢出防护，防止 ctx->size 接近 SIZE_MAX 时的整数回绕。同时应避免加载来自不可信来源的 GGUF 模型文件。
+  references:
+  - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-27940
+rule: version < "b8146"
+references:
+- https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+- https://nvd.nist.gov/vuln/detail/CVE-2026-27940

--- a/data/vuln/openchatbi/CVE-2026-28795.yaml
+++ b/data/vuln/openchatbi/CVE-2026-28795.yaml
@@ -1,0 +1,25 @@
+info:
+  name: OpenChatBI
+  cve: CVE-2026-28795
+  summary: OpenChatBI save_report 工具路径遍历漏洞导致任意文件写入及潜在 RCE
+  details: >-
+    OpenChatBI 是基于大语言模型的智能对话式 BI 工具，支持通过自然语言查询、分析和可视
+    化数据。0.2.2 版本之前，openchatbi/tool/save_report.py 中的 save_report 工具因
+    对 file_format 参数的过滤不足而存在路径遍历漏洞。该函数仅通过
+    file_format.lstrip(".") 去除前导点号，但未过滤 /../../ 等路径遍历序列。当输出文件
+    名通过字符串拼接 f"{timestamp}_{clean_title}.{file_format}" 构造时，恶意路径序列
+    被原样保留，使攻击者能够向指定报告目录之外写入文件。攻击者可操纵 LLM 以构造的
+    file_format 调用 save_report，覆盖 __init__.py 等关键应用文件，进而可能升级为远程
+    代码执行。目前未发现公开 PoC，利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: 立即将 OpenChatBI 升级至 0.2.2 或更高版本。补丁在 save_report.py 的 file_format 参数处添加了正确的路径净化逻辑，防止目录遍历序列被利用。
+  references:
+  - https://github.com/zhongyu09/openchatbi/security/advisories/GHSA-vmwq-8g8c-jm79
+  - https://github.com/zhongyu09/openchatbi/commit/372a7e861da5159c3106d64d6f6edf8284db8c75
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-28795
+rule: version <= "0.2.1"
+references:
+- https://github.com/zhongyu09/openchatbi/security/advisories/GHSA-vmwq-8g8c-jm79
+- https://github.com/zhongyu09/openchatbi/commit/372a7e861da5159c3106d64d6f6edf8284db8c75
+- https://nvd.nist.gov/vuln/detail/CVE-2026-28795

--- a/data/vuln/openclaw/CVE-2026-30741.yaml
+++ b/data/vuln/openclaw/CVE-2026-30741.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-30741
+  summary: OpenClaw Agent 平台 agent 任务执行中的请求侧提示词注入导致 RCE
+  details: >-
+    OpenClaw Agent Platform v2026.2.6 及更早版本在 agent 任务执行管道中存在远程代码执
+    行漏洞（CWE-94）。平台在处理用户提供的提示词内容时缺乏充分净化，未认证的远程攻击
+    者可通过请求侧提示词注入将恶意指令注入 agent 运行时，操纵 agent 在底层服务器上执行
+    任意代码。该漏洞无需认证即可触发，任何可达网络的攻击者均可利用。目前无公开 PoC，
+    利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 将 OpenClaw Agent Platform 升级至 v2026.2.6 之后的版本。对 agent 任务执行管道中所有用户提供的内容实施输入验证和提示词净化控制。
+  references:
+  - https://github.com/Named1ess/CVE-2026-30741
+  - https://github.com/OpenClaw/OpenClaw
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30741
+rule: version <= "2026.2.6"
+references:
+- https://github.com/Named1ess/CVE-2026-30741
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30741

--- a/data/vuln/openclaw/CVE-2026-32059.yaml
+++ b/data/vuln/openclaw/CVE-2026-32059.yaml
@@ -1,0 +1,18 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32059
+  summary: OpenClaw tools.exec.safeBins 白名单绕过漏洞（sort 命令 GNU 长选项缩写）
+  details: >-
+    OpenClaw 2026.2.22-2 版本的 tools.exec.safeBins 对 sort 命令的验证存在授权绕过漏洞。
+    验证逻辑未能正确验证 GNU 长选项缩写，允许攻击者通过白名单模式下的缩写选项绕过禁止标志检查。
+    远程攻击者可使用缩写长选项执行 sort 命令，从而跳过审批要求。
+    此漏洞影响 exec 工具的白名单执行机制，可能允许未经授权的命令以提升的权限执行。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 至 2026.2.23 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32059
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-3c6h-g97w-fg78
+rule: version >= "2026.2.22-2" && version < "2026.2.23"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32059

--- a/data/vuln/openclaw/CVE-2026-32060.yaml
+++ b/data/vuln/openclaw/CVE-2026-32060.yaml
@@ -1,0 +1,18 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32060
+  summary: OpenClaw apply_patch 路径穿越漏洞（任意文件写入/删除）
+  details: >-
+    OpenClaw 2026.2.14 之前版本的 apply_patch 功能中存在路径穿越漏洞。
+    当 apply_patch 启用且未配置文件系统沙箱隔离时，攻击者可通过精心构造的路径
+    （包含目录穿越序列如 ../../ 或绝对路径）逃逸工作区边界，修改或删除 OpenClaw
+    进程用户有权访问的任意文件。这可导致数据破坏、权限提升，或通过覆盖敏感系统文件
+    或应用配置实现远程代码执行。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 至 2026.2.14 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32060
+rule: version < "2026.2.14"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32060

--- a/data/vuln/openclaw/CVE-2026-32061.yaml
+++ b/data/vuln/openclaw/CVE-2026-32061.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32061
+  summary: OpenClaw $include 指令路径穿越漏洞（任意本地文件读取）
+  details: >-
+    OpenClaw 2026.2.17 之前版本的 $include 指令解析中存在路径穿越漏洞。
+    具有配置修改权限的攻击者可通过在 $include 指令中指定绝对路径、穿越序列或符号链接，
+    访问配置目录边界之外 OpenClaw 进程用户可读的敏感文件，包括 API 密钥和凭证等。
+    漏洞利用需要高权限（配置修改访问权限）且为本地攻击向量，但可导致敏感凭证信息的重大泄露。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: 升级 OpenClaw 至 2026.2.17 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32061
+rule: version < "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32061

--- a/data/vuln/openclaw/CVE-2026-32062.yaml
+++ b/data/vuln/openclaw/CVE-2026-32062.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32062
+  summary: OpenClaw 及 @openclaw/voice-call 未授权 WebSocket DoS 漏洞（流升级前置验证缺失）
+  details: >-
+    OpenClaw 2026.2.21-2 至 2026.2.22（不含）版本以及 @openclaw/voice-call 2026.2.21 至
+    2026.2.22（不含）版本在执行流验证之前接受媒体流 WebSocket 升级请求。这允许未经身份验证的
+    客户端建立连接而无需完成正确的验证流程，使远程攻击者可以持续保持空闲的预认证套接字，
+    消耗连接资源，降低合法流的服务可用性。此漏洞可被用于针对 OpenClaw 语音/媒体流服务发起拒绝服务攻击。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 及 @openclaw/voice-call 至 2026.2.22 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32062
+rule: version >= "2026.2.21-2" && version < "2026.2.22"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32062

--- a/data/vuln/openclaw/CVE-2026-32063.yaml
+++ b/data/vuln/openclaw/CVE-2026-32063.yaml
@@ -1,0 +1,18 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32063
+  summary: OpenClaw systemd 单元文件生成中的 CR/LF 注入命令执行漏洞
+  details: >-
+    OpenClaw 2026.2.19-2 至 2026.2.21（不含）版本的 systemd 单元文件生成过程中存在命令注入漏洞。
+    config.env.vars 中攻击者可控的环境变量值未对 CR/LF（回车/换行）字符进行验证，
+    允许通过换行注入突破生成单元文件中的 Environment= 行，进而注入任意 systemd 指令。
+    能够影响 config.env.vars 并触发服务安装或重启的攻击者，可以 OpenClaw 网关服务用户权限
+    执行任意命令。这是一个本地权限提升攻击向量，需要对配置具有写入权限。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 至 2026.2.21 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32063
+rule: version >= "2026.2.19-2" && version < "2026.2.21"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32063

--- a/data/vuln/openclaw/CVE-2026-32302.yaml
+++ b/data/vuln/openclaw/CVE-2026-32302.yaml
@@ -1,0 +1,28 @@
+info:
+  name: OpenClaw
+  cve: CVE-2026-32302
+  summary: OpenClaw 在 trusted-proxy 模式下 WebSocket 来源验证绕过，允许未授权建立特权 operator 会话
+  details: >-
+    OpenClaw 2026.3.11 之前版本在 gateway.auth.mode 配置为 "trusted-proxy" 时，
+    WebSocket 连接处理存在跨域请求验证绕过漏洞（CWE-346）。通过受信任反向代理携带
+    代理转发头抵达的浏览器发起的 WebSocket 连接，可绕过来源验证。来自恶意来源的不受信
+    任网页可通过受信任反向代理建立连接，继承代理认证身份，并在无需显式认证的情况下
+    建立特权 operator.admin 会话。这允许攻击者获得 OpenClaw 网关的完整管理权限，
+    包括访问用户对话、技能、记忆文件以及所有连接的消息渠道。该漏洞仅影响使用
+    trusted-proxy 认证模式配合反向代理部署的实例。发布时漏洞利用成熟度为 LOW，
+    官方公告引用单个提交修复。由于可特权提升至 operator.admin，严重性评级为 HIGH。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: >-
+    升级 OpenClaw 至 2026.3.11 或更高版本。临时缓解措施：将 gateway.auth.mode 从
+    "trusted-proxy" 改为 "token" 或 "password" 模式；或在反向代理层（如 Nginx）添加
+    显式 CORS/Origin 限制，拒绝来自不受信任来源的请求。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+    - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11
+rule: version < "2026.3.11"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+  - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11

--- a/data/vuln/openclaw/CVE-2026-4039.yaml
+++ b/data/vuln/openclaw/CVE-2026-4039.yaml
@@ -1,0 +1,16 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4039
+  summary: OpenClaw Skill Env Handler applySkillConfigenvOverrides 代码注入漏洞
+  details: >-
+    OpenClaw 2026.2.19-2 版本的 Skill Env Handler 组件中 applySkillConfigenvOverrides
+    函数存在代码注入漏洞。对环境变量覆盖值的操控可导致代码注入，允许远程攻击者执行任意代码。
+    该漏洞可远程利用，已在 2026.2.21-beta.1 版本中修复（补丁提交：8c9f35cdb51692b650ddf05b259ccdd75cc9a83c）。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级 OpenClaw 至 2026.2.21 或更高版本（修复首次包含于 2026.2.21-beta.1）。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4039
+rule: version <= "2026.2.19-2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4039

--- a/data/vuln/openclaw/CVE-2026-4040.yaml
+++ b/data/vuln/openclaw/CVE-2026-4040.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4040
+  summary: OpenClaw tools.exec.safeBins 文件存在性信息泄露漏洞（差异侧信道）
+  details: >-
+    OpenClaw 2026.2.17 及之前版本的 tools.exec.safeBins 文件存在性处理组件中存在信息泄露漏洞。
+    通过差异侧信道（时序或响应差异）可导致信息暴露，允许本地攻击者推断系统上文件的存在情况。
+    这是一个本地攻击向量，需要低权限，机密性影响有限。
+    已在 2026.2.19-beta.1 版本中修复（补丁：bafdbb6f112409a65decd3d4e7350fbd637c7754）。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: 升级 OpenClaw 至 2026.2.19 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4040
+rule: version <= "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4040

--- a/data/vuln/openwebui/CVE-2025-15603.yaml
+++ b/data/vuln/openwebui/CVE-2025-15603.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openwebui
+  cve: CVE-2025-15603
+  summary: Open WebUI JWT 密钥处理程序 WEBUI_SECRET_KEY 随机性不足漏洞
+  details: >-
+    Open WebUI 0.6.16 及之前版本的 JWT 密钥处理组件中存在弱随机性漏洞。
+    backend/start_windows.bat 文件中 WEBUI_SECRET_KEY 参数导致 JWT 密钥生成
+    使用了不足够随机的值。远程利用需要较高的攻击复杂度。成功利用此漏洞的攻击者
+    可能预测或恢复 JWT 密钥，从而允许伪造会话令牌并未经授权访问应用程序。
+    此漏洞已公开披露，可能正在被积极利用。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: 升级 Open WebUI 至 0.6.16 以上版本。确保 WEBUI_SECRET_KEY 设置为强随机生成值。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+    - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4
+rule: version <= "0.6.16"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+  - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4

--- a/data/vuln/sglang/CVE-2026-3059.yaml
+++ b/data/vuln/sglang/CVE-2026-3059.yaml
@@ -1,0 +1,22 @@
+info:
+  name: sglang
+  cve: CVE-2026-3059
+  summary: SGLang 多模态生成模块 ZMQ 代理不安全反序列化导致未认证 RCE
+  details: >-
+    SGLang 是面向大语言模型和视觉语言模型的高速推理框架。0.5.10 版本之前，多模态生成
+    模块中 sglang/multimodal_gen/runtime/scheduler_client.py 的 ZMQ broker 在接收网
+    络数据时未经认证或验证即进行反序列化（CWE-502）。ZMQ socket 接受来自任意网络客户
+    端的 pickle 序列化消息，未认证的远程攻击者可通过发送精心构造的反序列化载荷在服务器
+    上实现任意代码执行，以 SGLang 进程权限完全控制服务器。目前无公开 PoC，利用成熟度
+    为 LOW。Orca Security 发布的博客文章详细描述了攻击面。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 将 sglang 升级至 0.5.10 或更高版本。修复版本为多模态生成模块的 ZMQ broker 增加了认证和输入验证。避免将 SGLang ZMQ 端口暴露到不可信网络。
+  references:
+  - https://github.com/sgl-project/sglang/security/advisories/GHSA-rgq9-fqf5-fv58
+  - https://orca.security/resources/blog/sglang-llm-framework-rce-vulnerabilities/
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-3059
+rule: version <= "0.5.9"
+references:
+- https://github.com/sgl-project/sglang/security/advisories/GHSA-rgq9-fqf5-fv58
+- https://nvd.nist.gov/vuln/detail/CVE-2026-3059

--- a/data/vuln/sglang/CVE-2026-3060.yaml
+++ b/data/vuln/sglang/CVE-2026-3060.yaml
@@ -1,0 +1,22 @@
+info:
+  name: sglang
+  cve: CVE-2026-3060
+  summary: SGLang encoder 并行分解模块 ZMQ 不安全反序列化导致未认证 RCE
+  details: >-
+    SGLang 是面向大语言模型的高速推理框架。0.5.10 版本之前，encoder 并行分解系统中
+    sglang/srt/disaggregation/encode_receiver.py 在通过 ZMQ 接收数据时未经认证或验证
+    即进行反序列化（CWE-502）。与 CVE-2026-3059 类似，分解模块接受来自未认证网络客
+    户端的任意 pickle 序列化消息，可导致以 SGLang 服务器进程权限执行远程代码。该漏洞
+    存在于与多模态模块漏洞不同的代码路径中，需要单独修复。目前无公开 PoC，利用成熟度
+    为 LOW。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 将 sglang 升级至 0.5.10 或更高版本。修复版本为 ZMQ 分解模块添加了认证和验证。使用防火墙规则限制对 SGLang ZMQ 端口的网络访问。
+  references:
+  - https://github.com/sgl-project/sglang/security/advisories/GHSA-jx93-g359-86wm
+  - https://orca.security/resources/blog/sglang-llm-framework-rce-vulnerabilities/
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-3060
+rule: version <= "0.5.9"
+references:
+- https://github.com/sgl-project/sglang/security/advisories/GHSA-jx93-g359-86wm
+- https://nvd.nist.gov/vuln/detail/CVE-2026-3060

--- a/data/vuln/sglang/CVE-2026-3989.yaml
+++ b/data/vuln/sglang/CVE-2026-3989.yaml
@@ -1,0 +1,22 @@
+info:
+  name: sglang
+  cve: CVE-2026-3989
+  summary: SGLang replay_request_dump.py 不安全 pickle.load() 导致任意代码执行
+  details: >-
+    SGLang 0.5.10 版本之前，scripts/playground/replay_request_dump.py 中存在不安全反
+    序列化漏洞。该脚本使用 pickle.load() 对来自文件或网络来源的数据进行反序列化，未做
+    任何验证或完整性检查。能够提供恶意 pickle 文件的攻击者（例如通过共享文件系统、网络
+    路径或社会工程学）可在脚本处理该文件时实现任意代码执行。虽然该脚本位于 playground
+    目录，未必部署于所有环境，但使用重放功能的生产部署存在风险。目前无公开 PoC，利用
+    成熟度为 LOW。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 将 sglang 升级至 0.5.10 或更高版本。将 pickle.load() 替换为安全替代方案（如 json 或 msgpack）。避免从不可信来源加载重放转储文件。
+  references:
+  - https://github.com/sgl-project/sglang/security/advisories/GHSA-hvwj-8w5g-28rg
+  - https://orca.security/resources/blog/sglang-llm-framework-rce-vulnerabilities/
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-3989
+rule: version <= "0.5.9"
+references:
+- https://github.com/sgl-project/sglang/security/advisories/GHSA-hvwj-8w5g-28rg
+- https://nvd.nist.gov/vuln/detail/CVE-2026-3989

--- a/data/vuln/vllm/CVE-2026-25960.yaml
+++ b/data/vuln/vllm/CVE-2026-25960.yaml
@@ -1,0 +1,28 @@
+info:
+  name: vLLM
+  cve: CVE-2026-25960
+  summary: vLLM SSRF 防护绕过漏洞（URL 解析器不一致）
+  details: >-
+    vLLM 0.15.1 至 0.16.0 版本（0.17.0 已修复）在 `vllm/connections.py` 中的
+    `load_from_url_async` 方法存在服务端请求伪造（SSRF）防护绕过漏洞。原有 SSRF 修复
+    （GHSA-qh4c-xf7m-gxfc）使用 `urllib3.util.parse_url()` 进行 URL 验证，而实际 HTTP
+    请求通过 `aiohttp`（内部使用 `yarl` 库）发送。两个解析器对反斜杠字符处理方式不同：
+    urllib3 将 `\` URL 编码为 `%5C` 并视其为路径的一部分，而 yarl 则将 `\` 解释为用户信息
+    的一部分，将 `@` 作为用户信息/主机分隔符，导致实际请求发送至与验证不同的主机。
+    低权限认证攻击者可构造形如 `https://受信任主机\@evil.com/` 的 URL，绕过白名单验证，
+    强制服务器向任意内部或外部服务发起请求，实现完整 SSRF 攻击，包括访问云元数据接口
+    及内部服务。发布时未发现公开 PoC 或利用代码（利用成熟度：低）。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:L
+  severity: MEDIUM
+  security_advise: 升级 vLLM 至 0.17.0 或更高版本。修复方案详见
+    https://github.com/vllm-project/vllm/pull/34743。
+    临时缓解措施：限制 URL 白名单以阻止访问内网地址段，并使用统一的 URL 解析库进行验证。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+    - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+    - https://github.com/vllm-project/vllm/pull/34743
+rule: version >= "0.15.1" && version < "0.17.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+  - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+  - https://github.com/vllm-project/vllm/pull/34743

--- a/data/vuln/weknora/CVE-2026-30860.yaml
+++ b/data/vuln/weknora/CVE-2026-30860.yaml
@@ -1,0 +1,24 @@
+info:
+  name: WeKnora
+  cve: CVE-2026-30860
+  summary: WeKnora AI 数据库查询接口 SQL 注入绕过导致未认证 PostgreSQL RCE
+  details: >-
+    WeKnora 是腾讯开源的基于大语言模型的文档深度理解与语义检索框架。0.2.12 版本之前，
+    数据库查询功能（internal/utils/inject.go）存在严重 RCE 漏洞。应用实现了基于
+    PostgreSQL AST 解析的 7 阶段 SQL 校验框架，但第 5 阶段 validateNode() 函数未处理
+    ArrayExpr 和 RowExpr 节点类型。攻击者可将危险 PostgreSQL 函数（如 lo_import、
+    lo_export）嵌套在数组或行表达式中，绕过全部校验阶段。通过将大对象操作与
+    pg_read_binary_file 及共享库加载（lo_import + CREATE FUNCTION）组合利用，仅持有
+    普通账号（开放注册，无需审核）的攻击者即可在数据库服务器上以数据库用户权限执行任意
+    代码。0.2.12 版本的修复为 validateNode() 函数新增了对 ArrayExpr 和 RowExpr
+    节点类型的递归校验。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 立即将 WeKnora 升级至 0.2.12 或更高版本。补丁在 internal/utils/inject.go 的 validateNode() 函数中新增了对 ArrayExpr 和 RowExpr 节点类型的处理，从根本上修复 SQL 注入绕过。
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30860
+rule: version < "0.2.12"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30860

--- a/data/vuln/weknora/CVE-2026-30861.yaml
+++ b/data/vuln/weknora/CVE-2026-30861.yaml
@@ -1,0 +1,25 @@
+info:
+  name: WeKnora
+  cve: CVE-2026-30861
+  summary: WeKnora MCP stdio 配置校验绕过导致未认证命令注入 RCE
+  details: >-
+    WeKnora 是腾讯开源的基于大语言模型的文档深度理解与语义检索框架。0.2.5 至 0.2.9
+    版本的 MCP stdio 配置校验中存在严重未认证远程代码执行漏洞。应用实现了命令白名单
+    （npx、uvx）和参数黑名单以防止注入，但黑名单未覆盖 npx node 的 -p 标志。攻击者
+    可注册免费账号（无需邮箱验证或审批），获取 API 凭据后传入如 ["node", "-p",
+    "require('fs').writeFileSync(...)"] 的参数，通过 Node.js -p（print/eval）标志
+    执行任意 JavaScript，完全绕过 DangerousArgPatterns 校验，以应用权限实现任意代码
+    执行。该漏洞在 0.2.6 至 0.2.9 版本中持续存在，于 0.2.10 版本静默修复，未公开
+    CVE 披露，可能导致运营者对受影响版本毫不知情。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 立即将 WeKnora 升级至 0.2.10 或更高版本。如无法立即升级，应禁用开放式用户注册或限制 WeKnora 服务的网络访问，以防止漏洞被利用。
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+  - https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30861
+rule: version >= "0.2.5" && version < "0.2.10"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+- https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30861

--- a/data/vuln/zeptoclaw/CVE-2026-32231.yaml
+++ b/data/vuln/zeptoclaw/CVE-2026-32231.yaml
@@ -1,0 +1,22 @@
+info:
+  name: zeptoclaw
+  cve: CVE-2026-32231
+  summary: ZeptoClaw 通用 webhook 频道信任调用者提供的身份字段，导致发送者身份伪造
+  details: >-
+    ZeptoClaw 是个人 AI 助手平台。0.7.6 版本之前，通用 webhook 频道未经验证即信任请
+    求体中调用者提供的身份字段（sender、chat_id）。任何能够访问 webhook 端点的方均可伪
+    造任意发送者身份，冒充受信任用户或管理员。这破坏了基于 webhook 集成的认证假设，可
+    能允许攻击者触发特权 agent 操作、绕过白名单或以受信任身份注入消息。该漏洞被归类为
+    CWE-306（关键功能缺少认证）和 CWE-345（数据真实性验证不足）。目前无公开 PoC，
+    利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N
+  severity: HIGH
+  security_advise: 将 ZeptoClaw 升级至 0.7.6 或更高版本。修复版本在通用 webhook 频道处理器中增加了调用者身份的密码学验证，防止不可信调用者提供任意 sender 或 chat_id 值。
+  references:
+  - https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-46q5-g3j9-wx5c
+  - https://github.com/qhkm/zeptoclaw/commit/bf004a20d3687a0c1a9e052ec79536e30d6de134
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32231
+rule: version <= "0.7.5"
+references:
+- https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-46q5-g3j9-wx5c
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32231

--- a/data/vuln/zeptoclaw/CVE-2026-32232.yaml
+++ b/data/vuln/zeptoclaw/CVE-2026-32232.yaml
@@ -1,0 +1,22 @@
+info:
+  name: zeptoclaw
+  cve: CVE-2026-32232
+  summary: ZeptoClaw 符号链接、TOCTOU 和硬链接路径边界绕过导致工作区逃逸
+  details: >-
+    ZeptoClaw 0.7.6 版本之前，工作区文件处理中存在多个路径遍历和竞态条件漏洞（CWE-22、
+    CWE-62），涉及三种不同的绕过技术：悬挂符号链接组件绕过（跟踪在验证后解析到工作区
+    外的符号链接）、TOCTOU（路径验证与文件访问之间的检查时间/使用时间竞态）以及硬链
+    接绕过（创建指向工作区外文件但能通过边界检查的硬链接）。能够在工作区内创建符号链接
+    或硬链接的攻击者可逃逸工作区目录边界，读写 ZeptoClaw 进程可访问的任意文件。目前无
+    公开 PoC，利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: 将 ZeptoClaw 升级至 0.7.6 或更高版本。修复版本在边界检查前将符号链接解析为规范路径，并通过原子文件操作消除 TOCTOU 窗口。
+  references:
+  - https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-2m67-cxxq-c3h8
+  - https://github.com/qhkm/zeptoclaw/commit/f50c17e11ae3e2d40c96730abac41974ef2ee2a8
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32232
+rule: version <= "0.7.5"
+references:
+- https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-2m67-cxxq-c3h8
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32232

--- a/data/vuln_en/apache-livy/CVE-2025-60012.yaml
+++ b/data/vuln_en/apache-livy/CVE-2025-60012.yaml
@@ -1,0 +1,26 @@
+info:
+  name: Apache Livy
+  cve: CVE-2025-60012
+  summary: Apache Livy unauthorized file access via malicious Spark configuration
+  details: >-
+    Apache Livy 0.7.0 and 0.8.0 are vulnerable to unauthorized file access when
+    connecting to Apache Spark 3.1 or later. A request that includes a Spark
+    configuration value supported from Apache Spark version 3.1 can lead to users
+    gaining access to files they do not have permissions to. For the vulnerability
+    to be exploitable, the user needs to have access to Apache Livy's REST or JDBC
+    interface and be able to send requests with arbitrary Spark configuration values.
+    The vulnerability stems from improper input validation (CWE-20) of Spark
+    configuration parameters passed via the REST API. No public PoC or active
+    exploitation observed at time of publication.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade Apache Livy to version 0.9.0 or later, which fixes this issue.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-60012
+    - https://lists.apache.org/thread/gpc85fwrgrbglpk9gm8tmcjzqnctx64w
+    - http://www.openwall.com/lists/oss-security/2026/03/12/1
+rule: version == "0.7.0" || version == "0.8.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-60012
+  - https://lists.apache.org/thread/gpc85fwrgrbglpk9gm8tmcjzqnctx64w
+  - http://www.openwall.com/lists/oss-security/2026/03/12/1

--- a/data/vuln_en/apache-livy/CVE-2025-66249.yaml
+++ b/data/vuln_en/apache-livy/CVE-2025-66249.yaml
@@ -1,0 +1,27 @@
+info:
+  name: Apache Livy
+  cve: CVE-2025-66249
+  summary: Apache Livy path traversal via non-default local-dir-whitelist configuration
+  details: >-
+    Apache Livy versions from 0.3.0 before 0.9.0 contain an Improper Limitation
+    of a Pathname to a Restricted Directory (CWE-22) vulnerability. When the
+    configuration value "livy.file.local-dir-whitelist" is set to a non-default
+    value, the directory checking logic can be bypassed, allowing authenticated
+    users to perform path traversal attacks and access files outside the intended
+    directory. The vulnerability requires non-default server configuration to be
+    exploitable. No public PoC or active exploitation observed at time of
+    publication. Users are strongly recommended to upgrade to version 0.9.0 or later.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: >-
+    Upgrade Apache Livy to version 0.9.0 or later. As a temporary workaround,
+    ensure "livy.file.local-dir-whitelist" is not set to non-default values
+    or restrict API access to trusted users only.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-66249
+    - https://lists.apache.org/thread/1xwphsfn4jbtym4k4o0zlvwfogwqwwc3
+    - http://www.openwall.com/lists/oss-security/2026/03/12/2
+rule: version >= "0.3.0" && version < "0.9.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-66249
+  - https://lists.apache.org/thread/1xwphsfn4jbtym4k4o0zlvwfogwqwwc3

--- a/data/vuln_en/claudecodeui/CVE-2026-31861.yaml
+++ b/data/vuln_en/claudecodeui/CVE-2026-31861.yaml
@@ -1,0 +1,31 @@
+info:
+  name: claudecodeui
+  cve: CVE-2026-31861
+  summary: 'Cloud CLI claudecodeui shell command injection in git-config endpoint via gitName and gitEmail parameters'
+  details: >-
+    Cloud CLI (aka Claude Code UI) prior to version 1.24.0 contains a shell
+    command injection vulnerability in the /api/user/git-config endpoint
+    (server/routes/user.js, lines 58-59). The endpoint constructs shell
+    commands by interpolating user-supplied gitName and gitEmail values into
+    command strings passed to child_process.exec(). Input is placed within
+    double quotes with only the double-quote character escaped, leaving
+    backtick command substitution, $() substitution, and backslash sequences
+    unfiltered. An attacker with a valid JWT token (which can be bypassed via
+    the companion VULN-01 authentication bypass) can inject arbitrary OS
+    commands via gitName or gitEmail, resulting in RCE as the Node.js process
+    user. CVSS score of 8.8 assumes authentication is required; when chained
+    with the authentication bypass it escalates to critical impact.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade claudecodeui to version 1.24.0 or later. The patch sanitizes gitName and gitEmail parameters in the /api/user/git-config endpoint to prevent shell metacharacter injection.
+  references:
+  - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-7fv4-fmmc-86g2
+  - https://github.com/siteboon/claudecodeui/commit/86c33c1c0cb34176725a38f46960213714fc3e04
+  - https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31861
+rule: version <= "1.23.0"
+references:
+- https://github.com/siteboon/claudecodeui/security/advisories/GHSA-7fv4-fmmc-86g2
+- https://github.com/siteboon/claudecodeui/commit/86c33c1c0cb34176725a38f46960213714fc3e04
+- https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-31861

--- a/data/vuln_en/claudecodeui/CVE-2026-31862.yaml
+++ b/data/vuln_en/claudecodeui/CVE-2026-31862.yaml
@@ -1,0 +1,32 @@
+info:
+  name: claudecodeui
+  cve: CVE-2026-31862
+  summary: 'Cloud CLI claudecodeui command injection via shell metacharacters in Git API endpoints leads to RCE'
+  details: >-
+    Cloud CLI (aka Claude Code UI) is a web-based UI for Claude Code, Cursor
+    CLI, Codex, and Gemini-CLI. Prior to version 1.24.0, multiple Git-related
+    API endpoints in server/routes/git.js use execAsync() with direct string
+    interpolation of user-controlled parameters (file, branch, message,
+    commit). While the application attempts to escape double quotes, protection
+    is trivially bypassed using shell metacharacters such as command
+    substitution $(command), backtick execution, command chaining via
+    semicolons, and newline injection. Affected endpoints include GET
+    /api/git/diff, GET /api/git/status, POST /api/git/commit (files and
+    message), POST /api/git/checkout, POST /api/git/create-branch, GET
+    /api/git/commits, and GET /api/git/commit-diff. Authenticated attackers can
+    achieve RCE as the Node.js process user, enabling full server compromise,
+    data exfiltration, and supply chain attacks. The fix replaces all
+    execAsync() calls with spawnAsync() (shell: false), passing arguments as
+    arrays directly to the OS so shell metacharacters are inert.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade claudecodeui to version 1.24.0 or later. The fix replaces shell-interpolated execAsync() calls with spawnAsync() (shell: false) across all Git route handlers in server/routes/git.js.
+  references:
+  - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-f2fc-vc88-6w7q
+  - https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31862
+rule: version <= "1.23.0"
+references:
+- https://github.com/siteboon/claudecodeui/security/advisories/GHSA-f2fc-vc88-6w7q
+- https://github.com/siteboon/claudecodeui/releases/tag/v1.24.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-31862

--- a/data/vuln_en/claudecodeui/CVE-2026-31975.yaml
+++ b/data/vuln_en/claudecodeui/CVE-2026-31975.yaml
@@ -1,0 +1,25 @@
+info:
+  name: claudecodeui
+  cve: CVE-2026-31975
+  summary: Claude Code UI OS Command Injection via Unsanitized WebSocket Shell Parameters
+  details: >-
+    Cloud CLI (aka Claude Code UI) prior to version 1.25.0 contains an OS command
+    injection vulnerability in the WebSocket shell handler (server/index.js). Both
+    projectPath and initialCommand parameters taken from WebSocket message payloads
+    are directly interpolated into bash command strings without any sanitization,
+    enabling arbitrary OS command execution. A secondary injection vector exists via
+    an unsanitized sessionId. Any attacker who can reach the WebSocket endpoint can
+    inject arbitrary OS commands that execute with the privileges of the server process.
+    This is a critical remote code execution vulnerability affecting all users who
+    expose the Claude Code UI server to network access.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade Claude Code UI to version 1.25.0 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31975
+    - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-gv8f-wpm2-m5wr
+    - https://github.com/siteboon/claudecodeui/releases/tag/v1.25.0
+rule: version < "1.25.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31975
+  - https://github.com/siteboon/claudecodeui/security/advisories/GHSA-gv8f-wpm2-m5wr

--- a/data/vuln_en/fastgpt/CVE-2026-32128.yaml
+++ b/data/vuln_en/fastgpt/CVE-2026-32128.yaml
@@ -1,0 +1,24 @@
+info:
+  name: fastgpt
+  cve: CVE-2026-32128
+  summary: FastGPT Python Sandbox seccomp Bypass via stdout File Descriptor Remapping
+  details: >-
+    FastGPT version 4.14.7 and earlier includes a Python Sandbox (fastgpt-sandbox) with
+    guardrails intended to prevent file writes, using static detection combined with seccomp
+    system call filtering. These guardrails can be bypassed by remapping stdout (file
+    descriptor 1) to an arbitrary writable file descriptor using the fcntl syscall.
+    After remapping, writing via sys.stdout.write() still satisfies the seccomp rule
+    write(fd==1), enabling arbitrary file creation or overwrite inside the sandbox
+    container despite the intended "no file writes" restriction. This can be exploited by
+    malicious user-provided Python code to escape the sandbox's write restrictions,
+    potentially enabling container escape or data exfiltration.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade FastGPT to a version later than 4.14.7.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32128
+    - https://github.com/labring/FastGPT/security/advisories/GHSA-6hw6-mxrm-v6wj
+rule: version <= "4.14.7"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32128
+  - https://github.com/labring/FastGPT/security/advisories/GHSA-6hw6-mxrm-v6wj

--- a/data/vuln_en/flowise/CVE-2026-30820.yaml
+++ b/data/vuln_en/flowise/CVE-2026-30820.yaml
@@ -1,0 +1,34 @@
+info:
+  name: Flowise
+  cve: CVE-2026-30820
+  summary: Flowise Authorization Bypass via Spoofed x-request-from Header (Privilege Escalation)
+  details: >-
+    Flowise prior to version 3.0.13 contains an authorization bypass vulnerability
+    (CWE-863). The global middleware guarding /api/v1/** routes blindly trusts any
+    HTTP request that sets the header `x-request-from: internal`. An authenticated
+    low-privilege tenant can add this header to their browser cookie session and
+    bypass all API authorization checks, gaining access to internal administration
+    endpoints including API key management (/api/v1/apikey), credential stores
+    (/api/v1/credentials), custom function execution (/api/v1/node-custom-function),
+    and other privileged routes. This effectively enables privilege escalation and,
+    when combined with other vulnerabilities such as Custom Function RCE, may lead
+    to full system compromise. A public PoC is included in the official security
+    advisory (GHSA-wvhq-wp8g-c7vq). All self-hosted Flowise deployments prior to
+    3.0.13 that rely on the default middleware are affected. CVSS 4.0 score reflects
+    high confidentiality, integrity, and availability impact with network-accessible
+    attack vector and low privileges required.
+  cvss: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade Flowise to version 3.0.13 or later. The patch removes the blind trust
+    of the `x-request-from: internal` header and enforces proper authorization
+    checks on all /api/v1/** routes regardless of request headers.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+    - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13

--- a/data/vuln_en/flowise/CVE-2026-30823.yaml
+++ b/data/vuln_en/flowise/CVE-2026-30823.yaml
@@ -1,0 +1,31 @@
+info:
+  name: Flowise
+  cve: CVE-2026-30823
+  summary: Flowise IDOR vulnerability leads to account takeover and SSO enterprise feature bypass
+  details: >-
+    Flowise is a drag-and-drop UI platform for building customized large
+    language model (LLM) workflows. Prior to version 3.0.13, an Insecure
+    Direct Object Reference (IDOR) vulnerability exists in the PUT
+    /api/v1/loginmethod endpoint. The server accepts an organizationId
+    parameter from the JSON request body without verifying whether the
+    authenticated user owns or has administrative rights over the target
+    organization. Any low-privileged authenticated user (including Free plan
+    users) can exploit this flaw to overwrite another organization's SSO
+    configuration, enable enterprise-only features (SSO/SAML) without a
+    valid license, and perform account takeover by redirecting the
+    authentication flow to attacker-controlled OAuth credentials. A complete
+    step-by-step PoC is available in the official security advisory.
+    Exploitation requires only a valid JWT token and knowledge of the target
+    organizationId.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: Upgrade Flowise to version 3.0.13 or later. The patch adds ownership validation on the PUT /api/v1/loginmethod endpoint to ensure users can only modify their own organization's SSO configuration.
+  references:
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30823
+rule: version <= "3.0.12"
+references:
+- https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+- https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30823

--- a/data/vuln_en/flowise/CVE-2026-31829.yaml
+++ b/data/vuln_en/flowise/CVE-2026-31829.yaml
@@ -1,0 +1,35 @@
+info:
+  name: Flowise
+  cve: CVE-2026-31829
+  summary: Flowise HTTP Node Server-Side Request Forgery (SSRF) via Unrestricted User-Controlled URL
+  details: >-
+    Flowise versions prior to 3.0.13 expose an HTTP Node in AgentFlow and Chatflow
+    that performs server-side HTTP requests using user-controlled URLs without any
+    restrictions on target hosts. By default, private/internal IP ranges (RFC 1918),
+    localhost, and cloud metadata endpoints (e.g., AWS IMDSv1 at 169.254.169.254) are
+    not blocked. This enables Server-Side Request Forgery (SSRF), allowing any user
+    interacting with a publicly exposed chatflow to force the Flowise server to make
+    requests to internal network resources. The vulnerability is particularly severe
+    because Flowise instances are often deployed publicly without authentication
+    (FLOWISE_USERNAME/PASSWORD not set by default). The HTTP Node supports all standard
+    HTTP methods (GET, POST, PUT, PATCH, DELETE), enabling both read and write access
+    to internal services. Impact includes: retrieval of cloud provider IAM credentials
+    from metadata endpoints, access to internal admin panels (Jenkins, Kubernetes API),
+    port scanning of internal services, and potential lateral movement. A public proof
+    of concept demonstrating internal network access was included in the advisory.
+    Exploitation maturity is HIGH due to the straightforward nature of the attack and
+    the public PoC availability.
+  cvss: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:L
+  severity: HIGH
+  security_advise: Upgrade Flowise to version 3.0.13 or later. The fix adds optional
+    security controls to the HTTP Node including the ability to block private IP ranges
+    and localhost, and an allowed-domains whitelist. Until upgraded, restrict network
+    access of Flowise instances and enable authentication by setting
+    FLOWISE_USERNAME and FLOWISE_PASSWORD environment variables.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7

--- a/data/vuln_en/hyperterse/CVE-2026-31841.yaml
+++ b/data/vuln_en/hyperterse/CVE-2026-31841.yaml
@@ -1,0 +1,29 @@
+info:
+  name: hyperterse
+  cve: CVE-2026-31841
+  summary: Hyperterse MCP framework exposes raw SQL database statements to LLMs via search tool response
+  details: >-
+    Hyperterse is a tool-first MCP framework for building AI-ready backend
+    surfaces from declarative config. As of version 2.0.0, two tools are
+    exposed: search and execute. Prior to version 2.2.0, the search tool
+    allowed LLMs to search for tools using natural language, but its response
+    included the raw SQL queries that were supposed to be executed under the
+    hood. These internal database statements were exposed in the search tool
+    output, revealing backend query logic that should be protected from public
+    disclosure. In LLM-integrated deployments, this information leakage can
+    enable prompt injection attacks or assist attackers in crafting more
+    targeted SQL injection payloads by understanding the underlying query
+    structure. The flaw is classified as CWE-433 (Unparsed Raw Web Content
+    Delivery). No public PoC exists; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N
+  severity: MEDIUM
+  security_advise: Upgrade hyperterse to version 2.2.0 or later. The fix removes raw SQL statement exposure from the search tool response and adds tests to prevent regression.
+  references:
+  - https://github.com/hyperterse/hyperterse/security/advisories/GHSA-92gp-jfgx-9qpv
+  - https://github.com/hyperterse/hyperterse/releases/tag/v2.2.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31841
+rule: version >= "2.0.0" && version < "2.2.0"
+references:
+- https://github.com/hyperterse/hyperterse/security/advisories/GHSA-92gp-jfgx-9qpv
+- https://github.com/hyperterse/hyperterse/releases/tag/v2.2.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-31841

--- a/data/vuln_en/librechat/CVE-2026-31944.yaml
+++ b/data/vuln_en/librechat/CVE-2026-31944.yaml
@@ -1,0 +1,32 @@
+info:
+  name: LibreChat
+  cve: CVE-2026-31944
+  summary: LibreChat MCP OAuth callback session binding failure enables OAuth token theft and account takeover
+  details: >-
+    LibreChat versions 0.8.2 through 0.8.2-rc3 contain a critical authentication
+    flaw (CWE-306) in the MCP (Model Context Protocol) OAuth callback endpoint.
+    The callback accepts the redirect from the identity provider and stores OAuth
+    tokens for the session that initiated the flow, without verifying that the
+    browser completing the redirect URL is logged in as the same user who started
+    the flow. An attacker can craft an authorization URL and send it to a victim;
+    when the victim completes the OAuth flow, the victim's OAuth tokens are stored
+    on the attacker's LibreChat account. This enables account takeover of the
+    victim's MCP-linked services (e.g., Atlassian, Outlook, GitHub). The attack
+    requires the attacker to have an authenticated LibreChat account and the
+    victim to click the crafted link. Exploitation maturity is LOW at publication,
+    with no public PoC reported. Severity is HIGH due to potential account takeover
+    impact on MCP-connected third-party services.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: >-
+    Upgrade LibreChat to version 0.8.3-rc1 or later, which fixes the OAuth
+    callback session binding validation. As a temporary mitigation, disable MCP
+    OAuth integrations until patched. Users should revoke OAuth tokens for
+    MCP-linked services if unauthorized access is suspected.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g
+rule: version == "0.8.2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g

--- a/data/vuln_en/librechat/CVE-2026-31949.yaml
+++ b/data/vuln_en/librechat/CVE-2026-31949.yaml
@@ -1,0 +1,30 @@
+info:
+  name: LibreChat
+  cve: CVE-2026-31949
+  summary: LibreChat DoS via unhandled TypeError in DELETE /api/convos endpoint crashes Node.js server
+  details: >-
+    LibreChat versions prior to 0.8.3-rc1 contain a Denial of Service (DoS)
+    vulnerability (CWE-248) in the DELETE /api/convos endpoint. The route handler
+    attempts to destructure req.body.arg without first validating that req.body
+    exists or is non-null. When an authenticated attacker sends a malformed DELETE
+    request (e.g., with an empty or absent body), the server throws an unhandled
+    TypeError that bypasses Express.js error handling middleware and triggers
+    process.exit(1), crashing the entire Node.js server process. This effectively
+    causes a complete service outage for all users until the server is restarted.
+    The vulnerability requires an authenticated attacker but has no rate limiting
+    protection on this endpoint. Exploitation maturity is LOW at publication with
+    no public PoC reported.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+  severity: MEDIUM
+  security_advise: >-
+    Upgrade LibreChat to version 0.8.3-rc1 or later, which adds proper input
+    validation before destructuring req.body.arg. As a temporary mitigation,
+    restrict API access to trusted authenticated users only and monitor for
+    unusual DELETE /api/convos request patterns.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p
+rule: version < "0.8.3-rc1"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p

--- a/data/vuln_en/llama-cpp/CVE-2026-27940.yaml
+++ b/data/vuln_en/llama-cpp/CVE-2026-27940.yaml
@@ -1,0 +1,29 @@
+info:
+  name: llama-cpp
+  cve: CVE-2026-27940
+  summary: llama.cpp integer overflow in mem_size calculation leads to heap buffer overflow and arbitrary code execution via malicious GGUF file
+  details: >-
+    llama.cpp is a C/C++ inference engine for LLM models. Prior to build b8146,
+    gguf_init_from_file_impl() in gguf.cpp contains an integer overflow
+    vulnerability in the mem_size calculation. While CVE-2025-53630 added an
+    overflow check on per-addition accumulation of ctx->size, the final mem_size
+    computation at (n_tensors+1)*ggml_tensor_overhead() + ctx->size was not
+    guarded. When ctx->size is near SIZE_MAX (achievable via two large I8 tensors
+    whose per-addition sizes pass the CVE-2025-53630 check), the final addition
+    wraps around to a small value, resulting in an undersized heap allocation.
+    The subsequent fread() writes 528+ bytes of attacker-controlled data past the
+    buffer boundary. By tuning the allocation size to fall within glibc tcache
+    range, this escalates to full arbitrary code execution via system(/bin/sh).
+    Attack vector is local (AV:L); exploitation requires a user to load a
+    malicious GGUF model file. This is a bypass of the CVE-2025-53630 fix in
+    the same function. No public PoC; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade llama.cpp to build b8146 or later. The fix adds an overflow guard to the mem_size calculation in gguf_init_from_file_impl() to prevent integer wrap-around when ctx->size is near SIZE_MAX. Avoid loading GGUF model files from untrusted sources.
+  references:
+  - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-27940
+rule: version < "b8146"
+references:
+- https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+- https://nvd.nist.gov/vuln/detail/CVE-2026-27940

--- a/data/vuln_en/openchatbi/CVE-2026-28795.yaml
+++ b/data/vuln_en/openchatbi/CVE-2026-28795.yaml
@@ -1,0 +1,30 @@
+info:
+  name: OpenChatBI
+  cve: CVE-2026-28795
+  summary: OpenChatBI path traversal in save_report tool allows arbitrary file write and potential RCE
+  details: >-
+    OpenChatBI is an LLM-powered intelligent chat-based BI tool for querying,
+    analyzing, and visualizing data through natural language. Prior to version
+    0.2.2, the save_report tool in openchatbi/tool/save_report.py contains a
+    path traversal vulnerability due to insufficient sanitization of the
+    file_format parameter. The function strips leading dots via
+    file_format.lstrip(".") but does not filter path traversal sequences
+    such as /../../. When the output filename is constructed via string
+    concatenation as f"{timestamp}_{clean_title}.{file_format}", malicious
+    path sequences are preserved verbatim, enabling writes outside the
+    designated report directory. An attacker can manipulate the LLM to invoke
+    save_report with a crafted file_format to overwrite critical application
+    files such as __init__.py, potentially escalating to remote code
+    execution. No public PoC has been identified; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: Upgrade OpenChatBI to version 0.2.2 or later. The patch adds proper path sanitization to the file_format parameter in save_report.py to prevent directory traversal sequences.
+  references:
+  - https://github.com/zhongyu09/openchatbi/security/advisories/GHSA-vmwq-8g8c-jm79
+  - https://github.com/zhongyu09/openchatbi/commit/372a7e861da5159c3106d64d6f6edf8284db8c75
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-28795
+rule: version <= "0.2.1"
+references:
+- https://github.com/zhongyu09/openchatbi/security/advisories/GHSA-vmwq-8g8c-jm79
+- https://github.com/zhongyu09/openchatbi/commit/372a7e861da5159c3106d64d6f6edf8284db8c75
+- https://nvd.nist.gov/vuln/detail/CVE-2026-28795

--- a/data/vuln_en/openclaw/CVE-2026-30741.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-30741.yaml
@@ -1,0 +1,25 @@
+info:
+  name: openclaw
+  cve: CVE-2026-30741
+  summary: OpenClaw Agent Platform RCE via request-side prompt injection in agent task execution
+  details: >-
+    OpenClaw Agent Platform v2026.2.6 and earlier contains a remote code execution
+    vulnerability (CWE-94) in the agent task execution pipeline. The platform
+    processes user-supplied prompt content without adequate sanitization, allowing
+    an unauthenticated remote attacker to inject malicious instructions via
+    request-side prompt injection. The injected content can manipulate the agent
+    runtime to execute arbitrary code on the underlying server. This vulnerability
+    does not require authentication, making it exploitable by any network-reachable
+    attacker. No public PoC has been identified; exploit maturity is LOW. The
+    vulnerability was reported via the OpenClaw GitHub repository.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade OpenClaw Agent Platform to a version later than v2026.2.6. Apply input validation and prompt sanitization controls to all user-supplied content processed by the agent task execution pipeline.
+  references:
+  - https://github.com/Named1ess/CVE-2026-30741
+  - https://github.com/OpenClaw/OpenClaw
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30741
+rule: version <= "2026.2.6"
+references:
+- https://github.com/Named1ess/CVE-2026-30741
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30741

--- a/data/vuln_en/openclaw/CVE-2026-32059.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32059.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32059
+  summary: OpenClaw tools.exec.safeBins Allowlist Bypass via GNU Long-Option Abbreviation in sort Command
+  details: >-
+    OpenClaw version 2026.2.22-2 contains an authorization bypass vulnerability in the
+    tools.exec.safeBins validation for the sort command. The validation fails to properly
+    validate GNU long-option abbreviations, allowing attackers to bypass denied-flag checks
+    via abbreviated options in allowlist mode. Remote attackers can execute sort commands
+    with abbreviated long options to skip approval requirements.
+    This vulnerability affects the exec tool's allowlist enforcement mechanism,
+    potentially allowing unauthorized command execution with elevated permissions.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw to version 2026.2.23 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32059
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-3c6h-g97w-fg78
+rule: version >= "2026.2.22-2" && version < "2026.2.23"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32059

--- a/data/vuln_en/openclaw/CVE-2026-32060.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32060.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32060
+  summary: OpenClaw apply_patch Path Traversal Allowing Arbitrary File Write/Delete Outside Workspace
+  details: >-
+    OpenClaw versions prior to 2026.2.14 contain a path traversal vulnerability in the
+    apply_patch functionality. When apply_patch is enabled without filesystem sandbox
+    containment, attackers can exploit crafted paths including directory traversal sequences
+    (e.g., ../../) or absolute paths to escape workspace boundaries and modify or delete
+    arbitrary files accessible to the OpenClaw process user. This can lead to data
+    destruction, privilege escalation, or remote code execution by overwriting sensitive
+    system files or application configuration.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw to version 2026.2.14 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32060
+rule: version < "2026.2.14"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32060

--- a/data/vuln_en/openclaw/CVE-2026-32061.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32061.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32061
+  summary: OpenClaw $include Directive Path Traversal Allowing Arbitrary Local File Read
+  details: >-
+    OpenClaw versions prior to 2026.2.17 contain a path traversal vulnerability in the
+    $include directive resolution. Attackers with config modification capabilities can
+    exploit this by specifying absolute paths, traversal sequences, or symlinks in the
+    $include directive to access sensitive files readable by the OpenClaw process user,
+    including API keys and credentials stored outside the config directory boundary.
+    Exploitation requires high privileges (config modification access) and is a local
+    attack vector, but can lead to significant information disclosure of sensitive secrets.
+  cvss: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: Upgrade OpenClaw to version 2026.2.17 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32061
+rule: version < "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32061

--- a/data/vuln_en/openclaw/CVE-2026-32062.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32062.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32062
+  summary: OpenClaw and @openclaw/voice-call Unauthenticated WebSocket DoS via Pre-validation Stream Upgrade
+  details: >-
+    OpenClaw versions 2026.2.21-2 prior to 2026.2.22 and @openclaw/voice-call versions
+    2026.2.21 prior to 2026.2.22 accept media-stream WebSocket upgrades before stream
+    validation is performed. This allows unauthenticated clients to establish connections
+    without completing proper validation, enabling remote attackers to hold idle
+    pre-authenticated sockets open to consume connection resources and degrade service
+    availability for legitimate streams. The vulnerability can be exploited to cause
+    denial of service against the OpenClaw voice/media streaming services.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw and @openclaw/voice-call to version 2026.2.22 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32062
+rule: version >= "2026.2.21-2" && version < "2026.2.22"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32062

--- a/data/vuln_en/openclaw/CVE-2026-32063.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32063.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32063
+  summary: OpenClaw Command Injection via CR/LF Injection in systemd Unit File Generation
+  details: >-
+    OpenClaw version 2026.2.19-2 prior to 2026.2.21 contains a command injection vulnerability
+    in the systemd unit file generation process. Attacker-controlled environment values in
+    config.env.vars are not validated for CR/LF (carriage return/line feed) characters,
+    allowing newline injection to break out of Environment= lines in the generated unit file
+    and inject arbitrary systemd directives. An attacker who can influence config.env.vars
+    and trigger service install or restart can execute arbitrary commands with the privileges
+    of the OpenClaw gateway service user. This is a local privilege escalation vector
+    requiring write access to configuration.
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw to version 2026.2.21 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32063
+rule: version >= "2026.2.19-2" && version < "2026.2.21"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32063

--- a/data/vuln_en/openclaw/CVE-2026-32302.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32302.yaml
@@ -1,0 +1,35 @@
+info:
+  name: OpenClaw
+  cve: CVE-2026-32302
+  summary: OpenClaw WebSocket origin bypass in trusted-proxy mode enables unauthorized privileged operator session
+  details: >-
+    OpenClaw versions prior to 2026.3.11 contain a Cross-Origin Request validation
+    bypass (CWE-346) in the WebSocket connection handling when gateway.auth.mode
+    is configured as "trusted-proxy". Browser-originated WebSocket connections
+    arriving via a trusted reverse proxy with proxy-forwarded headers can bypass
+    origin validation. An untrusted web page served from a malicious origin can
+    connect through a trusted reverse proxy, inherit proxy-authenticated identity,
+    and establish a privileged operator.admin session without explicit authentication.
+    This allows an attacker to gain full administrative access to the OpenClaw
+    gateway, including access to user conversations, skills, memory files, and
+    any connected messaging channels. The vulnerability only affects deployments
+    using trusted-proxy authentication mode with a reverse proxy. Exploitation
+    maturity is LOW at publication; the official advisory references a single
+    commit fix. Severity is HIGH due to privilege escalation to operator.admin.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: >-
+    Upgrade OpenClaw to version 2026.3.11 or later, which adds strict WebSocket
+    origin validation in trusted-proxy mode. As a temporary mitigation, switch
+    gateway.auth.mode from "trusted-proxy" to "token" or "password" mode, or
+    add explicit CORS/Origin restrictions at the reverse proxy level (e.g., Nginx
+    map directives to reject requests from untrusted origins).
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+    - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11
+rule: version < "2026.3.11"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+  - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11

--- a/data/vuln_en/openclaw/CVE-2026-4039.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-4039.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4039
+  summary: OpenClaw applySkillConfigenvOverrides Skill Env Handler Code Injection
+  details: >-
+    OpenClaw version 2026.2.19-2 contains a code injection vulnerability in the
+    applySkillConfigenvOverrides function of the Skill Env Handler component.
+    Manipulation of environment variable overrides can lead to code injection,
+    allowing remote attackers to execute arbitrary code. The vulnerability is
+    remotely exploitable and was fixed in version 2026.2.21-beta.1.
+    The patch is identified as commit 8c9f35cdb51692b650ddf05b259ccdd75cc9a83c.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade OpenClaw to version 2026.2.21 or later (fix first included in 2026.2.21-beta.1).
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4039
+rule: version <= "2026.2.19-2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4039

--- a/data/vuln_en/openclaw/CVE-2026-4040.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-4040.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4040
+  summary: OpenClaw tools.exec.safeBins File Existence Information Disclosure via Timing Discrepancy
+  details: >-
+    OpenClaw versions up to 2026.2.17 contain an information disclosure vulnerability in
+    the tools.exec.safeBins File Existence Handler component. The manipulation leads to
+    information exposure through discrepancy (timing or response difference), allowing
+    local attackers to infer the existence of files on the system. This is a local attack
+    vector requiring low privileges, resulting in limited confidentiality impact.
+    Fixed in version 2026.2.19-beta.1 (patch: bafdbb6f112409a65decd3d4e7350fbd637c7754).
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: Upgrade OpenClaw to version 2026.2.19 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4040
+rule: version <= "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4040

--- a/data/vuln_en/openwebui/CVE-2025-15603.yaml
+++ b/data/vuln_en/openwebui/CVE-2025-15603.yaml
@@ -1,0 +1,22 @@
+info:
+  name: openwebui
+  cve: CVE-2025-15603
+  summary: Open WebUI JWT Key Handler Insufficiently Random WEBUI_SECRET_KEY Values
+  details: >-
+    Open WebUI up to version 0.6.16 contains a weak randomness vulnerability in the
+    JWT Key Handler component. The WEBUI_SECRET_KEY argument in the backend/start_windows.bat
+    file leads to insufficiently random values being used for JWT secret key generation.
+    Remote exploitation requires high attack complexity. An attacker who successfully
+    exploits this vulnerability could predict or recover the JWT secret key, potentially
+    allowing session token forgery and unauthorized access to the application.
+    The vulnerability has been publicly disclosed and may be actively exploited.
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: Upgrade Open WebUI to a version later than 0.6.16. Ensure WEBUI_SECRET_KEY is set to a strong, randomly generated value.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+    - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4
+rule: version <= "0.6.16"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+  - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4

--- a/data/vuln_en/sglang/CVE-2026-3059.yaml
+++ b/data/vuln_en/sglang/CVE-2026-3059.yaml
@@ -1,0 +1,27 @@
+info:
+  name: sglang
+  cve: CVE-2026-3059
+  summary: SGLang multimodal generation module exposes unauthenticated RCE via insecure ZMQ deserialization
+  details: >-
+    SGLang is a fast serving framework for large language models and vision-language
+    models. Prior to version 0.5.10, the multimodal generation module's ZMQ broker
+    in sglang/multimodal_gen/runtime/scheduler_client.py deserializes untrusted
+    data received over the network without authentication or validation (CWE-502).
+    The ZMQ socket accepts arbitrary pickle-serialized messages from any network
+    client, allowing unauthenticated remote attackers to achieve arbitrary code
+    execution on the server by sending crafted deserialization payloads. This
+    vulnerability is exploitable without any credentials and results in full server
+    compromise with the privileges of the SGLang process. No public PoC; exploit
+    maturity is LOW. An Orca Security blog post details the attack surface.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade sglang to version 0.5.10 or later. The fix adds authentication and input validation to the ZMQ broker in the multimodal generation module. Avoid exposing SGLang ZMQ ports to untrusted networks.
+  references:
+  - https://github.com/sgl-project/sglang/security/advisories/GHSA-rgq9-fqf5-fv58
+  - https://orca.security/resources/blog/sglang-llm-framework-rce-vulnerabilities/
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-3059
+rule: version <= "0.5.9"
+references:
+- https://github.com/sgl-project/sglang/security/advisories/GHSA-rgq9-fqf5-fv58
+- https://orca.security/resources/blog/sglang-llm-framework-rce-vulnerabilities/
+- https://nvd.nist.gov/vuln/detail/CVE-2026-3059

--- a/data/vuln_en/sglang/CVE-2026-3060.yaml
+++ b/data/vuln_en/sglang/CVE-2026-3060.yaml
@@ -1,0 +1,25 @@
+info:
+  name: sglang
+  cve: CVE-2026-3060
+  summary: SGLang encoder parallel disaggregation module exposes unauthenticated RCE via insecure ZMQ deserialization
+  details: >-
+    SGLang is a fast serving framework for large language models. Prior to version
+    0.5.10, the encoder parallel disaggregation system in
+    sglang/srt/disaggregation/encode_receiver.py deserializes untrusted data
+    received over ZMQ without authentication or validation (CWE-502). Similar to
+    CVE-2026-3059, the disaggregation module accepts arbitrary pickle-serialized
+    messages from unauthenticated network clients, enabling remote code execution
+    with the privileges of the SGLang server process. The vulnerability is present
+    in a distinct code path from the multimodal module vulnerability and requires
+    a separate fix. No public PoC; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade sglang to version 0.5.10 or later. The fix adds authentication and validation to the ZMQ-based disaggregation module. Restrict network access to SGLang ZMQ ports using firewall rules.
+  references:
+  - https://github.com/sgl-project/sglang/security/advisories/GHSA-jx93-g359-86wm
+  - https://orca.security/resources/blog/sglang-llm-framework-rce-vulnerabilities/
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-3060
+rule: version <= "0.5.9"
+references:
+- https://github.com/sgl-project/sglang/security/advisories/GHSA-jx93-g359-86wm
+- https://nvd.nist.gov/vuln/detail/CVE-2026-3060

--- a/data/vuln_en/sglang/CVE-2026-3989.yaml
+++ b/data/vuln_en/sglang/CVE-2026-3989.yaml
@@ -1,0 +1,25 @@
+info:
+  name: sglang
+  cve: CVE-2026-3989
+  summary: SGLang replay_request_dump.py contains insecure pickle.load() allowing arbitrary code execution
+  details: >-
+    SGLang prior to version 0.5.10 contains an insecure deserialization
+    vulnerability in scripts/playground/replay_request_dump.py. The script uses
+    pickle.load() to deserialize data from files or network sources without any
+    validation or integrity checks. An attacker who can supply a malicious pickle
+    file (e.g., via a shared filesystem, network path, or social engineering) can
+    achieve arbitrary code execution when the script processes the file. While this
+    script is in the playground directory and may not be deployed in all
+    environments, production deployments that use replay functionality are at risk.
+    No public PoC; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade sglang to version 0.5.10 or later. Replace pickle.load() with safe alternatives such as json or msgpack. Avoid loading replay dumps from untrusted sources.
+  references:
+  - https://github.com/sgl-project/sglang/security/advisories/GHSA-hvwj-8w5g-28rg
+  - https://orca.security/resources/blog/sglang-llm-framework-rce-vulnerabilities/
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-3989
+rule: version <= "0.5.9"
+references:
+- https://github.com/sgl-project/sglang/security/advisories/GHSA-hvwj-8w5g-28rg
+- https://nvd.nist.gov/vuln/detail/CVE-2026-3989

--- a/data/vuln_en/vllm/CVE-2026-25960.yaml
+++ b/data/vuln_en/vllm/CVE-2026-25960.yaml
@@ -1,0 +1,34 @@
+info:
+  name: vLLM
+  cve: CVE-2026-25960
+  summary: vLLM SSRF Protection Bypass via URL Parser Inconsistency
+  details: >-
+    vLLM versions 0.15.1 through 0.16.0 (fixed in 0.17.0) contain a Server-Side Request
+    Forgery (SSRF) protection bypass vulnerability in the `load_from_url_async` method
+    within `vllm/connections.py`. The SSRF fix (GHSA-qh4c-xf7m-gxfc) uses
+    `urllib3.util.parse_url()` for URL validation, but the actual HTTP request is made
+    via `aiohttp` which internally uses the `yarl` library. These two parsers handle
+    backslash characters differently: urllib3 URL-encodes `\` as `%5C` and treats the
+    remaining path as part of the URL path, while yarl interprets `\` as part of userinfo
+    and `@` as the userinfo/host separator, causing the request to be directed to a
+    different host than validated. An authenticated attacker with low privileges can craft
+    a URL such as `https://trusted-host\@evil.com/` to bypass allowlist validation and
+    force the server to make requests to arbitrary internal or external services, enabling
+    full SSRF attacks including access to cloud metadata endpoints and internal services.
+    No public PoC or exploit code has been identified at time of publication (LOW exploitation
+    maturity).
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:L
+  severity: MEDIUM
+  security_advise: Upgrade vLLM to version 0.17.0 or later. The fix is available in
+    pull request https://github.com/vllm-project/vllm/pull/34743. As a temporary
+    mitigation, restrict the URL allowlist to prevent access to internal network ranges
+    and validate URLs using a consistent URL parsing library.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+    - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+    - https://github.com/vllm-project/vllm/pull/34743
+rule: version >= "0.15.1" && version < "0.17.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+  - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+  - https://github.com/vllm-project/vllm/pull/34743

--- a/data/vuln_en/weknora/CVE-2026-30860.yaml
+++ b/data/vuln_en/weknora/CVE-2026-30860.yaml
@@ -1,0 +1,29 @@
+info:
+  name: WeKnora
+  cve: CVE-2026-30860
+  summary: WeKnora SQL injection bypass in AI database query tool leads to unauthenticated RCE via PostgreSQL
+  details: >-
+    WeKnora is an LLM-powered framework for deep document understanding and
+    semantic retrieval. Prior to version 0.2.12, a critical RCE vulnerability
+    exists in the database query functionality (internal/utils/inject.go).
+    The application implements a 7-phase SQL validation framework using
+    PostgreSQL AST parsing, but Phase 5 (validateNode) fails to handle
+    ArrayExpr and RowExpr node types. Attackers can smuggle dangerous
+    PostgreSQL functions (e.g., lo_import, lo_export) inside array or row
+    expressions, bypassing all validation phases. By chaining large object
+    operations with pg_read_binary_file and shared library loading
+    (lo_import + CREATE FUNCTION), an attacker with only a valid account
+    (open registration, no verification required) can achieve arbitrary code
+    execution on the database server with database user privileges. The fix
+    in version 0.2.12 adds recursive AST node validation for ArrayExpr and
+    RowExpr types.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade WeKnora to version 0.2.12 or later. The patch adds ArrayExpr and RowExpr node type handling to the validateNode() function in internal/utils/inject.go to prevent SQL injection bypass.
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30860
+rule: version < "0.2.12"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30860

--- a/data/vuln_en/weknora/CVE-2026-30861.yaml
+++ b/data/vuln_en/weknora/CVE-2026-30861.yaml
@@ -1,0 +1,31 @@
+info:
+  name: WeKnora
+  cve: CVE-2026-30861
+  summary: WeKnora MCP stdio configuration validation bypass leads to unauthenticated RCE via command injection
+  details: >-
+    WeKnora is an LLM-powered framework for deep document understanding and
+    semantic retrieval. Versions 0.2.5 through 0.2.9 contain a critical
+    unauthenticated remote code execution vulnerability in the MCP stdio
+    configuration validation. The application implements a command whitelist
+    (npx, uvx) and argument blacklist to prevent injection, but the blacklist
+    fails to block the -p flag in npx node. An attacker can register a free
+    account (no email verification or approval required), obtain API
+    credentials, and pass arguments like ["node", "-p",
+    "require('fs').writeFileSync(...)"] to execute arbitrary JavaScript via
+    Node.js -p (print/eval) flag, fully bypassing the DangerousArgPatterns
+    validation. This results in arbitrary code execution with the
+    application's privileges. The vulnerability was silently patched in
+    version 0.2.10 without a CVE disclosure, potentially leaving operators
+    unaware across versions 0.2.6 through 0.2.9.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade WeKnora to version 0.2.10 or later. If immediate upgrade is not possible, disable open user registration or restrict network access to the WeKnora service to prevent exploitation.
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+  - https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30861
+rule: version >= "0.2.5" && version < "0.2.10"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+- https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30861

--- a/data/vuln_en/zeptoclaw/CVE-2026-32231.yaml
+++ b/data/vuln_en/zeptoclaw/CVE-2026-32231.yaml
@@ -1,0 +1,26 @@
+info:
+  name: zeptoclaw
+  cve: CVE-2026-32231
+  summary: ZeptoClaw generic webhook channel trusts caller-supplied identity fields enabling sender impersonation
+  details: >-
+    ZeptoClaw is a personal AI assistant platform. Prior to version 0.7.6, the
+    generic webhook channel trusts caller-supplied identity fields (sender,
+    chat_id) from the request body without verification. Any party that can reach
+    the webhook endpoint can forge arbitrary sender identities, impersonating
+    trusted users or administrators. This breaks authentication assumptions in
+    webhook-based integrations and may allow attackers to trigger privileged agent
+    actions, bypass allowlists, or inject messages as trusted identities. The
+    vulnerability is classified as CWE-306 (Missing Authentication for Critical
+    Function) and CWE-345 (Insufficient Verification of Data Authenticity).
+    No public PoC; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N
+  severity: HIGH
+  security_advise: Upgrade ZeptoClaw to version 0.7.6 or later. The fix adds cryptographic verification of caller identity in the generic webhook channel handler, preventing untrusted callers from supplying arbitrary sender or chat_id values.
+  references:
+  - https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-46q5-g3j9-wx5c
+  - https://github.com/qhkm/zeptoclaw/commit/bf004a20d3687a0c1a9e052ec79536e30d6de134
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32231
+rule: version <= "0.7.5"
+references:
+- https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-46q5-g3j9-wx5c
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32231

--- a/data/vuln_en/zeptoclaw/CVE-2026-32232.yaml
+++ b/data/vuln_en/zeptoclaw/CVE-2026-32232.yaml
@@ -1,0 +1,26 @@
+info:
+  name: zeptoclaw
+  cve: CVE-2026-32232
+  summary: ZeptoClaw path boundary bypass via symlink, TOCTOU, and hardlink allowing workspace escape
+  details: >-
+    ZeptoClaw prior to version 0.7.6 contains multiple path traversal and race
+    condition vulnerabilities (CWE-22, CWE-62) in its workspace file handling.
+    The vulnerabilities involve three distinct bypass techniques: dangling symlink
+    component bypass (following symlinks that resolve outside the workspace after
+    validation), TOCTOU (time-of-check/time-of-use race between path validation
+    and file access), and hardlink bypass (creating hardlinks to files outside the
+    workspace that pass boundary checks). An attacker with the ability to create
+    symlinks or hardlinks within the workspace can escape the workspace directory
+    boundary and read or write arbitrary files accessible to the ZeptoClaw process.
+    No public PoC; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: Upgrade ZeptoClaw to version 0.7.6 or later. The fix resolves symlinks to their canonical paths before boundary checks and eliminates the TOCTOU window by using atomic file operations.
+  references:
+  - https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-2m67-cxxq-c3h8
+  - https://github.com/qhkm/zeptoclaw/commit/f50c17e11ae3e2d40c96730abac41974ef2ee2a8
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32232
+rule: version <= "0.7.5"
+references:
+- https://github.com/qhkm/zeptoclaw/security/advisories/GHSA-2m67-cxxq-c3h8
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32232


### PR DESCRIPTION
## 🤖 自动生成的 AIG 规则 [2026-03-16]

本 PR 由 AIG-Bot 自动创建，包含最新发现的 CVE 漏洞检测规则。

### 📊 统计

| 类型 | 数量 |
|------|------|
| 漏洞规则 (EN + CN) | 32 条 |
| 指纹规则 | 11 条 |

### 📋 新增漏洞规则

- `CVE-2025-15603` (openwebui)
- `CVE-2025-60012` (apache-livy)
- `CVE-2025-66249` (apache-livy)
- `CVE-2026-25960` (vllm)
- `CVE-2026-27940` (llama-cpp)
- `CVE-2026-28795` (openchatbi)
- `CVE-2026-3059` (sglang)
- `CVE-2026-3060` (sglang)
- `CVE-2026-30741` (openclaw)
- `CVE-2026-30820` (flowise)
- `CVE-2026-30823` (flowise)
- `CVE-2026-30860` (weknora)
- `CVE-2026-30861` (weknora)
- `CVE-2026-31829` (flowise)
- `CVE-2026-31841` (hyperterse)
- `CVE-2026-31861` (claudecodeui)
- `CVE-2026-31862` (claudecodeui)
- `CVE-2026-31944` (librechat)
- `CVE-2026-31949` (librechat)
- `CVE-2026-31975` (claudecodeui)
- `CVE-2026-32059` (openclaw)
- `CVE-2026-32060` (openclaw)
- `CVE-2026-32061` (openclaw)
- `CVE-2026-32062` (openclaw)
- `CVE-2026-32063` (openclaw)
- `CVE-2026-32128` (fastgpt)
- `CVE-2026-32231` (zeptoclaw)
- `CVE-2026-32232` (zeptoclaw)
- `CVE-2026-32302` (openclaw)
- `CVE-2026-3989` (sglang)
- `CVE-2026-4039` (openclaw)
- `CVE-2026-4040` (openclaw)

### 🔍 新增/更新指纹规则

- `apache-livy.yaml`
- `claudecodeui.yaml`
- `fastgpt.yaml`
- `flowise.yaml`
- `hyperterse.yaml`
- `librechat.yaml`
- `openchatbi.yaml`
- `openclaw.yaml`
- `sglang.yaml`
- `weknora.yaml`
- `zeptoclaw.yaml`

---
*由 AIG-Bot 自动生成，请人工审核后合并。*
