### PR TITLE
[AIG-Bot] 新增漏洞规则 2026-03-20（51 条 CVE + 5 条指纹）

### DIFF
--- a/data/fingerprints/flowise.yaml
+++ b/data/fingerprints/flowise.yaml
@@ -1,0 +1,20 @@
+info:
+  name: flowise
+  author: A.I.G bot
+  severity: info
+  desc: Flowise is an open-source low-code platform for building AI agents and LLM-powered chatflows with a visual drag-and-drop interface.
+  metadata:
+    product: flowise
+    vendor: flowiseai
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>Flowise</title>"
+version:
+  - method: GET
+    path: '/api/v1/version'
+    extractor:
+      part: body
+      group: 1
+      regex: '"version"\s*:\s*"(\d+\.\d+\.?\d*?)"'

--- a/data/fingerprints/librechat.yaml
+++ b/data/fingerprints/librechat.yaml
@@ -1,0 +1,20 @@
+info:
+  name: librechat
+  author: A.I.G bot
+  severity: info
+  desc: LibreChat is an open-source AI chat platform supporting multiple AI providers, with customizable UI and multi-user support.
+  metadata:
+    product: librechat
+    vendor: librechat
+http:
+  - method: GET
+    path: /
+    matchers:
+      - body="<title>LibreChat</title>"
+version:
+  - method: GET
+    path: /api/version
+    extractor:
+      part: body
+      group: 1
+      regex: '"version"\s*:\s*"(\d+\.\d+\.?\d*?)"'

--- a/data/fingerprints/mlflow.yaml
+++ b/data/fingerprints/mlflow.yaml
@@ -1,0 +1,20 @@
+info:
+  name: mlflow
+  author: A.I.G bot
+  severity: info
+  desc: MLflow - Machine Learning lifecycle platform for experiment tracking, model management, and deployment.
+  metadata:
+    product: mlflow
+    vendor: mlflow
+http:
+  - method: GET
+    path: /
+    matchers:
+      - body="<title>MLflow</title>" || body="mlflow-ui-container"
+version:
+  - method: GET
+    path: /version
+    extractor:
+      part: body
+      group: 1
+      regex: '^(\d+\.\d+\.\d+.*)$'

--- a/data/fingerprints/openclaw.yaml
+++ b/data/fingerprints/openclaw.yaml
@@ -1,0 +1,13 @@
+info:
+  name: openclaw
+  author: A.I.G bot
+  severity: info
+  desc: OpenClaw is a personal AI assistant platform with tool-use, skill management, and gateway service.
+  metadata:
+    product: openclaw
+    vendor: openclaw
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<openclaw-app>" || body="<title>OpenClaw Control</title>" || body="<title>Clawdbot Control</title>"

--- a/data/fingerprints/weknora.yaml
+++ b/data/fingerprints/weknora.yaml
@@ -1,0 +1,13 @@
+info:
+  name: weknora
+  author: A.I.G bot
+  severity: info
+  desc: WeKnora是腾讯开源的基于大语言模型的文档深度理解与语义检索框架，提供Web服务接口，支持文档导入、语义搜索和MCP配置。
+  metadata:
+    product: weknora
+    vendor: tencent
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>WeKnora</title>" || body="weknora"

--- a/data/vuln/anythingllm/CVE-2026-32617.yaml
+++ b/data/vuln/anythingllm/CVE-2026-32617.yaml
@@ -1,0 +1,26 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32617
+  summary: Mintplexlabs anythingllm AnythingLLM 宽松的 CORS 策略漏洞
+  details: >-
+    AnythingLLM 是一款将内容片段转化为任何 LLM 可在聊天时引用的上下文的应用。在 1.11.1 及更早版本中，未配置密码或
+    API 密钥的默认安装环境下，所有 HTTP 端点和 Agent WebSocket 均缺少身份验证，且服务器的 CORS 策略接受任意来源。AnythingLLM
+    Desktop 默认绑定到 127.0.0.1（回环地址）。现代浏览器（Chrome、Edge、Firefox）实现了私有网络访问（PNA）机制，会显式阻止公共网站向本地
+    IP 地址发起请求。因此该漏洞仅在同一局域网（LAN）内可利用，浏览器级别会阻止公网到私网的请求。
+
+
+    [利用成熟度：LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:L
+  severity: HIGH
+  security_advise: 遵循官方安全公告并升级到最新修复版本。
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-24qj-pw4h-3jmm
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32617.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32617
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-24qj-pw4h-3jmm
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32617.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32617

--- a/data/vuln/anythingllm/CVE-2026-32626.yaml
+++ b/data/vuln/anythingllm/CVE-2026-32626.yaml
@@ -1,0 +1,19 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32626
+  summary: AnythingLLM 流式阶段 XSS 到 RCE（通过 LLM 响应注入浏览器扩展工具）
+  details: AnythingLLM 1.11.1 及更早版本中，流式阶段存在 XSS 漏洞，攻击者可通过 LLM 响应注入浏览器扩展工具，最终实现远程代码执行（RCE）。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 升级到 AnythingLLM 最新修复版本。
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/9e2d144dc8be6fab29f560f5bcdaa9ef7dbb4214
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-rrmw-2j6x-4mf2
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32626.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32626
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/9e2d144dc8be6fab29f560f5bcdaa9ef7dbb4214
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-rrmw-2j6x-4mf2
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32626.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32626

--- a/data/vuln/anythingllm/CVE-2026-32628.yaml
+++ b/data/vuln/anythingllm/CVE-2026-32628.yaml
@@ -1,0 +1,27 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32628
+  summary: Mintplexlabs anythingllm AnythingLLM 内置 SQL Agent 插件中存在 SQL 注入漏洞（未过滤 table_name 参数）
+  details: >-
+    AnythingLLM 是一款将内容片段转化为任何 LLM 可在聊天时引用的上下文的应用。在 1.11.1 及更早版本中，内置 SQL Agent
+    插件存在 SQL 注入漏洞，允许任何可调用 Agent 的用户在已连接的数据库上执行任意 SQL 命令。所有三种数据库连接器（MySQL、PostgreSQL、MSSQL）中的
+    getTableSchemaSql() 方法使用直接字符串拼接构造 SQL 查询，table_name 参数未经过滤或参数化。
+
+
+    [利用成熟度：LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 遵循官方安全公告并升级到最新修复版本。
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/334ce052f063b53a4275518cbed3bab357695d7e
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-jwjx-mw2p-5wc7
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32628.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32628
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/334ce052f063b53a4275518cbed3bab357695d7e
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-jwjx-mw2p-5wc7
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32628.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32628

--- a/data/vuln/anythingllm/CVE-2026-32715.yaml
+++ b/data/vuln/anythingllm/CVE-2026-32715.yaml
@@ -1,0 +1,27 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32715
+  summary: Mintplexlabs anythingllm AnythingLLM Manager 角色权限绕过，可访问仅限管理员的系统偏好设置
+  details: >-
+    AnythingLLM 是一款将内容片段转化为任何 LLM 可在聊天时引用的上下文的应用。在 1.11.1 及更早版本中，两个通用的
+    system-preferences 端点允许 manager 角色访问，而其他所有接触相同设置的接口都限制为仅管理员访问。由于这种不一致性，manager
+    角色可直接调用通用端点读取明文 SQL 数据库凭据，并覆盖仅限管理员的全局设置，如默认系统提示词和社区中心 API 密钥。
+
+
+    [利用成熟度：LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:L/A:N
+  severity: LOW
+  security_advise: 遵循官方安全公告并升级到最新修复版本。
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/af68b482a5fd5e7ea74b12937f4e1071b96f3c6b
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-7jx2-7r2w-m7c5
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32715.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32715
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/af68b482a5fd5e7ea74b12937f4e1071b96f3c6b
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-7jx2-7r2w-m7c5
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32715.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32715

--- a/data/vuln/anythingllm/CVE-2026-32717.yaml
+++ b/data/vuln/anythingllm/CVE-2026-32717.yaml
@@ -1,0 +1,27 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32717
+  summary: Mintplexlabs anythingllm AnythingLLM 访问控制绕过：已暂停用户可继续使用浏览器扩展 API 密钥
+  details: >-
+    AnythingLLM 是一款将内容片段转化为任何 LLM 可在聊天时引用的上下文的应用。在 1.11.1 及更早版本中，多用户模式下，AnythingLLM
+    在正常的 JWT 会话路径上阻止已暂停用户，但在浏览器扩展 API 密钥路径上未阻止。如果用户已拥有有效的 brx-... 浏览器扩展 API
+    密钥，该密钥在用户被暂停后仍然有效。因此，已暂停用户仍可访问浏览器扩展端点，读取可访问的工作空间元数据，并继续上传或嵌入操作，即使正常的认证请求已被拒绝。
+
+
+    [利用成熟度：LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N
+  severity: LOW
+  security_advise: 遵循官方安全公告并升级到最新修复版本。
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/7d46ccdf9085f83fe92b14a99de80ad5a12c3db5
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-x2hq-q6h4-cmq3
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32717.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32717
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/7d46ccdf9085f83fe92b14a99de80ad5a12c3db5
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-x2hq-q6h4-cmq3
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32717.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32717

--- a/data/vuln/anythingllm/CVE-2026-32719.yaml
+++ b/data/vuln/anythingllm/CVE-2026-32719.yaml
@@ -1,0 +1,27 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32719
+  summary: Mintplexlabs anythingllm AnythingLLM 社区中心插件导入存在 Zip Slip 路径遍历和代码执行漏洞
+  details: >-
+    AnythingLLM 是一款将内容片段转化为任何 LLM 可在聊天时引用的上下文的应用。在 1.11.1 及更早版本中，server/utils/agents/imported.js
+    中的 ImportedPlugin.importCommunityItemFromUrl() 函数从社区中心 URL 下载 ZIP 文件并使用 AdmZip.extractAllTo()
+    解压，未验证压缩包内的文件路径。这使得攻击者可发起 Zip Slip 路径遍历攻击，导致任意代码执行。
+
+
+    [利用成熟度：LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: MEDIUM
+  security_advise: 遵循官方安全公告并升级到最新修复版本。
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/6e0c1a7c89df7fa46cd36a062e7d8e3e43a8e088
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-c64v-g82f-jg8w
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32719.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32719
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/6e0c1a7c89df7fa46cd36a062e7d8e3e43a8e088
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-c64v-g82f-jg8w
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32719.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32719

--- a/data/vuln/flowise/CVE-2026-30820.yaml
+++ b/data/vuln/flowise/CVE-2026-30820.yaml
@@ -1,0 +1,29 @@
+info:
+  name: flowise
+  cve: CVE-2026-30820
+  summary: Flowise 通过伪造 x-request-from 请求头实现授权绕过（权限提升）
+  details: >-
+    Flowise 3.0.13 之前的版本存在授权绕过漏洞（CWE-863：授权验证不当）。
+    负责保护 /api/v1/** 路由的全局中间件会盲目信任任何携带
+    `x-request-from: internal` 头部的 HTTP 请求，绕过所有 /api/v1/** 的授权检查。
+    低权限租户只需持有有效的浏览器 Cookie，附加该伪造请求头即可访问内部管理端点，
+    包括 API 密钥管理（/api/v1/apikey）、凭证存储（/api/v1/credentials）、
+    自定义函数执行（/api/v1/node-custom-function）等高权限接口，实现权限提升。
+    若与自定义函数 RCE 等其他漏洞链式利用，可能导致服务器完全失陷。
+    官方安全公告（GHSA-wvhq-wp8g-c7vq）中已包含公开的 PoC 验证步骤。
+    所有依赖默认中间件的自托管 Flowise 3.0.13 之前部署均受影响。
+    CVSS 4.0 评分反映了网络可达、低权限、高保密性/完整性/可用性影响的攻击特征。
+  cvss: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+  severity: CRITICAL
+  security_advise: >-
+    将 Flowise 升级至 3.0.13 或更高版本。补丁移除了对 `x-request-from: internal`
+    请求头的盲目信任逻辑，对所有 /api/v1/** 路由强制执行正确的授权检查，不再受请求头影响。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+    - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13

--- a/data/vuln/flowise/CVE-2026-30823.yaml
+++ b/data/vuln/flowise/CVE-2026-30823.yaml
@@ -1,0 +1,24 @@
+info:
+  name: flowise
+  cve: CVE-2026-30823
+  summary: Flowise IDOR 漏洞导致账户接管及企业 SSO 功能鉴权绕过
+  details: >-
+    Flowise 是一款拖拽式低代码大语言模型工作流构建平台。3.0.13 版本之前，PUT
+    /api/v1/loginmethod 接口存在不安全的直接对象引用（IDOR）漏洞。服务端从请求
+    体中接收 organizationId 参数，但未校验当前认证用户是否拥有对目标组织的所有权
+    或管理员权限。任意低权限认证用户（包括免费计划用户）均可利用此缺陷：覆盖其他
+    组织的 SSO 配置、在无有效许可证的情况下启用企业级功能（SSO/SAML），并通过将
+    认证流重定向至攻击者控制的 OAuth 凭据来实施账户接管。官方安全公告中已包含完整
+    的分步利用 PoC，利用仅需一个有效 JWT Token 以及目标 organizationId。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: 立即将 Flowise 升级至 3.0.13 或更高版本。补丁在 PUT /api/v1/loginmethod 接口增加了归属校验，确保用户只能修改自己组织的 SSO 配置。
+  references:
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30823
+rule: version <= "3.0.12"
+references:
+- https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+- https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30823

--- a/data/vuln/flowise/CVE-2026-31829.yaml
+++ b/data/vuln/flowise/CVE-2026-31829.yaml
@@ -1,0 +1,27 @@
+info:
+  name: flowise
+  cve: CVE-2026-31829
+  summary: Flowise HTTP 节点服务端请求伪造（SSRF）漏洞，攻击者可访问内部网络
+  details: >-
+    Flowise 3.0.13 之前版本在 AgentFlow 和 Chatflow 中暴露了 HTTP 节点，该节点使用用户
+    可控的 URL 执行服务端 HTTP 请求，且默认不限制目标主机。私有/内网 IP 地址段
+    （RFC 1918）、localhost 以及云元数据接口（如 AWS IMDSv1 169.254.169.254）均未被
+    过滤。这使得任何与公开暴露的 chatflow 交互的用户均可触发服务端请求伪造（SSRF），
+    强制 Flowise 服务器向内网资源发起请求。该漏洞危害尤为严重，原因是 Flowise 实例常在
+    未启用认证（默认未设置 FLOWISE_USERNAME/PASSWORD）的情况下公开部署。HTTP 节点支持
+    所有标准 HTTP 方法（GET/POST/PUT/PATCH/DELETE），可对内部服务实施读写操作。危害包括：
+    从云元数据接口获取 IAM 凭证、访问内部管理面板（Jenkins、Kubernetes API）、对内网
+    服务进行端口扫描及横向移动。漏洞公告中附有完整攻击概念验证（PoC），利用成熟度为高。
+  cvss: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:L
+  severity: HIGH
+  security_advise: 升级 Flowise 至 3.0.13 或更高版本。修复版本在 HTTP 节点中新增了安全
+    控制选项，包括"阻止私有 IP 范围和 localhost"开关及允许域名白名单。在升级前，建议
+    限制 Flowise 实例的网络访问权限，并通过设置 FLOWISE_USERNAME 和 FLOWISE_PASSWORD
+    环境变量启用身份认证。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7

--- a/data/vuln/langflow/CVE-2026-33017.yaml
+++ b/data/vuln/langflow/CVE-2026-33017.yaml
@@ -1,0 +1,14 @@
+info:
+  name: langflow
+  cve: CVE-2026-33017
+  summary: 通过公共流构建端点实现未授权远程代码执行
+  details: Langflow 修复前的版本在公共流构建端点存在未授权远程代码执行漏洞。攻击者可利用此漏洞在无需认证的情况下在服务器上执行任意代码。这是一个影响
+    AI 工作流平台的严重漏洞。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 升级 Langflow 至 1.8.2 或更高版本。限制流构建端点的访问。实施身份验证和授权控制。
+  references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx
+rule: version <= "1.8.1"
+references:
+- https://github.com/advisories/GHSA-vwmf-pq79-vjvx

--- a/data/vuln/langflow/CVE-2026-33053.yaml
+++ b/data/vuln/langflow/CVE-2026-33053.yaml
@@ -1,0 +1,78 @@
+info:
+  name: langflow
+  cve: CVE-2026-33053
+  summary: Langflow API 密钥删除缺少所有权验证（IDOR）
+  details: >-
+    **检测方法：** Kolega.dev 深度代码扫描
+
+
+    | 属性 | 值 |
+
+    |---|---|
+
+    | 位置 | src/backend/base/langflow/api/v1/api_key.py:44-53 |
+
+    | 实际可利用性 | 高 |
+
+    | 开发者审批人 | faizan@kolega.ai |
+
+
+    ### 描述
+
+    delete_api_key_route() 端点接受 api_key_id 路径参数，仅通过通用的身份验证检查（get_current_active_user 依赖）就删除 API 密钥。
+    然而，delete_api_key() CRUD 函数在删除前**并未验证 API 密钥是否属于当前用户**。
+
+
+    ### 受影响代码
+
+    ```
+
+    @router.delete("/{api_key_id}", dependencies=[Depends(auth_utils.get_current_active_user)])
+
+    async def delete_api_key_route(
+        api_key_id: UUID,
+        db: DbSession,
+    ):
+        try:
+            await delete_api_key(db, api_key_id)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        return {"detail": "API Key deleted"}
+    ```
+
+
+    ### 证据
+
+    在 crud.py 第 44-49 行，delete_api_key() 通过 ID 检索 API 密钥并删除，未检查密钥是否属于已认证用户。
+    该端点也未将 current_user 传递给删除函数进行验证。
+
+
+    ### 影响
+
+    已认证的攻击者可以通过猜测或发现其他用户的 API 密钥 ID 来枚举和删除这些密钥。这将导致账户接管、拒绝服务和破坏其他用户的集成。
+
+
+    ### 建议
+
+    修改 delete_api_key 端点和函数：(1) 将 current_user 传递给删除函数；(2) 在 delete_api_key() 中，删除前验证 api_key.user_id == current_user.id；
+    (3) 如果用户不拥有该密钥，则返回 403 Forbidden 错误。示例：if api_key.user_id != user_id: raise HTTPException(status_code=403, detail='Unauthorized')
+
+
+    ### 备注
+
+    已确认的 IDOR 漏洞。第 44-53 行的 delete_api_key_route 端点接受 api_key_id 并调用 delete_api_key(db, api_key_id)，
+    未传递 current_user。crud.py:44 的 CRUD 函数 delete_api_key() 未进行所有权验证。
+  cvss: null
+  severity: HIGH
+  security_advise: 升级到 langflow 1.7.2 或更高版本。
+  references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-rf6x-r45m-xv3w
+  - https://github.com/langflow-ai/langflow/commit/fdc1b3b1448ff3317d73d3e769a6c4a1717f74d7
+  - https://github.com/langflow-ai/langflow/releases/tag/1.7.2
+  - https://github.com/advisories/GHSA-rf6x-r45m-xv3w
+rule: version < "1.7.2"
+references:
+- https://github.com/langflow-ai/langflow/security/advisories/GHSA-rf6x-r45m-xv3w
+- https://github.com/langflow-ai/langflow/commit/fdc1b3b1448ff3317d73d3e769a6c4a1717f74d7
+- https://github.com/langflow-ai/langflow/releases/tag/1.7.2
+- https://github.com/advisories/GHSA-rf6x-r45m-xv3w

--- a/data/vuln/langflow/CVE-2026-33309.yaml
+++ b/data/vuln/langflow/CVE-2026-33309.yaml
@@ -1,0 +1,24 @@
+info:
+  name: langflow
+  cve: CVE-2026-33309
+  summary: Langflow v2 API 存在任意文件写入漏洞（可导致 RCE，深度防御绕过）
+  details: >-
+    在审查 CVE-2025-68478（v1.7.1 中外部控制文件名）的补丁时，发现 LocalStorageService
+    中存在未修复的根本性架构问题。POST /api/v2/files/ 接口存在任意文件写入漏洞：multipart
+    上传的文件名直接从 Content-Disposition 头提取并传递给 LocalStorageService，缺少规范化路径
+    边界检查（即未实现 resolve().is_relative_to(base_dir)）。已认证的攻击者可在宿主机文件系统
+    的任意位置写入文件，进而导致远程代码执行（RCE）。已有针对 langflow v1.7.3 的公开 PoC
+    验证了该漏洞的可利用性。v1.9.0 已修复。
+  cvss: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  severity: CRITICAL
+  security_advise: >-
+    升级 Langflow 至 1.9.0 或更高版本。临时缓解措施：限制对 POST /api/v2/files/ 接口的访问，
+    并确保 Langflow 不对不受信任用户开放。应对 multipart 文件名进行输入净化（去除目录穿越字符），
+    并在 LocalStorageService.save_file 中添加路径边界检查。
+  references:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-g2j9-7rj2-gm6c
+    - https://github.com/advisories/GHSA-g2j9-7rj2-gm6c
+rule: version >= "1.2.0" && version <= "1.8.1"
+references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-g2j9-7rj2-gm6c
+  - https://github.com/advisories/GHSA-g2j9-7rj2-gm6c

--- a/data/vuln/librechat/CVE-2025-41258.yaml
+++ b/data/vuln/librechat/CVE-2025-41258.yaml
@@ -1,0 +1,16 @@
+info:
+  name: librechat
+  cve: CVE-2025-41258
+  summary: LibreChat v0.8.1-rc2 JWT 密钥重用漏洞
+  details: >-
+    LibreChat 版本 0.8.1-rc2 对用户会话机制和 RAG API 使用相同的 JWT 密钥，损害了 RAG API 的服务级身份验证。
+  cvss: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级到 LibreChat 最新的修复版本。
+  references:
+    - https://github.com/danny-avila/LibreChat
+    - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
+rule: ""
+references:
+  - https://github.com/danny-avila/LibreChat
+  - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass

--- a/data/vuln/librechat/CVE-2026-31944.yaml
+++ b/data/vuln/librechat/CVE-2026-31944.yaml
@@ -1,0 +1,25 @@
+info:
+  name: librechat
+  cve: CVE-2026-31944
+  summary: LibreChat MCP OAuth 回调会话绑定缺失，导致 OAuth 令牌窃取与账户接管
+  details: >-
+    LibreChat 0.8.2 至 0.8.2-rc3 版本在 MCP（Model Context Protocol）OAuth 回调端点
+    存在严重认证缺陷（CWE-306）。回调端点在接受身份提供商重定向后，将 OAuth 令牌存储到
+    发起流程的会话中，但未验证完成重定向的浏览器是否以相同用户身份登录。攻击者可构造
+    授权 URL 并发送给受害者；当受害者完成 OAuth 流程后，受害者的 OAuth 令牌将被存储在
+    攻击者的 LibreChat 账户中，从而实现对受害者 MCP 关联服务（如 Atlassian、Outlook、
+    GitHub）的账户接管。攻击要求攻击者拥有已认证的 LibreChat 账户且受害者点击构造链接。
+    发布时漏洞利用成熟度为 LOW，暂无公开 PoC。由于可能造成 MCP 关联第三方服务的账户
+    接管，严重性评级为 HIGH。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: >-
+    升级 LibreChat 至 0.8.3-rc1 或更高版本。临时缓解措施：在完成升级前禁用 MCP OAuth
+    集成。若怀疑存在未授权访问，应立即撤销 MCP 关联服务的 OAuth 令牌。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g
+rule: version == "0.8.2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g

--- a/data/vuln/librechat/CVE-2026-31949.yaml
+++ b/data/vuln/librechat/CVE-2026-31949.yaml
@@ -1,0 +1,24 @@
+info:
+  name: librechat
+  cve: CVE-2026-31949
+  summary: LibreChat DELETE /api/convos 端点未处理的 TypeError 导致 Node.js 服务器进程崩溃（DoS）
+  details: >-
+    LibreChat 0.8.3-rc1 之前版本在 DELETE /api/convos 端点存在拒绝服务（DoS）漏洞
+    （CWE-248）。路由处理器在未验证 req.body 是否存在或非空的情况下直接对
+    req.body.arg 进行解构赋值。当经过认证的攻击者发送格式错误的 DELETE 请求（如请求体
+    为空或缺失）时，服务器抛出未处理的 TypeError，该异常绕过 Express.js 错误处理中间件
+    并触发 process.exit(1)，导致整个 Node.js 服务进程崩溃。这将造成所有用户的完全服务中断，
+    直至服务器重启。该漏洞需要经过认证的攻击者，且此端点无速率限制保护。发布时漏洞
+    利用成熟度为 LOW，暂无公开 PoC。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+  severity: MEDIUM
+  security_advise: >-
+    升级 LibreChat 至 0.8.3-rc1 或更高版本。临时缓解措施：将 API 访问限制为
+    受信任的认证用户，并监控异常的 DELETE /api/convos 请求模式。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p
+rule: version < "0.8.3-rc1"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p

--- a/data/vuln/librechat/CVE-2026-33265.yaml
+++ b/data/vuln/librechat/CVE-2026-33265.yaml
@@ -1,0 +1,16 @@
+info:
+  name: librechat
+  cve: CVE-2026-33265
+  summary: LibreChat v0.8.1-rc2 JWT 令牌暴露
+  details: >-
+    在 LibreChat 0.8.1-rc2 中，已登录用户同时获得 LibreChat API 和 RAG API 的 JWT 令牌。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级到 LibreChat 最新的修复版本。
+  references:
+    - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
+    - https://www.openwall.com/lists/oss-security/2026/03/18/3
+rule: ""
+references:
+  - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
+  - https://www.openwall.com/lists/oss-security/2026/03/18/3

--- a/data/vuln/librechat/CVE-2026-4276.yaml
+++ b/data/vuln/librechat/CVE-2026-4276.yaml
@@ -1,0 +1,16 @@
+info:
+  name: librechat
+  cve: CVE-2026-4276
+  summary: LibreChat RAG API v0.7.0 日志注入漏洞
+  details: >-
+    LibreChat RAG API 版本 0.7.0 存在日志注入漏洞，允许攻击者伪造日志条目。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N
+  severity: HIGH
+  security_advise: 升级到 LibreChat 的修复版本。
+  references:
+    - https://kb.cert.org/vuls/id/624941
+    - https://www.kb.cert.org/vuls/id/624941
+rule: ""
+references:
+  - https://kb.cert.org/vuls/id/624941
+  - https://www.kb.cert.org/vuls/id/624941

--- a/data/vuln/llama-cpp/CVE-2026-27940.yaml
+++ b/data/vuln/llama-cpp/CVE-2026-27940.yaml
@@ -1,0 +1,25 @@
+info:
+  name: llama-cpp
+  cve: CVE-2026-27940
+  summary: llama.cpp mem_size 计算整数溢出导致堆缓冲区溢出，可通过恶意 GGUF 文件触发任意代码执行
+  details: >-
+    llama.cpp 是基于 C/C++ 的 LLM 模型推理引擎。b8146 构建版本之前，gguf.cpp 中的
+    gguf_init_from_file_impl() 函数在 mem_size 计算中存在整数溢出漏洞。CVE-2025-53630
+    虽然为 ctx->size 的逐次累加添加了溢出检查，但最终的 mem_size 计算公式
+    (n_tensors+1)*ggml_tensor_overhead() + ctx->size 未加防护。当 ctx->size 接近
+    SIZE_MAX 时（可通过两个大型 I8 张量实现，各次累加均通过 CVE-2025-53630 检查），
+    最终加法产生整数回绕，导致堆分配大小偏小。后续的 fread() 调用将 528+ 字节的攻击
+    者可控数据写入缓冲区边界之外。通过将分配大小调整到 glibc tcache 范围内，可将此漏
+    洞升级为完整的任意代码执行（通过 system(/bin/sh) 获取 root shell）。攻击向量为本
+    地（AV:L），需诱导用户加载恶意 GGUF 模型文件。该漏洞是对同一函数中 CVE-2025-53630
+    修复的绕过。目前无公开 PoC，利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 将 llama.cpp 升级至 b8146 或更高构建版本。修复版本在 gguf_init_from_file_impl() 的 mem_size 计算中增加了溢出防护，防止 ctx->size 接近 SIZE_MAX 时的整数回绕。同时应避免加载来自不可信来源的 GGUF 模型文件。
+  references:
+  - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-27940
+rule: version < "b8146"
+references:
+- https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+- https://nvd.nist.gov/vuln/detail/CVE-2026-27940

--- a/data/vuln/mlflow/CVE-2025-14287.yaml
+++ b/data/vuln/mlflow/CVE-2025-14287.yaml
@@ -1,0 +1,25 @@
+info:
+  name: mlflow
+  cve: CVE-2025-14287
+  summary: mlflow MLflow 在 mlflow/sagemaker/__init__.py 中存在命令注入漏洞
+  details: >-
+    MLflow v3.7.0 之前版本存在命令注入漏洞，具体位于 `mlflow/sagemaker/__init__.py` 文件的 161-167
+    行。该漏洞源于用户提供的容器镜像名称未经适当过滤直接插值到 shell 命令中，随后使用 `os.system()` 执行。这使得攻击者可通过 CLI
+    的 `--container` 参数提供恶意输入来执行任意命令。该问题影响使用 MLflow 的环境，包括开发环境、CI/CD 流水线和云部署。
+
+
+    [利用成熟度：LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级到 MLflow v3.7.0 或更高版本。
+  references:
+  - https://github.com/mlflow/mlflow/security/advisories/GHSA-4jjw-6r75-46mc
+  - https://github.com/mlflow/mlflow/commit/d1e9b2c18663d57cb01b6cf66bae5f60c1d9fe08
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-14287
+rule: version < "3.8.0rc0"
+references:
+- https://github.com/mlflow/mlflow/security/advisories/GHSA-4jjw-6r75-46mc
+- https://github.com/mlflow/mlflow/commit/d1e9b2c18663d57cb01b6cf66bae5f60c1d9fe08
+- https://nvd.nist.gov/vuln/detail/CVE-2025-14287

--- a/data/vuln/mlflow/CVE-2025-15031.yaml
+++ b/data/vuln/mlflow/CVE-2025-15031.yaml
@@ -1,0 +1,16 @@
+info:
+  name: mlflow
+  cve: CVE-2025-15031
+  summary: MLflow pyfunc tar.gz 提取路径遍历漏洞
+  details: >-
+    MLflow 的 pyfunc 提取流程中存在漏洞，由于对 tar 归档文件条目处理不当，允许任意文件写入。具体来说，使用 `tarfile.extractall` 时未进行路径验证，
+    使得包含 `..` 或绝对路径的恶意 tar.gz 文件能够逃逸预期的提取目录。该问题影响 MLflow 最新版本，在涉及多租户环境或摄入不可信构件的场景中存在高/严重风险，
+    可能导致任意文件覆盖和潜在的远程代码执行。
+  cvss: ""
+  severity: HIGH
+  security_advise: 升级到 MLflow 最新的修复版本，并避免摄入不可信的 tar.gz 构件。
+  references:
+    - https://huntr.com/bounties/09856f77-f968-446f-a930-657d126efe4e
+rule: ""
+references:
+  - https://huntr.com/bounties/09856f77-f968-446f-a930-657d126efe4e

--- a/data/vuln/openclaw/CVE-2026-22168.yaml
+++ b/data/vuln/openclaw/CVE-2026-22168.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22168
+  summary: OpenClaw Windows system.run 审批不匹配（cmd.exe /c 尾随空格绕过）
+  details: OpenClaw 2026.2.23 之前版本在 Windows 上存在 system.run 审批不匹配漏洞，攻击者可通过在 cmd.exe
+    /c 命令末尾添加尾随空格绕过审批逻辑，执行未经授权的命令。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.23 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/6007941f04df1edcca679dd6c95949744fdbd4df
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-5v6x-rfc3-7qfr
+  - https://www.vulncheck.com/advisories/openclaw-command-injection-via-cmd-exe-c-trailing-arguments-in-system-run
+  - https://github.com/advisories/GHSA-5v6x-rfc3-7qfr
+rule: version < "2026.2.21"
+references:
+- https://github.com/openclaw/openclaw/commit/6007941f04df1edcca679dd6c95949744fdbd4df
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-5v6x-rfc3-7qfr
+- https://www.vulncheck.com/advisories/openclaw-command-injection-via-cmd-exe-c-trailing-arguments-in-system-run
+- https://github.com/advisories/GHSA-5v6x-rfc3-7qfr

--- a/data/vuln/openclaw/CVE-2026-22169.yaml
+++ b/data/vuln/openclaw/CVE-2026-22169.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22169
+  summary: OpenClaw 非默认 safeBins 排序配置可绕过预期的执行限制
+  details: OpenClaw 2026.2.23 之前版本中，非默认的 safeBins 排序配置可被绕过，导致预期的执行限制失效。
+  cvss: CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.23 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/57fbbaebca4d34d17549accf6092ae26eb7b605c
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-vmqr-rc7x-3446
+  - https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-sort-configuration-in-safebins
+  - https://github.com/advisories/GHSA-vmqr-rc7x-3446
+rule: version < "2026.2.22"
+references:
+- https://github.com/openclaw/openclaw/commit/57fbbaebca4d34d17549accf6092ae26eb7b605c
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-vmqr-rc7x-3446
+- https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-sort-configuration-in-safebins
+- https://github.com/advisories/GHSA-vmqr-rc7x-3446

--- a/data/vuln/openclaw/CVE-2026-22170.yaml
+++ b/data/vuln/openclaw/CVE-2026-22170.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22170
+  summary: OpenClaw BlueBubbles（可选插件）配对/白名单不匹配可通过硬重置绕过
+  details: OpenClaw 2026.2.23 之前版本中，BlueBubbles（可选插件）存在配对/白名单不匹配漏洞，攻击者可通过硬重置绕过设备白名单限制。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.23 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/2ba6de7eaad812e5e8603018e14e54e96bdd57dd
+  - https://github.com/openclaw/openclaw/commit/4540790cb62412676f7b61cfc6e47443f84a251e
+  - https://github.com/openclaw/openclaw/commit/51c0893673de8e5cea64e64351dbfa4680ba0dec
+  - https://github.com/openclaw/openclaw/commit/9632b9bcf032c5f2280c3103961fde912ab1f920
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-jwf4-8wf4-jf2m
+rule: version < "2026.2.22"
+references:
+- https://github.com/openclaw/openclaw/commit/2ba6de7eaad812e5e8603018e14e54e96bdd57dd
+- https://github.com/openclaw/openclaw/commit/4540790cb62412676f7b61cfc6e47443f84a251e
+- https://github.com/openclaw/openclaw/commit/51c0893673de8e5cea64e64351dbfa4680ba0dec
+- https://github.com/openclaw/openclaw/commit/9632b9bcf032c5f2280c3103961fde912ab1f920
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-jwf4-8wf4-jf2m

--- a/data/vuln/openclaw/CVE-2026-22171.yaml
+++ b/data/vuln/openclaw/CVE-2026-22171.yaml
@@ -1,0 +1,23 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22171
+  summary: openclaw 飞书媒体文件临时路径命名存在路径遍历漏洞，可写入 os.tmpdir() 外的文件
+  details: OpenClaw 2026.2.19 之前版本在飞书媒体下载流程中存在路径遍历漏洞，extensions/feishu/src/media.ts
+    中未经验证的媒体键值被直接插值到临时文件路径。攻击者可通过控制返回给客户端的飞书媒体键值，利用遍历片段逃逸 os.tmpdir()
+    并在 OpenClaw 进程权限范围内写入任意文件。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: 升级到 openclaw 2026.2.19 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/c821099157a9767d4df208c6b12f214946507871
+  - https://github.com/openclaw/openclaw/commit/cdb00fe2428000e7a08f9b7848784a0049176705
+  - https://github.com/openclaw/openclaw/commit/ec232a9e2dff60f0e3d7e827a7c868db5254473f
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-vj3g-5px3-gr46
+  - https://www.vulncheck.com/advisories/openclaw-path-traversal-in-feishu-media-temporary-file-naming
+rule: version < "2026.2.19"
+references:
+- https://github.com/openclaw/openclaw/commit/c821099157a9767d4df208c6b12f214946507871
+- https://github.com/openclaw/openclaw/commit/cdb00fe2428000e7a08f9b7848784a0049176705
+- https://github.com/openclaw/openclaw/commit/ec232a9e2dff60f0e3d7e827a7c868db5254473f
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-vj3g-5px3-gr46
+- https://www.vulncheck.com/advisories/openclaw-path-traversal-in-feishu-media-temporary-file-naming

--- a/data/vuln/openclaw/CVE-2026-22174.yaml
+++ b/data/vuln/openclaw/CVE-2026-22174.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22174
+  summary: OpenClaw Loopback CDP 探测可向本地监听器泄露 Gateway 令牌
+  details: OpenClaw 2026.2.21 之前版本中，Loopback CDP 探测功能可向本地监听器泄露 Gateway 令牌，导致敏感凭据暴露。
+  cvss: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.21 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/afa22acc4a09fdf32be8a167ae216bee85c30dad
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-v3j7-34xh-6g3w
+  - https://www.vulncheck.com/advisories/openclaw-gateway-token-disclosure-via-chrome-cdp-probe
+  - https://github.com/advisories/GHSA-v3j7-34xh-6g3w
+rule: version <= "2026.2.21-2"
+references:
+- https://github.com/openclaw/openclaw/commit/afa22acc4a09fdf32be8a167ae216bee85c30dad
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-v3j7-34xh-6g3w
+- https://www.vulncheck.com/advisories/openclaw-gateway-token-disclosure-via-chrome-cdp-probe
+- https://github.com/advisories/GHSA-v3j7-34xh-6g3w

--- a/data/vuln/openclaw/CVE-2026-22175.yaml
+++ b/data/vuln/openclaw/CVE-2026-22175.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22175
+  summary: openclaw 白名单模式下 exec 永久许可可通过未识别的多路复用 shell 包装器（busybox/toybox sh -c）绕过
+  details: OpenClaw 2026.2.23 之前版本在白名单模式下存在 exec 审批绕过漏洞，攻击者可通过未被识别的多路复用 shell
+    包装器（如 busybox 和 toybox 的 sh -c 命令）绕过永久许可（allow-always）授权。攻击者可在相同的多路复用包装器下调用任意载荷，以满足已存储的白名单规则，从而绕过预期的执行限制。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: 升级到 openclaw 2026.2.23 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/a67689a7e3ad494b6637c76235a664322d526f9e
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-gwqp-86q6-w47g
+  - https://www.vulncheck.com/advisories/openclaw-exec-approval-bypass-via-unrecognized-multiplexer-shell-wrappers
+  - https://github.com/advisories/GHSA-gwqp-86q6-w47g
+rule: version < "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/a67689a7e3ad494b6637c76235a664322d526f9e
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-gwqp-86q6-w47g
+- https://www.vulncheck.com/advisories/openclaw-exec-approval-bypass-via-unrecognized-multiplexer-shell-wrappers
+- https://github.com/advisories/GHSA-gwqp-86q6-w47g

--- a/data/vuln/openclaw/CVE-2026-22177.yaml
+++ b/data/vuln/openclaw/CVE-2026-22177.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22177
+  summary: OpenClaw 的配置环境变量允许启动环境注入到服务运行时
+  details: OpenClaw 2026.2.23 之前版本允许通过配置环境变量将启动环境注入到服务运行时，可能导致权限提升或配置篡改。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.23 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/2cdbadee1f8fcaa93302d7debbfc529e19868ea4
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-8fmp-37rc-p5g7
+  - https://www.vulncheck.com/advisories/openclaw-environment-variable-injection-via-config-env-vars
+  - https://github.com/advisories/GHSA-8fmp-37rc-p5g7
+rule: version < "2026.2.21"
+references:
+- https://github.com/openclaw/openclaw/commit/2cdbadee1f8fcaa93302d7debbfc529e19868ea4
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-8fmp-37rc-p5g7
+- https://www.vulncheck.com/advisories/openclaw-environment-variable-injection-via-config-env-vars
+- https://github.com/advisories/GHSA-8fmp-37rc-p5g7

--- a/data/vuln/openclaw/CVE-2026-22178.yaml
+++ b/data/vuln/openclaw/CVE-2026-22178.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22178
+  summary: OpenClaw 在处理未转义的飞书 mention 元数据时存在 ReDoS 和正则注入
+  details: OpenClaw 2026.2.21 之前版本在处理未转义的飞书 mention 元数据时存在正则表达式拒绝服务（ReDoS）和正则注入漏洞。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.21 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/74268489137510b6f6349919d1e197b17290d92c
+  - https://github.com/openclaw/openclaw/commit/7e67ab75cc2f0e93569d12fecd1411c2961fcc8c
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-c6hr-w26q-c636
+  - https://www.vulncheck.com/advisories/openclaw-redos-and-regex-injection-via-unescaped-feishu-mention-metadata
+  - https://github.com/advisories/GHSA-c6hr-w26q-c636
+rule: version < "2026.2.19"
+references:
+- https://github.com/openclaw/openclaw/commit/74268489137510b6f6349919d1e197b17290d92c
+- https://github.com/openclaw/openclaw/commit/7e67ab75cc2f0e93569d12fecd1411c2961fcc8c
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-c6hr-w26q-c636
+- https://www.vulncheck.com/advisories/openclaw-redos-and-regex-injection-via-unescaped-feishu-mention-metadata
+- https://github.com/advisories/GHSA-c6hr-w26q-c636

--- a/data/vuln/openclaw/CVE-2026-22179.yaml
+++ b/data/vuln/openclaw/CVE-2026-22179.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22179
+  summary: OpenClaw macOS system.run 白名单通过引号命令替换绕过
+  details: OpenClaw 2026.2.23 之前版本在 macOS 上存在 system.run 白名单绕过漏洞，攻击者可通过引号命令替换技巧绕过白名单限制。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.23 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/90a378ca3a9ecbf1634cd247f17a35f4612c6ca6
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-9p38-94jf-hgjj
+  - https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-command-substitution-in-system-run
+  - https://github.com/advisories/GHSA-9p38-94jf-hgjj
+rule: version < "2026.2.22"
+references:
+- https://github.com/openclaw/openclaw/commit/90a378ca3a9ecbf1634cd247f17a35f4612c6ca6
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-9p38-94jf-hgjj
+- https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-command-substitution-in-system-run
+- https://github.com/advisories/GHSA-9p38-94jf-hgjj

--- a/data/vuln/openclaw/CVE-2026-22180.yaml
+++ b/data/vuln/openclaw/CVE-2026-22180.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22180
+  summary: OpenClaw 统一根边界写入加固（浏览器输出和相关路径）
+  details: OpenClaw 2026.2.22 之前版本缺少统一的根边界写入加固机制，浏览器输出和相关路径可能写入非预期位置。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.22 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/104d32bb64cdf19d5e77f70553a511a2ae90ad1c
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-3pxq-f3cp-jmxp
+  - https://www.vulncheck.com/advisories/openclaw-path-confinement-bypass-in-browser-output-and-file-write-operations
+  - https://github.com/advisories/GHSA-3pxq-f3cp-jmxp
+rule: version <= "2026.3.1"
+references:
+- https://github.com/openclaw/openclaw/commit/104d32bb64cdf19d5e77f70553a511a2ae90ad1c
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-3pxq-f3cp-jmxp
+- https://www.vulncheck.com/advisories/openclaw-path-confinement-bypass-in-browser-output-and-file-write-operations
+- https://github.com/advisories/GHSA-3pxq-f3cp-jmxp

--- a/data/vuln/openclaw/CVE-2026-22181.yaml
+++ b/data/vuln/openclaw/CVE-2026-22181.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22181
+  summary: OpenClaw web 工具严格 URL 守卫在环境探测禁用时可能丢失 DNS 固定
+  details: OpenClaw 2026.2.21 之前版本中，web 工具的严格 URL 守卫在环境探测禁用时可能丢失 DNS 固定（DNS pinning），导致
+    SSRF 风险。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.21 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/345abf0b2e0f43b0f229e96f252ebf56f1e5549e
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-8mvx-p2r9-r375
+  - https://www.vulncheck.com/advisories/openclaw-dns-pinning-bypass-via-environment-proxy-configuration-in-web-fetch
+  - https://github.com/advisories/GHSA-8mvx-p2r9-r375
+rule: version <= "2026.3.1"
+references:
+- https://github.com/openclaw/openclaw/commit/345abf0b2e0f43b0f229e96f252ebf56f1e5549e
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-8mvx-p2r9-r375
+- https://www.vulncheck.com/advisories/openclaw-dns-pinning-bypass-via-environment-proxy-configuration-in-web-fetch
+- https://github.com/advisories/GHSA-8mvx-p2r9-r375

--- a/data/vuln/openclaw/CVE-2026-22217.yaml
+++ b/data/vuln/openclaw/CVE-2026-22217.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22217
+  summary: OpenClaw shell-env trusted-prefix 回退允许攻击者控制的环境注入
+  details: OpenClaw 2026.2.25 之前版本中，shell-env 的 trusted-prefix 回退机制允许攻击者控制的环境注入到受信任的上下文。
+  cvss: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.2.25 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/ff10fe8b91670044a6bb0cd85deb736a0ec8fb55
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-p4wh-cr8m-gm6c
+  - https://www.vulncheck.com/advisories/openclaw-arbitrary-binary-execution-via-shell-environment-variable-trusted-prefix-fallback
+  - https://github.com/advisories/GHSA-p4wh-cr8m-gm6c
+rule: version >= "2026.2.22" && version < "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/ff10fe8b91670044a6bb0cd85deb736a0ec8fb55
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-p4wh-cr8m-gm6c
+- https://www.vulncheck.com/advisories/openclaw-arbitrary-binary-execution-via-shell-environment-variable-trusted-prefix-fallback
+- https://github.com/advisories/GHSA-p4wh-cr8m-gm6c

--- a/data/vuln/openclaw/CVE-2026-27522.yaml
+++ b/data/vuln/openclaw/CVE-2026-27522.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27522
+  summary: OpenClaw 消息操作附件水合绕过本地媒体根边界
+  details: OpenClaw 2026.3.1 之前版本中，消息操作附件水合（hydration）流程可绕过本地媒体根路径边界，导致路径遍历。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.3.1 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/270ab03e379f9653e15f7033c9830399b66b7e51
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-fqcm-97m6-w7rm
+  - https://www.vulncheck.com/advisories/openclaw-arbitrary-file-read-via-sendattachment-and-setgroupicon-message-actions
+  - https://github.com/advisories/GHSA-fqcm-97m6-w7rm
+rule: version <= "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/270ab03e379f9653e15f7033c9830399b66b7e51
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-fqcm-97m6-w7rm
+- https://www.vulncheck.com/advisories/openclaw-arbitrary-file-read-via-sendattachment-and-setgroupicon-message-actions
+- https://github.com/advisories/GHSA-fqcm-97m6-w7rm

--- a/data/vuln/openclaw/CVE-2026-27523.yaml
+++ b/data/vuln/openclaw/CVE-2026-27523.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27523
+  summary: OpenClaw 沙箱绑定验证可绕过 allowed-root 和阻止路径检查
+  details: OpenClaw 2026.3.1 之前版本中，沙箱绑定验证逻辑存在缺陷，可绕过 allowed-root 和阻止路径检查。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.3.1 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/b5787e4abba0dcc6baf09051099f6773c1679ec1
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-m8v2-6wwh-r4gc
+  - https://www.vulncheck.com/advisories/openclaw-sandbox-bind-validation-bypass-via-symlink-parent-missing-leaf-paths
+  - https://github.com/advisories/GHSA-m8v2-6wwh-r4gc
+rule: version <= "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/b5787e4abba0dcc6baf09051099f6773c1679ec1
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-m8v2-6wwh-r4gc
+- https://www.vulncheck.com/advisories/openclaw-sandbox-bind-validation-bypass-via-symlink-parent-missing-leaf-paths
+- https://github.com/advisories/GHSA-m8v2-6wwh-r4gc

--- a/data/vuln/openclaw/CVE-2026-27524.yaml
+++ b/data/vuln/openclaw/CVE-2026-27524.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27524
+  summary: OpenClaw 运行时 /debug 覆盖路径接受原型保留键导致污染
+  details: OpenClaw 2026.3.1 之前版本中，运行时 /debug 覆盖路径接受原型保留键（如 __proto__），导致原型污染风险。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N
+  severity: LOW
+  security_advise: 升级到 OpenClaw 2026.3.1 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/fbb79d4013000552d6a2c23b9613d8b3cb92f6b6
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-62f6-mrcj-v8h5
+  - https://www.vulncheck.com/advisories/openclaw-prototype-pollution-via-debug-override-path
+  - https://github.com/advisories/GHSA-62f6-mrcj-v8h5
+rule: version < "2026.2.21"
+references:
+- https://github.com/openclaw/openclaw/commit/fbb79d4013000552d6a2c23b9613d8b3cb92f6b6
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-62f6-mrcj-v8h5
+- https://www.vulncheck.com/advisories/openclaw-prototype-pollution-via-debug-override-path
+- https://github.com/advisories/GHSA-62f6-mrcj-v8h5

--- a/data/vuln/openclaw/CVE-2026-27545.yaml
+++ b/data/vuln/openclaw/CVE-2026-27545.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27545
+  summary: OpenClaw Node system.run 审批通过父符号链接 cwd 重绑定绕过
+  details: OpenClaw 2026.3.1 之前版本在 Node 环境下，system.run 审批可通过父符号链接的 cwd 重绑定绕过。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: 升级到 OpenClaw 2026.3.1 或更高版本。
+  references:
+  - https://github.com/openclaw/openclaw/commit/4b4718c8dfce2e2c48404aa5088af7c013bed60b
+  - https://github.com/openclaw/openclaw/commit/4e690e09c746408b5e27617a20cb3fdc5190dbda
+  - https://github.com/openclaw/openclaw/commit/78a7ff2d50fb3bcef351571cb5a0f21430a340c1
+  - https://github.com/openclaw/openclaw/commit/d06632ba45a8482192792c55d5ff0b2e21abb0a7
+  - https://github.com/openclaw/openclaw/commit/d82c042b09727a6148f3ca651b254c4a677aff26
+rule: version <= "2026.2.25"
+references:
+- https://github.com/openclaw/openclaw/commit/4b4718c8dfce2e2c48404aa5088af7c013bed60b
+- https://github.com/openclaw/openclaw/commit/4e690e09c746408b5e27617a20cb3fdc5190dbda
+- https://github.com/openclaw/openclaw/commit/78a7ff2d50fb3bcef351571cb5a0f21430a340c1
+- https://github.com/openclaw/openclaw/commit/d06632ba45a8482192792c55d5ff0b2e21abb0a7
+- https://github.com/openclaw/openclaw/commit/d82c042b09727a6148f3ca651b254c4a677aff26

--- a/data/vuln/openclaw/CVE-2026-30741.yaml
+++ b/data/vuln/openclaw/CVE-2026-30741.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-30741
+  summary: OpenClaw Agent 平台 agent 任务执行中的请求侧提示词注入导致 RCE
+  details: >-
+    OpenClaw Agent Platform v2026.2.6 及更早版本在 agent 任务执行管道中存在远程代码执
+    行漏洞（CWE-94）。平台在处理用户提供的提示词内容时缺乏充分净化，未认证的远程攻击
+    者可通过请求侧提示词注入将恶意指令注入 agent 运行时，操纵 agent 在底层服务器上执行
+    任意代码。该漏洞无需认证即可触发，任何可达网络的攻击者均可利用。目前无公开 PoC，
+    利用成熟度为 LOW。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 将 OpenClaw Agent Platform 升级至 v2026.2.6 之后的版本。对 agent 任务执行管道中所有用户提供的内容实施输入验证和提示词净化控制。
+  references:
+  - https://github.com/Named1ess/CVE-2026-30741
+  - https://github.com/OpenClaw/OpenClaw
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30741
+rule: version <= "2026.2.6"
+references:
+- https://github.com/Named1ess/CVE-2026-30741
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30741

--- a/data/vuln/openclaw/CVE-2026-32038.yaml
+++ b/data/vuln/openclaw/CVE-2026-32038.yaml
@@ -1,0 +1,23 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32038
+  summary: OpenClaw 沙箱网络隔离绕过漏洞（docker.network=container:<id>）
+  details: >-
+    OpenClaw 2026.2.24 之前的版本存在沙箱网络隔离绕过漏洞（CWE-284：访问控制不当）。
+    受信任的操作员可通过将 docker.network 参数配置为 container:<id> 格式，加入目标容器的
+    网络命名空间，从而绕过网络加固控制措施。攻击者可借此访问原本隔离的目标容器内的服务。
+    任何具有沙箱参数配置权限的操作员均可利用此漏洞。
+  cvss: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  severity: CRITICAL
+  security_advise: >-
+    升级 OpenClaw 至 2026.2.24 或更高版本。限制操作员对 docker.network 参数的配置权限。
+    审计现有沙箱配置中是否存在 container:<id> 格式的网络引用，并移除未授权配置项。
+  references:
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-ww6v-v748-x7g9
+    - https://github.com/openclaw/openclaw/commit/14b6eea6e
+    - https://github.com/openclaw/openclaw/commit/5552f9073
+    - https://www.vulncheck.com/advisories/openclaw-sandbox-network-isolation-bypass-via-docker-network-container-parameter
+rule: ""
+references:
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-ww6v-v748-x7g9
+  - https://www.vulncheck.com/advisories/openclaw-sandbox-network-isolation-bypass-via-docker-network-container-parameter

--- a/data/vuln/openclaw/CVE-2026-32059.yaml
+++ b/data/vuln/openclaw/CVE-2026-32059.yaml
@@ -1,0 +1,18 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32059
+  summary: OpenClaw tools.exec.safeBins 白名单绕过漏洞（sort 命令 GNU 长选项缩写）
+  details: >-
+    OpenClaw 2026.2.22-2 版本的 tools.exec.safeBins 对 sort 命令的验证存在授权绕过漏洞。
+    验证逻辑未能正确验证 GNU 长选项缩写，允许攻击者通过白名单模式下的缩写选项绕过禁止标志检查。
+    远程攻击者可使用缩写长选项执行 sort 命令，从而跳过审批要求。
+    此漏洞影响 exec 工具的白名单执行机制，可能允许未经授权的命令以提升的权限执行。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 至 2026.2.23 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32059
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-3c6h-g97w-fg78
+rule: version >= "2026.2.22-2" && version < "2026.2.23"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32059

--- a/data/vuln/openclaw/CVE-2026-32060.yaml
+++ b/data/vuln/openclaw/CVE-2026-32060.yaml
@@ -1,0 +1,18 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32060
+  summary: OpenClaw apply_patch 路径穿越漏洞（任意文件写入/删除）
+  details: >-
+    OpenClaw 2026.2.14 之前版本的 apply_patch 功能中存在路径穿越漏洞。
+    当 apply_patch 启用且未配置文件系统沙箱隔离时，攻击者可通过精心构造的路径
+    （包含目录穿越序列如 ../../ 或绝对路径）逃逸工作区边界，修改或删除 OpenClaw
+    进程用户有权访问的任意文件。这可导致数据破坏、权限提升，或通过覆盖敏感系统文件
+    或应用配置实现远程代码执行。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 至 2026.2.14 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32060
+rule: version < "2026.2.14"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32060

--- a/data/vuln/openclaw/CVE-2026-32061.yaml
+++ b/data/vuln/openclaw/CVE-2026-32061.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32061
+  summary: OpenClaw $include 指令路径穿越漏洞（任意本地文件读取）
+  details: >-
+    OpenClaw 2026.2.17 之前版本的 $include 指令解析中存在路径穿越漏洞。
+    具有配置修改权限的攻击者可通过在 $include 指令中指定绝对路径、穿越序列或符号链接，
+    访问配置目录边界之外 OpenClaw 进程用户可读的敏感文件，包括 API 密钥和凭证等。
+    漏洞利用需要高权限（配置修改访问权限）且为本地攻击向量，但可导致敏感凭证信息的重大泄露。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: 升级 OpenClaw 至 2026.2.17 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32061
+rule: version < "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32061

--- a/data/vuln/openclaw/CVE-2026-32062.yaml
+++ b/data/vuln/openclaw/CVE-2026-32062.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32062
+  summary: OpenClaw 及 @openclaw/voice-call 未授权 WebSocket DoS 漏洞（流升级前置验证缺失）
+  details: >-
+    OpenClaw 2026.2.21-2 至 2026.2.22（不含）版本以及 @openclaw/voice-call 2026.2.21 至
+    2026.2.22（不含）版本在执行流验证之前接受媒体流 WebSocket 升级请求。这允许未经身份验证的
+    客户端建立连接而无需完成正确的验证流程，使远程攻击者可以持续保持空闲的预认证套接字，
+    消耗连接资源，降低合法流的服务可用性。此漏洞可被用于针对 OpenClaw 语音/媒体流服务发起拒绝服务攻击。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 及 @openclaw/voice-call 至 2026.2.22 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32062
+rule: version >= "2026.2.21-2" && version < "2026.2.22"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32062

--- a/data/vuln/openclaw/CVE-2026-32063.yaml
+++ b/data/vuln/openclaw/CVE-2026-32063.yaml
@@ -1,0 +1,18 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32063
+  summary: OpenClaw systemd 单元文件生成中的 CR/LF 注入命令执行漏洞
+  details: >-
+    OpenClaw 2026.2.19-2 至 2026.2.21（不含）版本的 systemd 单元文件生成过程中存在命令注入漏洞。
+    config.env.vars 中攻击者可控的环境变量值未对 CR/LF（回车/换行）字符进行验证，
+    允许通过换行注入突破生成单元文件中的 Environment= 行，进而注入任意 systemd 指令。
+    能够影响 config.env.vars 并触发服务安装或重启的攻击者，可以 OpenClaw 网关服务用户权限
+    执行任意命令。这是一个本地权限提升攻击向量，需要对配置具有写入权限。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 OpenClaw 至 2026.2.21 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32063
+rule: version >= "2026.2.19-2" && version < "2026.2.21"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32063

--- a/data/vuln/openclaw/CVE-2026-32302.yaml
+++ b/data/vuln/openclaw/CVE-2026-32302.yaml
@@ -1,0 +1,28 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32302
+  summary: OpenClaw 在 trusted-proxy 模式下 WebSocket 来源验证绕过，允许未授权建立特权 operator 会话
+  details: >-
+    OpenClaw 2026.3.11 之前版本在 gateway.auth.mode 配置为 "trusted-proxy" 时，
+    WebSocket 连接处理存在跨域请求验证绕过漏洞（CWE-346）。通过受信任反向代理携带
+    代理转发头抵达的浏览器发起的 WebSocket 连接，可绕过来源验证。来自恶意来源的不受信
+    任网页可通过受信任反向代理建立连接，继承代理认证身份，并在无需显式认证的情况下
+    建立特权 operator.admin 会话。这允许攻击者获得 OpenClaw 网关的完整管理权限，
+    包括访问用户对话、技能、记忆文件以及所有连接的消息渠道。该漏洞仅影响使用
+    trusted-proxy 认证模式配合反向代理部署的实例。发布时漏洞利用成熟度为 LOW，
+    官方公告引用单个提交修复。由于可特权提升至 operator.admin，严重性评级为 HIGH。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: >-
+    升级 OpenClaw 至 2026.3.11 或更高版本。临时缓解措施：将 gateway.auth.mode 从
+    "trusted-proxy" 改为 "token" 或 "password" 模式；或在反向代理层（如 Nginx）添加
+    显式 CORS/Origin 限制，拒绝来自不受信任来源的请求。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+    - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11
+rule: version < "2026.3.11"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+  - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11

--- a/data/vuln/openclaw/CVE-2026-4039.yaml
+++ b/data/vuln/openclaw/CVE-2026-4039.yaml
@@ -1,0 +1,16 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4039
+  summary: OpenClaw Skill Env Handler applySkillConfigenvOverrides 代码注入漏洞
+  details: >-
+    OpenClaw 2026.2.19-2 版本的 Skill Env Handler 组件中 applySkillConfigenvOverrides
+    函数存在代码注入漏洞。对环境变量覆盖值的操控可导致代码注入，允许远程攻击者执行任意代码。
+    该漏洞可远程利用，已在 2026.2.21-beta.1 版本中修复（补丁提交：8c9f35cdb51692b650ddf05b259ccdd75cc9a83c）。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: 升级 OpenClaw 至 2026.2.21 或更高版本（修复首次包含于 2026.2.21-beta.1）。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4039
+rule: version <= "2026.2.19-2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4039

--- a/data/vuln/openclaw/CVE-2026-4040.yaml
+++ b/data/vuln/openclaw/CVE-2026-4040.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4040
+  summary: OpenClaw tools.exec.safeBins 文件存在性信息泄露漏洞（差异侧信道）
+  details: >-
+    OpenClaw 2026.2.17 及之前版本的 tools.exec.safeBins 文件存在性处理组件中存在信息泄露漏洞。
+    通过差异侧信道（时序或响应差异）可导致信息暴露，允许本地攻击者推断系统上文件的存在情况。
+    这是一个本地攻击向量，需要低权限，机密性影响有限。
+    已在 2026.2.19-beta.1 版本中修复（补丁：bafdbb6f112409a65decd3d4e7350fbd637c7754）。
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: 升级 OpenClaw 至 2026.2.19 或更高版本。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4040
+rule: version <= "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4040

--- a/data/vuln/openwebui/CVE-2025-15603.yaml
+++ b/data/vuln/openwebui/CVE-2025-15603.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openwebui
+  cve: CVE-2025-15603
+  summary: Open WebUI JWT 密钥处理程序 WEBUI_SECRET_KEY 随机性不足漏洞
+  details: >-
+    Open WebUI 0.6.16 及之前版本的 JWT 密钥处理组件中存在弱随机性漏洞。
+    backend/start_windows.bat 文件中 WEBUI_SECRET_KEY 参数导致 JWT 密钥生成
+    使用了不足够随机的值。远程利用需要较高的攻击复杂度。成功利用此漏洞的攻击者
+    可能预测或恢复 JWT 密钥，从而允许伪造会话令牌并未经授权访问应用程序。
+    此漏洞已公开披露，可能正在被积极利用。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: 升级 Open WebUI 至 0.6.16 以上版本。确保 WEBUI_SECRET_KEY 设置为强随机生成值。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+    - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4
+rule: version <= "0.6.16"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+  - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4

--- a/data/vuln/ray/CVE-2026-32981.yaml
+++ b/data/vuln/ray/CVE-2026-32981.yaml
@@ -1,0 +1,23 @@
+info:
+  name: ray
+  cve: CVE-2026-32981
+  summary: Ray Dashboard 路径遍历漏洞，可导致本地文件泄露
+  details: >-
+    在 Ray 2.8.1 之前的版本中，Ray Dashboard（默认端口 8265）的静态文件处理机制对用户输入路径
+    缺乏充分的验证和净化，存在路径遍历漏洞（CWE-22）。未经认证的攻击者可通过构造包含 ../
+    等遍历序列的请求，访问预期静态目录之外的文件，造成本地文件泄露。Ray Dashboard 默认无需认证
+    即可公开访问，在对外暴露的部署环境中该漏洞危险性尤为突出。PacketStorm 上已有公开 PoC 引用。
+  cvss: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  severity: HIGH
+  security_advise: >-
+    升级 Ray 至 2.8.1 或更高版本。若无法立即升级，应通过防火墙规则或网络策略限制对 Ray Dashboard
+    （默认端口 8265）的访问，防止其暴露于不受信任的网络。不要将 Ray Dashboard 对公网开放。
+  references:
+    - https://github.com/ray-project/ray
+    - https://packetstorm.news/files/id/215801/
+    - https://www.vulncheck.com/advisories/ray-dashboard-path-traversal-leading-to-local-file-disclosure
+rule: ""
+references:
+  - https://github.com/ray-project/ray
+  - https://packetstorm.news/files/id/215801/
+  - https://www.vulncheck.com/advisories/ray-dashboard-path-traversal-leading-to-local-file-disclosure

--- a/data/vuln/vllm/CVE-2026-25960.yaml
+++ b/data/vuln/vllm/CVE-2026-25960.yaml
@@ -1,0 +1,28 @@
+info:
+  name: vllm
+  cve: CVE-2026-25960
+  summary: vLLM SSRF 防护绕过漏洞（URL 解析器不一致）
+  details: >-
+    vLLM 0.15.1 至 0.16.0 版本（0.17.0 已修复）在 `vllm/connections.py` 中的
+    `load_from_url_async` 方法存在服务端请求伪造（SSRF）防护绕过漏洞。原有 SSRF 修复
+    （GHSA-qh4c-xf7m-gxfc）使用 `urllib3.util.parse_url()` 进行 URL 验证，而实际 HTTP
+    请求通过 `aiohttp`（内部使用 `yarl` 库）发送。两个解析器对反斜杠字符处理方式不同：
+    urllib3 将 `\` URL 编码为 `%5C` 并视其为路径的一部分，而 yarl 则将 `\` 解释为用户信息
+    的一部分，将 `@` 作为用户信息/主机分隔符，导致实际请求发送至与验证不同的主机。
+    低权限认证攻击者可构造形如 `https://受信任主机\@evil.com/` 的 URL，绕过白名单验证，
+    强制服务器向任意内部或外部服务发起请求，实现完整 SSRF 攻击，包括访问云元数据接口
+    及内部服务。发布时未发现公开 PoC 或利用代码（利用成熟度：低）。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:L
+  severity: MEDIUM
+  security_advise: 升级 vLLM 至 0.17.0 或更高版本。修复方案详见
+    https://github.com/vllm-project/vllm/pull/34743。
+    临时缓解措施：限制 URL 白名单以阻止访问内网地址段，并使用统一的 URL 解析库进行验证。
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+    - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+    - https://github.com/vllm-project/vllm/pull/34743
+rule: version >= "0.15.1" && version < "0.17.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+  - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+  - https://github.com/vllm-project/vllm/pull/34743

--- a/data/vuln/weknora/CVE-2026-30860.yaml
+++ b/data/vuln/weknora/CVE-2026-30860.yaml
@@ -1,0 +1,24 @@
+info:
+  name: weknora
+  cve: CVE-2026-30860
+  summary: WeKnora AI 数据库查询接口 SQL 注入绕过导致未认证 PostgreSQL RCE
+  details: >-
+    WeKnora 是腾讯开源的基于大语言模型的文档深度理解与语义检索框架。0.2.12 版本之前，
+    数据库查询功能（internal/utils/inject.go）存在严重 RCE 漏洞。应用实现了基于
+    PostgreSQL AST 解析的 7 阶段 SQL 校验框架，但第 5 阶段 validateNode() 函数未处理
+    ArrayExpr 和 RowExpr 节点类型。攻击者可将危险 PostgreSQL 函数（如 lo_import、
+    lo_export）嵌套在数组或行表达式中，绕过全部校验阶段。通过将大对象操作与
+    pg_read_binary_file 及共享库加载（lo_import + CREATE FUNCTION）组合利用，仅持有
+    普通账号（开放注册，无需审核）的攻击者即可在数据库服务器上以数据库用户权限执行任意
+    代码。0.2.12 版本的修复为 validateNode() 函数新增了对 ArrayExpr 和 RowExpr
+    节点类型的递归校验。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 立即将 WeKnora 升级至 0.2.12 或更高版本。补丁在 internal/utils/inject.go 的 validateNode() 函数中新增了对 ArrayExpr 和 RowExpr 节点类型的处理，从根本上修复 SQL 注入绕过。
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30860
+rule: version < "0.2.12"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30860

--- a/data/vuln/weknora/CVE-2026-30861.yaml
+++ b/data/vuln/weknora/CVE-2026-30861.yaml
@@ -1,0 +1,25 @@
+info:
+  name: weknora
+  cve: CVE-2026-30861
+  summary: WeKnora MCP stdio 配置校验绕过导致未认证命令注入 RCE
+  details: >-
+    WeKnora 是腾讯开源的基于大语言模型的文档深度理解与语义检索框架。0.2.5 至 0.2.9
+    版本的 MCP stdio 配置校验中存在严重未认证远程代码执行漏洞。应用实现了命令白名单
+    （npx、uvx）和参数黑名单以防止注入，但黑名单未覆盖 npx node 的 -p 标志。攻击者
+    可注册免费账号（无需邮箱验证或审批），获取 API 凭据后传入如 ["node", "-p",
+    "require('fs').writeFileSync(...)"] 的参数，通过 Node.js -p（print/eval）标志
+    执行任意 JavaScript，完全绕过 DangerousArgPatterns 校验，以应用权限实现任意代码
+    执行。该漏洞在 0.2.6 至 0.2.9 版本中持续存在，于 0.2.10 版本静默修复，未公开
+    CVE 披露，可能导致运营者对受影响版本毫不知情。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: 立即将 WeKnora 升级至 0.2.10 或更高版本。如无法立即升级，应禁用开放式用户注册或限制 WeKnora 服务的网络访问，以防止漏洞被利用。
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+  - https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30861
+rule: version >= "0.2.5" && version < "0.2.10"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+- https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30861

--- a/data/vuln_en/anythingllm/CVE-2026-32617.yaml
+++ b/data/vuln_en/anythingllm/CVE-2026-32617.yaml
@@ -1,0 +1,28 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32617
+  summary: Mintplexlabs anythingllm AnythingLLM Permissable CORS policy
+  details: >-
+    AnythingLLM is an application that turns pieces of content into context that any LLM can use as references during chatting.
+    In 1.11.1 and earlier, On default installations where no password or API key has been configured, all HTTP endpoints and
+    the agent WebSocket lack authentication, and the server's CORS policy accepts any origin. AnythingLLM Desktop binds to
+    127.0.0.1 (loopback) by default. Modern browsers (Chrome, Edge, Firefox) implement Private Network Access (PNA). This
+    explicitly blocks public websites from making requests to local IP addresses. Exploitation is only viable from within
+    the same local network (LAN) due to browser-level blocking of public-to-private requests.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:L
+  severity: HIGH
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-24qj-pw4h-3jmm
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32617.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32617
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-24qj-pw4h-3jmm
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32617.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32617

--- a/data/vuln_en/anythingllm/CVE-2026-32626.yaml
+++ b/data/vuln_en/anythingllm/CVE-2026-32626.yaml
@@ -1,0 +1,25 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32626
+  summary: Mintplexlabs anythingllm AnythingLLM has a Streaming Phase XSS  to RCE via LLM Response Injection
+  details: AnythingLLM is an application that turns pieces of content into context that any LLM can use as references during
+    chatting. In 1.11.1 and earlier, AnythingLLM Desktop contains a Streaming Phase XSS vulnerability in the chat rendering
+    pipeline that escalates to Remote Code Execution on the host OS due to insecure Electron configuration. This works with
+    default settings and requires no user interaction beyond normal chat usage. The custom markdown-it image renderer in frontend/src/utils/chat/markdown.js
+    interpolates token.content directly into the alt attribute without HTML entity escaping. The PromptReply component renders
+    this output via dangerouslySetInnerHTML without DOMPurify sanitization — unlike HistoricalMessage which correctly applies
+    DOMPurify.sanitize().
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/9e2d144dc8be6fab29f560f5bcdaa9ef7dbb4214
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-rrmw-2j6x-4mf2
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32626.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32626
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/9e2d144dc8be6fab29f560f5bcdaa9ef7dbb4214
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-rrmw-2j6x-4mf2
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32626.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32626

--- a/data/vuln_en/anythingllm/CVE-2026-32628.yaml
+++ b/data/vuln_en/anythingllm/CVE-2026-32628.yaml
@@ -1,0 +1,30 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32628
+  summary: Mintplexlabs anythingllm AnythingLLM has SQL Injection in Built-in SQL Agent Plugin via Unsanitized table_name
+    Parameter
+  details: >-
+    AnythingLLM is an application that turns pieces of content into context that any LLM can use as references during chatting.
+    In 1.11.1 and earlier, a SQL injection vulnerability in the built-in SQL Agent plugin allows any user who can invoke the
+    agent to execute arbitrary SQL commands on connected databases. The getTableSchemaSql() method in all three database connectors
+    (MySQL, PostgreSQL, MSSQL) constructs SQL queries using direct string concatenation of the table_name parameter without
+    sanitization or parameterization.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/334ce052f063b53a4275518cbed3bab357695d7e
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-jwjx-mw2p-5wc7
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32628.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32628
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/334ce052f063b53a4275518cbed3bab357695d7e
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-jwjx-mw2p-5wc7
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32628.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32628

--- a/data/vuln_en/anythingllm/CVE-2026-32715.yaml
+++ b/data/vuln_en/anythingllm/CVE-2026-32715.yaml
@@ -1,0 +1,29 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32715
+  summary: Mintplexlabs anythingllm AnythingLLM Manager Privilege Bypass Allows Access to Admin-Only System Preferences
+  details: >-
+    AnythingLLM is an application that turns pieces of content into context that any LLM can use as references during chatting.
+    In 1.11.1 and earlier, The two generic system-preferences endpoints allow manager role access, while every other surface
+    that touches the same settings is restricted to admin only. Because of this inconsistency, a manager can call the generic
+    endpoints directly to read plaintext SQL database credentials and overwrite admin-only global settings such as the default
+    system prompt and the Community Hub API key.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N
+  severity: LOW
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/732eac6fa89f43288bbb65ecc6298ebcd96b7aeb
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-wfq3-65gm-3g2p
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32715.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32715
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/732eac6fa89f43288bbb65ecc6298ebcd96b7aeb
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-wfq3-65gm-3g2p
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32715.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32715

--- a/data/vuln_en/anythingllm/CVE-2026-32717.yaml
+++ b/data/vuln_en/anythingllm/CVE-2026-32717.yaml
@@ -1,0 +1,31 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32717
+  summary: 'Mintplexlabs anythingllm AnythingLLM access control bypass: suspended users can continue using Browser Extension
+    API keys'
+  details: >-
+    AnythingLLM is an application that turns pieces of content into context that any LLM can use as references during chatting.
+    In 1.11.1 and earlier, in multi-user mode, AnythingLLM blocks suspended users on the normal JWT-backed session path, but
+    it does not block them on the browser extension API key path. If a user already has a valid brx-... browser extension
+    API key, that key continues to work after suspension. As a result, a suspended user can still access browser extension
+    endpoints, read reachable workspace metadata, and continue upload or embed operations even though normal authenticated
+    requests are rejected.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:N
+  severity: LOW
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/a207449095158f28c7e16acf113356b336c87803
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-7754-8jcc-2rg3
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32717.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32717
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/a207449095158f28c7e16acf113356b336c87803
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-7754-8jcc-2rg3
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32717.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32717

--- a/data/vuln_en/anythingllm/CVE-2026-32719.yaml
+++ b/data/vuln_en/anythingllm/CVE-2026-32719.yaml
@@ -1,0 +1,29 @@
+info:
+  name: anythingllm
+  cve: CVE-2026-32719
+  summary: Mintplexlabs anythingllm AnythingLLM has a Zip Slip Path Traversal and Code Execution via Community Hub Plugin
+    Import
+  details: >-
+    AnythingLLM is an application that turns pieces of content into context that any LLM can use as references during chatting.
+    In 1.11.1 and earlier, The ImportedPlugin.importCommunityItemFromUrl() function in server/utils/agents/imported.js downloads
+    a ZIP file from a community hub URL and extracts it using AdmZip.extractAllTo() without validating file paths within the
+    archive. This enables a Zip Slip path traversal attack that can lead to arbitrary code execution.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:N/I:H/A:N
+  severity: MEDIUM
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/Mintplex-Labs/anything-llm/commit/6a492f038da195a5c9a239d5ca2e9f2151c25f8c
+  - https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-rh66-4w74-cf4m
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32719.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32719
+rule: version <= "1.11.1"
+references:
+- https://github.com/Mintplex-Labs/anything-llm/commit/6a492f038da195a5c9a239d5ca2e9f2151c25f8c
+- https://github.com/Mintplex-Labs/anything-llm/security/advisories/GHSA-rh66-4w74-cf4m
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/32xxx/CVE-2026-32719.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-32719

--- a/data/vuln_en/flowise/CVE-2026-30820.yaml
+++ b/data/vuln_en/flowise/CVE-2026-30820.yaml
@@ -1,0 +1,34 @@
+info:
+  name: flowise
+  cve: CVE-2026-30820
+  summary: Flowise Authorization Bypass via Spoofed x-request-from Header (Privilege Escalation)
+  details: >-
+    Flowise prior to version 3.0.13 contains an authorization bypass vulnerability
+    (CWE-863). The global middleware guarding /api/v1/** routes blindly trusts any
+    HTTP request that sets the header `x-request-from: internal`. An authenticated
+    low-privilege tenant can add this header to their browser cookie session and
+    bypass all API authorization checks, gaining access to internal administration
+    endpoints including API key management (/api/v1/apikey), credential stores
+    (/api/v1/credentials), custom function execution (/api/v1/node-custom-function),
+    and other privileged routes. This effectively enables privilege escalation and,
+    when combined with other vulnerabilities such as Custom Function RCE, may lead
+    to full system compromise. A public PoC is included in the official security
+    advisory (GHSA-wvhq-wp8g-c7vq). All self-hosted Flowise deployments prior to
+    3.0.13 that rely on the default middleware are affected. CVSS 4.0 score reflects
+    high confidentiality, integrity, and availability impact with network-accessible
+    attack vector and low privileges required.
+  cvss: CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade Flowise to version 3.0.13 or later. The patch removes the blind trust
+    of the `x-request-from: internal` header and enforces proper authorization
+    checks on all /api/v1/** routes regardless of request headers.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+    - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30820
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-wvhq-wp8g-c7vq
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13

--- a/data/vuln_en/flowise/CVE-2026-30823.yaml
+++ b/data/vuln_en/flowise/CVE-2026-30823.yaml
@@ -1,0 +1,31 @@
+info:
+  name: flowise
+  cve: CVE-2026-30823
+  summary: Flowise IDOR vulnerability leads to account takeover and SSO enterprise feature bypass
+  details: >-
+    Flowise is a drag-and-drop UI platform for building customized large
+    language model (LLM) workflows. Prior to version 3.0.13, an Insecure
+    Direct Object Reference (IDOR) vulnerability exists in the PUT
+    /api/v1/loginmethod endpoint. The server accepts an organizationId
+    parameter from the JSON request body without verifying whether the
+    authenticated user owns or has administrative rights over the target
+    organization. Any low-privileged authenticated user (including Free plan
+    users) can exploit this flaw to overwrite another organization's SSO
+    configuration, enable enterprise-only features (SSO/SAML) without a
+    valid license, and perform account takeover by redirecting the
+    authentication flow to attacker-controlled OAuth credentials. A complete
+    step-by-step PoC is available in the official security advisory.
+    Exploitation requires only a valid JWT token and knowledge of the target
+    organizationId.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: Upgrade Flowise to version 3.0.13 or later. The patch adds ownership validation on the PUT /api/v1/loginmethod endpoint to ensure users can only modify their own organization's SSO configuration.
+  references:
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+  - https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30823
+rule: version <= "3.0.12"
+references:
+- https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-cwc3-p92j-g7qm
+- https://github.com/FlowiseAI/Flowise/releases/tag/flowise%403.0.13
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30823

--- a/data/vuln_en/flowise/CVE-2026-31829.yaml
+++ b/data/vuln_en/flowise/CVE-2026-31829.yaml
@@ -1,0 +1,35 @@
+info:
+  name: flowise
+  cve: CVE-2026-31829
+  summary: Flowise HTTP Node Server-Side Request Forgery (SSRF) via Unrestricted User-Controlled URL
+  details: >-
+    Flowise versions prior to 3.0.13 expose an HTTP Node in AgentFlow and Chatflow
+    that performs server-side HTTP requests using user-controlled URLs without any
+    restrictions on target hosts. By default, private/internal IP ranges (RFC 1918),
+    localhost, and cloud metadata endpoints (e.g., AWS IMDSv1 at 169.254.169.254) are
+    not blocked. This enables Server-Side Request Forgery (SSRF), allowing any user
+    interacting with a publicly exposed chatflow to force the Flowise server to make
+    requests to internal network resources. The vulnerability is particularly severe
+    because Flowise instances are often deployed publicly without authentication
+    (FLOWISE_USERNAME/PASSWORD not set by default). The HTTP Node supports all standard
+    HTTP methods (GET, POST, PUT, PATCH, DELETE), enabling both read and write access
+    to internal services. Impact includes: retrieval of cloud provider IAM credentials
+    from metadata endpoints, access to internal admin panels (Jenkins, Kubernetes API),
+    port scanning of internal services, and potential lateral movement. A public proof
+    of concept demonstrating internal network access was included in the advisory.
+    Exploitation maturity is HIGH due to the straightforward nature of the attack and
+    the public PoC availability.
+  cvss: CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:L
+  severity: HIGH
+  security_advise: Upgrade Flowise to version 3.0.13 or later. The fix adds optional
+    security controls to the HTTP Node including the ability to block private IP ranges
+    and localhost, and an allowed-domains whitelist. Until upgraded, restrict network
+    access of Flowise instances and enable authentication by setting
+    FLOWISE_USERNAME and FLOWISE_PASSWORD environment variables.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+    - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7
+rule: version < "3.0.13"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31829
+  - https://github.com/FlowiseAI/Flowise/security/advisories/GHSA-fvcw-9w9r-pxc7

--- a/data/vuln_en/langflow/CVE-2026-33017.yaml
+++ b/data/vuln_en/langflow/CVE-2026-33017.yaml
@@ -1,0 +1,17 @@
+info:
+  name: langflow
+  cve: CVE-2026-33017
+  summary: Unauthenticated Remote Code Execution via Public Flow Build Endpoint
+  details: Langflow versions prior to a fix contain an unauthenticated remote code
+    execution vulnerability in the public flow build endpoint. An attacker can exploit
+    this vulnerability to execute arbitrary code on the server without authentication.
+    This is a critical vulnerability affecting AI workflow platforms.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade Langflow to version 1.8.2 or later. Restrict access to
+    the flow build endpoint. Implement authentication and authorization controls.
+  references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-vwmf-pq79-vjvx
+rule: version <= "1.8.1"
+references:
+- https://github.com/advisories/GHSA-vwmf-pq79-vjvx

--- a/data/vuln_en/langflow/CVE-2026-33053.yaml
+++ b/data/vuln_en/langflow/CVE-2026-33053.yaml
@@ -1,0 +1,81 @@
+info:
+  name: langflow
+  cve: CVE-2026-33053
+  summary: langflow Langflow is Missing Ownership Verification in API Key Deletion (IDOR)
+  details: >-
+    **Detection Method:** Kolega.dev Deep Code Scan
+
+
+    | Attribute | Value |
+
+    |---|---|
+
+    | Location | src/backend/base/langflow/api/v1/api_key.py:44-53 |
+
+    | Practical Exploitability | High |
+
+    | Developer Approver | faizan@kolega.ai |
+
+
+    ### Description
+
+    The delete_api_key_route() endpoint accepts an api_key_id path parameter and deletes it with only a generic authentication
+    check (get_current_active_user dependency). However, the delete_api_key() CRUD function does NOT verify that the API key
+    belongs to the current user before deletion.
+
+
+    ### Affected Code
+
+    ```
+
+    @router.delete("/{api_key_id}", dependencies=[Depends(auth_utils.get_current_active_user)])
+
+    async def delete_api_key_route(
+        api_key_id: UUID,
+        db: DbSession,
+    ):
+        try:
+            await delete_api_key(db, api_key_id)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        return {"detail": "API Key deleted"}
+    ```
+
+
+    ### Evidence
+
+    In crud.py lines 44-49, delete_api_key() retrieves the API key by ID and deletes it without checking if the key belongs
+    to the authenticated user. The endpoint also doesn't pass the current_user to the delete function for verification.
+
+
+    ### Impact
+
+    An authenticated attacker can enumerate and delete API keys belonging to other users by guessing or discovering their
+    API key IDs. This allows account takeover, denial of service, and disruption of other users' integrations.
+
+
+    ### Recommendation
+
+    Modify the delete_api_key endpoint and function: (1) Pass current_user to the delete function; (2) In delete_api_key(),
+    verify api_key.user_id == current_user.id before deletion; (3) Raise a 403 Forbidden error if the user doesn't own the
+    key. Example: if api_key.user_id != user_id: raise HTTPException(status_code=403, detail='Unauthorized')
+
+
+    ### Notes
+
+    Confirmed IDOR vulnerability. The delete_api_key_route endpoint at line 44-53 accepts an api_key_id and calls delete_api_key(db,
+    api_key_id) without passing the current_user. The CRUD function delete_api_key() at crud.py:44-...
+  cvss: null
+  severity: HIGH
+  security_advise: Upgrade to langflow 1.7.2 or later.
+  references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-rf6x-r45m-xv3w
+  - https://github.com/langflow-ai/langflow/commit/fdc1b3b1448ff3317d73d3e769a6c4a1717f74d7
+  - https://github.com/langflow-ai/langflow/releases/tag/1.7.2
+  - https://github.com/advisories/GHSA-rf6x-r45m-xv3w
+rule: version < "1.7.2"
+references:
+- https://github.com/langflow-ai/langflow/security/advisories/GHSA-rf6x-r45m-xv3w
+- https://github.com/langflow-ai/langflow/commit/fdc1b3b1448ff3317d73d3e769a6c4a1717f74d7
+- https://github.com/langflow-ai/langflow/releases/tag/1.7.2
+- https://github.com/advisories/GHSA-rf6x-r45m-xv3w

--- a/data/vuln_en/langflow/CVE-2026-33309.yaml
+++ b/data/vuln_en/langflow/CVE-2026-33309.yaml
@@ -1,0 +1,27 @@
+info:
+  name: langflow
+  cve: CVE-2026-33309
+  summary: Langflow has an Arbitrary File Write (RCE) via v2 API (Defense-in-Depth Bypass)
+  details: >-
+    While reviewing the patch for CVE-2025-68478 (External Control of File Name in v1.7.1),
+    a root architectural issue in LocalStorageService was found to remain unresolved. The
+    POST /api/v2/files/ endpoint is vulnerable to Arbitrary File Write: the multipart upload
+    filename is extracted verbatim from the Content-Disposition header and passed to
+    LocalStorageService without canonical path containment checks (missing
+    resolve().is_relative_to(base_dir)). An authenticated attacker can write files anywhere
+    on the host filesystem, leading to Remote Code Execution. A public PoC exists confirming
+    exploitation against langflow v1.7.3. Patched in v1.9.0.
+  cvss: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade Langflow to version 1.9.0 or later. As a mitigation, restrict access to the
+    POST /api/v2/files/ endpoint and ensure Langflow is not exposed to untrusted users.
+    Apply input sanitization for multipart filenames: strip directory traversal characters
+    and add containment checks in LocalStorageService.save_file.
+  references:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-g2j9-7rj2-gm6c
+    - https://github.com/advisories/GHSA-g2j9-7rj2-gm6c
+rule: version >= "1.2.0" && version <= "1.8.1"
+references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-g2j9-7rj2-gm6c
+  - https://github.com/advisories/GHSA-g2j9-7rj2-gm6c

--- a/data/vuln_en/librechat/CVE-2025-41258.yaml
+++ b/data/vuln_en/librechat/CVE-2025-41258.yaml
@@ -1,0 +1,17 @@
+info:
+  name: librechat
+  cve: CVE-2025-41258
+  summary: LibreChat v0.8.1-rc2 JWT secret reuse vulnerability
+  details: >-
+    LibreChat version 0.8.1-rc2 uses the same JWT secret for the user session mechanism and RAG API which compromises the 
+    service-level authentication of the RAG API.
+  cvss: CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade to the latest patched version of LibreChat.
+  references:
+    - https://github.com/danny-avila/LibreChat
+    - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
+rule: ""
+references:
+  - https://github.com/danny-avila/LibreChat
+  - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass

--- a/data/vuln_en/librechat/CVE-2026-31944.yaml
+++ b/data/vuln_en/librechat/CVE-2026-31944.yaml
@@ -1,0 +1,32 @@
+info:
+  name: librechat
+  cve: CVE-2026-31944
+  summary: LibreChat MCP OAuth callback session binding failure enables OAuth token theft and account takeover
+  details: >-
+    LibreChat versions 0.8.2 through 0.8.2-rc3 contain a critical authentication
+    flaw (CWE-306) in the MCP (Model Context Protocol) OAuth callback endpoint.
+    The callback accepts the redirect from the identity provider and stores OAuth
+    tokens for the session that initiated the flow, without verifying that the
+    browser completing the redirect URL is logged in as the same user who started
+    the flow. An attacker can craft an authorization URL and send it to a victim;
+    when the victim completes the OAuth flow, the victim's OAuth tokens are stored
+    on the attacker's LibreChat account. This enables account takeover of the
+    victim's MCP-linked services (e.g., Atlassian, Outlook, GitHub). The attack
+    requires the attacker to have an authenticated LibreChat account and the
+    victim to click the crafted link. Exploitation maturity is LOW at publication,
+    with no public PoC reported. Severity is HIGH due to potential account takeover
+    impact on MCP-connected third-party services.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: >-
+    Upgrade LibreChat to version 0.8.3-rc1 or later, which fixes the OAuth
+    callback session binding validation. As a temporary mitigation, disable MCP
+    OAuth integrations until patched. Users should revoke OAuth tokens for
+    MCP-linked services if unauthorized access is suspected.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g
+rule: version == "0.8.2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31944
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-vf7j-7mrx-hp7g

--- a/data/vuln_en/librechat/CVE-2026-31949.yaml
+++ b/data/vuln_en/librechat/CVE-2026-31949.yaml
@@ -1,0 +1,30 @@
+info:
+  name: librechat
+  cve: CVE-2026-31949
+  summary: LibreChat DoS via unhandled TypeError in DELETE /api/convos endpoint crashes Node.js server
+  details: >-
+    LibreChat versions prior to 0.8.3-rc1 contain a Denial of Service (DoS)
+    vulnerability (CWE-248) in the DELETE /api/convos endpoint. The route handler
+    attempts to destructure req.body.arg without first validating that req.body
+    exists or is non-null. When an authenticated attacker sends a malformed DELETE
+    request (e.g., with an empty or absent body), the server throws an unhandled
+    TypeError that bypasses Express.js error handling middleware and triggers
+    process.exit(1), crashing the entire Node.js server process. This effectively
+    causes a complete service outage for all users until the server is restarted.
+    The vulnerability requires an authenticated attacker but has no rate limiting
+    protection on this endpoint. Exploitation maturity is LOW at publication with
+    no public PoC reported.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H
+  severity: MEDIUM
+  security_advise: >-
+    Upgrade LibreChat to version 0.8.3-rc1 or later, which adds proper input
+    validation before destructuring req.body.arg. As a temporary mitigation,
+    restrict API access to trusted authenticated users only and monitor for
+    unusual DELETE /api/convos request patterns.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+    - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p
+rule: version < "0.8.3-rc1"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-31949
+  - https://github.com/danny-avila/LibreChat/security/advisories/GHSA-5m32-chq6-232p

--- a/data/vuln_en/librechat/CVE-2026-33265.yaml
+++ b/data/vuln_en/librechat/CVE-2026-33265.yaml
@@ -1,0 +1,16 @@
+info:
+  name: librechat
+  cve: CVE-2026-33265
+  summary: LibreChat v0.8.1-rc2 JWT token exposure
+  details: >-
+    In LibreChat 0.8.1-rc2, a logged-in user obtains a JWT for both the LibreChat API and the RAG API.
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to the latest patched version of LibreChat.
+  references:
+    - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
+    - https://www.openwall.com/lists/oss-security/2026/03/18/3
+rule: ""
+references:
+  - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
+  - https://www.openwall.com/lists/oss-security/2026/03/18/3

--- a/data/vuln_en/librechat/CVE-2026-4276.yaml
+++ b/data/vuln_en/librechat/CVE-2026-4276.yaml
@@ -1,0 +1,16 @@
+info:
+  name: librechat
+  cve: CVE-2026-4276
+  summary: LibreChat RAG API v0.7.0 log injection vulnerability
+  details: >-
+    LibreChat RAG API, version 0.7.0, contains a log-injection vulnerability that allows attackers to forge log entries.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N
+  severity: HIGH
+  security_advise: Upgrade to a patched version of LibreChat.
+  references:
+    - https://kb.cert.org/vuls/id/624941
+    - https://www.kb.cert.org/vuls/id/624941
+rule: ""
+references:
+  - https://kb.cert.org/vuls/id/624941
+  - https://www.kb.cert.org/vuls/id/624941

--- a/data/vuln_en/llama-cpp/CVE-2026-27940.yaml
+++ b/data/vuln_en/llama-cpp/CVE-2026-27940.yaml
@@ -1,0 +1,29 @@
+info:
+  name: llama-cpp
+  cve: CVE-2026-27940
+  summary: llama.cpp integer overflow in mem_size calculation leads to heap buffer overflow and arbitrary code execution via malicious GGUF file
+  details: >-
+    llama.cpp is a C/C++ inference engine for LLM models. Prior to build b8146,
+    gguf_init_from_file_impl() in gguf.cpp contains an integer overflow
+    vulnerability in the mem_size calculation. While CVE-2025-53630 added an
+    overflow check on per-addition accumulation of ctx->size, the final mem_size
+    computation at (n_tensors+1)*ggml_tensor_overhead() + ctx->size was not
+    guarded. When ctx->size is near SIZE_MAX (achievable via two large I8 tensors
+    whose per-addition sizes pass the CVE-2025-53630 check), the final addition
+    wraps around to a small value, resulting in an undersized heap allocation.
+    The subsequent fread() writes 528+ bytes of attacker-controlled data past the
+    buffer boundary. By tuning the allocation size to fall within glibc tcache
+    range, this escalates to full arbitrary code execution via system(/bin/sh).
+    Attack vector is local (AV:L); exploitation requires a user to load a
+    malicious GGUF model file. This is a bypass of the CVE-2025-53630 fix in
+    the same function. No public PoC; exploit maturity is LOW.
+  cvss: CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade llama.cpp to build b8146 or later. The fix adds an overflow guard to the mem_size calculation in gguf_init_from_file_impl() to prevent integer wrap-around when ctx->size is near SIZE_MAX. Avoid loading GGUF model files from untrusted sources.
+  references:
+  - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-27940
+rule: version < "b8146"
+references:
+- https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-3p4r-fq3f-q74v
+- https://nvd.nist.gov/vuln/detail/CVE-2026-27940

--- a/data/vuln_en/mlflow/CVE-2025-14287.yaml
+++ b/data/vuln_en/mlflow/CVE-2025-14287.yaml
@@ -1,0 +1,31 @@
+info:
+  name: mlflow
+  cve: CVE-2025-14287
+  summary: mlflow MLflow has a command injection in mlflow/sagemaker/__init__.py
+  details: >-
+    A command injection vulnerability exists in mlflow/mlflow versions before v3.7.0, specifically in the `mlflow/sagemaker/__init__.py`
+    file at lines 161-167. The vulnerability arises from the direct interpolation of user-supplied container image names into
+    shell commands without proper sanitization, which are then executed using `os.system()`. This allows attackers to execute
+    arbitrary commands by supplying malicious input through the `--container` parameter of the CLI. The issue affects environments
+    where MLflow is used, including development setups, CI/CD pipelines, and cloud deployments.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: ''
+  severity: HIGH
+  security_advise: Upgrade to mlflow 3.8.0rc0 or later.
+  references:
+  - https://huntr.com/bounties/229cd526-41aa-4819-b6f0-e2d0371c89e3
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-14287
+  - https://github.com/mlflow/mlflow/pull/19277
+  - https://github.com/mlflow/mlflow/commit/8b8792a7034fb33a14b0b31cabcaa9b912d3485f
+  - https://github.com/mlflow/mlflow/releases/tag/v3.8.0rc0
+rule: version < "3.8.0rc0"
+references:
+- https://huntr.com/bounties/229cd526-41aa-4819-b6f0-e2d0371c89e3
+- https://nvd.nist.gov/vuln/detail/CVE-2025-14287
+- https://github.com/mlflow/mlflow/pull/19277
+- https://github.com/mlflow/mlflow/commit/8b8792a7034fb33a14b0b31cabcaa9b912d3485f
+- https://github.com/mlflow/mlflow/releases/tag/v3.8.0rc0

--- a/data/vuln_en/mlflow/CVE-2025-15031.yaml
+++ b/data/vuln_en/mlflow/CVE-2025-15031.yaml
@@ -1,0 +1,18 @@
+info:
+  name: mlflow
+  cve: CVE-2025-15031
+  summary: MLflow pyfunc tar.gz extraction path traversal vulnerability
+  details: >-
+    A vulnerability in MLflow's pyfunc extraction process allows for arbitrary file writes due to improper handling of tar archive entries. 
+    Specifically, the use of `tarfile.extractall` without path validation enables crafted tar.gz files containing `..` or absolute paths 
+    to escape the intended extraction directory. This issue affects the latest version of MLflow and poses a high/critical risk in scenarios 
+    involving multi-tenant environments or ingestion of untrusted artifacts, as it can lead to arbitrary file overwrites and potential 
+    remote code execution.
+  cvss: ""
+  severity: HIGH
+  security_advise: Upgrade to the latest patched version of MLflow and avoid ingesting untrusted tar.gz artifacts.
+  references:
+    - https://huntr.com/bounties/09856f77-f968-446f-a930-657d126efe4e
+rule: ""
+references:
+  - https://huntr.com/bounties/09856f77-f968-446f-a930-657d126efe4e

--- a/data/vuln_en/openclaw/CVE-2026-22168.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22168.yaml
@@ -1,0 +1,28 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22168
+  summary: openclaw OpenClaw has Windows system.run approval mismatch on cmd.exe /c trailing arguments
+  details: >-
+    OpenClaw versions prior to 2026.2.21 contain an approval-integrity mismatch vulnerability in system.run that allows authenticated
+    operators to execute arbitrary trailing arguments after cmd.exe /c while approval text reflects only a benign command.
+    Attackers can smuggle malicious arguments through cmd.exe /c to achieve local command execution on trusted Windows nodes
+    with mismatched audit logs.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.21 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/6007941f04df1edcca679dd6c95949744fdbd4df
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-5v6x-rfc3-7qfr
+  - https://www.vulncheck.com/advisories/openclaw-command-injection-via-cmd-exe-c-trailing-arguments-in-system-run
+  - https://github.com/advisories/GHSA-5v6x-rfc3-7qfr
+rule: version < "2026.2.21"
+references:
+- https://github.com/openclaw/openclaw/commit/6007941f04df1edcca679dd6c95949744fdbd4df
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-5v6x-rfc3-7qfr
+- https://www.vulncheck.com/advisories/openclaw-command-injection-via-cmd-exe-c-trailing-arguments-in-system-run
+- https://github.com/advisories/GHSA-5v6x-rfc3-7qfr

--- a/data/vuln_en/openclaw/CVE-2026-22169.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22169.yaml
@@ -1,0 +1,28 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22169
+  summary: openclaw OpenClaw's non-default safeBins sort configuration can bypass intended allowlist approval constraints
+  details: >-
+    OpenClaw versions prior to 2026.2.22 contain an allowlist bypass vulnerability in the safeBins configuration that allows
+    attackers to invoke external helpers through the compress-program option. When sort is explicitly added to tools.exec.safeBins,
+    remote attackers can bypass intended safe-bin approval constraints by leveraging the compress-program parameter to execute
+    unauthorized external programs.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.22 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/57fbbaebca4d34d17549accf6092ae26eb7b605c
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-vmqr-rc7x-3446
+  - https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-sort-configuration-in-safebins
+  - https://github.com/advisories/GHSA-vmqr-rc7x-3446
+rule: version < "2026.2.22"
+references:
+- https://github.com/openclaw/openclaw/commit/57fbbaebca4d34d17549accf6092ae26eb7b605c
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-vmqr-rc7x-3446
+- https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-sort-configuration-in-safebins
+- https://github.com/advisories/GHSA-vmqr-rc7x-3446

--- a/data/vuln_en/openclaw/CVE-2026-22170.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22170.yaml
@@ -1,0 +1,30 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22170
+  summary: 'openclaw OpenClaw: BlueBubbles (optional plugin) pairing/allowlist mismatch when allowFrom is empty'
+  details: >-
+    OpenClaw versions prior to 2026.2.22 with the optional BlueBubbles plugin contain an access control bypass vulnerability
+    where empty allowFrom configuration causes dmPolicy pairing and allowlist restrictions to be ineffective. Remote attackers
+    can send direct messages to BlueBubbles accounts by exploiting the misconfigured allowlist validation logic to bypass
+    intended sender authorization checks.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.22 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/2ba6de7eaad812e5e8603018e14e54e96bdd57dd
+  - https://github.com/openclaw/openclaw/commit/4540790cb62412676f7b61cfc6e47443f84a251e
+  - https://github.com/openclaw/openclaw/commit/51c0893673de8e5cea64e64351dbfa4680ba0dec
+  - https://github.com/openclaw/openclaw/commit/9632b9bcf032c5f2280c3103961fde912ab1f920
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-jwf4-8wf4-jf2m
+rule: version < "2026.2.22"
+references:
+- https://github.com/openclaw/openclaw/commit/2ba6de7eaad812e5e8603018e14e54e96bdd57dd
+- https://github.com/openclaw/openclaw/commit/4540790cb62412676f7b61cfc6e47443f84a251e
+- https://github.com/openclaw/openclaw/commit/51c0893673de8e5cea64e64351dbfa4680ba0dec
+- https://github.com/openclaw/openclaw/commit/9632b9bcf032c5f2280c3103961fde912ab1f920
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-jwf4-8wf4-jf2m

--- a/data/vuln_en/openclaw/CVE-2026-22171.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22171.yaml
@@ -1,0 +1,24 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22171
+  summary: openclaw OpenClaw vulnerable to path traversal in Feishu media temp-file naming allows writes outside os.tmpdir()
+  details: OpenClaw versions prior to 2026.2.19 contain a path traversal vulnerability in the Feishu media download flow where
+    untrusted media keys are interpolated directly into temporary file paths in extensions/feishu/src/media.ts. An attacker
+    who can control Feishu media key values returned to the client can use traversal segments to escape os.tmpdir() and write
+    arbitrary files within the OpenClaw process permissions.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: Upgrade to openclaw 2026.2.19 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/c821099157a9767d4df208c6b12f214946507871
+  - https://github.com/openclaw/openclaw/commit/cdb00fe2428000e7a08f9b7848784a0049176705
+  - https://github.com/openclaw/openclaw/commit/ec232a9e2dff60f0e3d7e827a7c868db5254473f
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-vj3g-5px3-gr46
+  - https://www.vulncheck.com/advisories/openclaw-path-traversal-in-feishu-media-temporary-file-naming
+rule: version < "2026.2.19"
+references:
+- https://github.com/openclaw/openclaw/commit/c821099157a9767d4df208c6b12f214946507871
+- https://github.com/openclaw/openclaw/commit/cdb00fe2428000e7a08f9b7848784a0049176705
+- https://github.com/openclaw/openclaw/commit/ec232a9e2dff60f0e3d7e827a7c868db5254473f
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-vj3g-5px3-gr46
+- https://www.vulncheck.com/advisories/openclaw-path-traversal-in-feishu-media-temporary-file-naming

--- a/data/vuln_en/openclaw/CVE-2026-22174.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22174.yaml
@@ -1,0 +1,27 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22174
+  summary: openclaw OpenClaw Loopback CDP probe can leak Gateway token to local listener
+  details: >-
+    OpenClaw versions prior to 2026.2.22 inject the x-OpenClaw-relay-token header into Chrome CDP probe traffic on loopback
+    interfaces, allowing local processes to capture the Gateway authentication token. An attacker controlling a loopback port
+    can intercept CDP reachability probes to the /json/version endpoint and reuse the leaked token as Gateway bearer authentication.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:L/A:N
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.22 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/afa22acc4a09fdf32be8a167ae216bee85c30dad
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-v3j7-34xh-6g3w
+  - https://www.vulncheck.com/advisories/openclaw-gateway-token-disclosure-via-chrome-cdp-probe
+  - https://github.com/advisories/GHSA-v3j7-34xh-6g3w
+rule: version <= "2026.2.21-2"
+references:
+- https://github.com/openclaw/openclaw/commit/afa22acc4a09fdf32be8a167ae216bee85c30dad
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-v3j7-34xh-6g3w
+- https://www.vulncheck.com/advisories/openclaw-gateway-token-disclosure-via-chrome-cdp-probe
+- https://github.com/advisories/GHSA-v3j7-34xh-6g3w

--- a/data/vuln_en/openclaw/CVE-2026-22175.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22175.yaml
@@ -1,0 +1,23 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22175
+  summary: openclaw OpenClaw's exec allow-always can be bypassed via unrecognized multiplexer shell wrappers (busybox/toybox
+    sh -c)
+  details: OpenClaw versions prior to 2026.2.23 contain an exec approval bypass vulnerability in allowlist mode where allow-always
+    grants could be circumvented through unrecognized multiplexer shell wrappers like busybox and toybox sh -c commands. Attackers
+    can exploit this by invoking arbitrary payloads under the same multiplexer wrapper to satisfy stored allowlist rules,
+    bypassing intended execution restrictions.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: Upgrade to openclaw 2026.2.23 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/a67689a7e3ad494b6637c76235a664322d526f9e
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-gwqp-86q6-w47g
+  - https://www.vulncheck.com/advisories/openclaw-exec-approval-bypass-via-unrecognized-multiplexer-shell-wrappers
+  - https://github.com/advisories/GHSA-gwqp-86q6-w47g
+rule: version < "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/a67689a7e3ad494b6637c76235a664322d526f9e
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-gwqp-86q6-w47g
+- https://www.vulncheck.com/advisories/openclaw-exec-approval-bypass-via-unrecognized-multiplexer-shell-wrappers
+- https://github.com/advisories/GHSA-gwqp-86q6-w47g

--- a/data/vuln_en/openclaw/CVE-2026-22177.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22177.yaml
@@ -1,0 +1,27 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22177
+  summary: openclaw OpenClaw's config env vars allowed startup env injection into service runtime
+  details: >-
+    OpenClaw versions prior to 2026.2.21 fail to filter dangerous process-control environment variables from config env.vars,
+    allowing startup-time code execution. Attackers can inject variables like NODE_OPTIONS or LD_* through configuration to
+    execute arbitrary code in the OpenClaw gateway service runtime context.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.21 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/2cdbadee1f8fcaa93302d7debbfc529e19868ea4
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-8fmp-37rc-p5g7
+  - https://www.vulncheck.com/advisories/openclaw-environment-variable-injection-via-config-env-vars
+  - https://github.com/advisories/GHSA-8fmp-37rc-p5g7
+rule: version < "2026.2.21"
+references:
+- https://github.com/openclaw/openclaw/commit/2cdbadee1f8fcaa93302d7debbfc529e19868ea4
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-8fmp-37rc-p5g7
+- https://www.vulncheck.com/advisories/openclaw-environment-variable-injection-via-config-env-vars
+- https://github.com/advisories/GHSA-8fmp-37rc-p5g7

--- a/data/vuln_en/openclaw/CVE-2026-22178.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22178.yaml
@@ -1,0 +1,30 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22178
+  summary: openclaw OpenClaw has ReDoS and regex injection via unescaped Feishu mention metadata in RegExp construction
+  details: >-
+    OpenClaw versions prior to 2026.2.19 construct RegExp objects directly from unescaped Feishu mention metadata in the stripBotMention
+    function, allowing regex injection and denial of service. Attackers can craft nested-quantifier patterns or metacharacters
+    in mention metadata to trigger catastrophic backtracking, block message processing, or remove unintended content before
+    model processing.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.19 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/74268489137510b6f6349919d1e197b17290d92c
+  - https://github.com/openclaw/openclaw/commit/7e67ab75cc2f0e93569d12fecd1411c2961fcc8c
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-c6hr-w26q-c636
+  - https://www.vulncheck.com/advisories/openclaw-redos-and-regex-injection-via-unescaped-feishu-mention-metadata
+  - https://github.com/advisories/GHSA-c6hr-w26q-c636
+rule: version < "2026.2.19"
+references:
+- https://github.com/openclaw/openclaw/commit/74268489137510b6f6349919d1e197b17290d92c
+- https://github.com/openclaw/openclaw/commit/7e67ab75cc2f0e93569d12fecd1411c2961fcc8c
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-c6hr-w26q-c636
+- https://www.vulncheck.com/advisories/openclaw-redos-and-regex-injection-via-unescaped-feishu-mention-metadata
+- https://github.com/advisories/GHSA-c6hr-w26q-c636

--- a/data/vuln_en/openclaw/CVE-2026-22179.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22179.yaml
@@ -1,0 +1,28 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22179
+  summary: openclaw OpenClaw has macOS `system.run` allowlist bypass via quoted command substitution
+  details: >-
+    OpenClaw versions prior to 2026.2.22 in macOS node-host system.run contain an allowlist bypass vulnerability that allows
+    remote attackers to execute non-allowlisted commands by exploiting improper parsing of command substitution tokens. Attackers
+    can craft shell payloads with command substitution syntax within double-quoted text to bypass security restrictions and
+    execute arbitrary commands on the system.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.22 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/90a378ca3a9ecbf1634cd247f17a35f4612c6ca6
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-9p38-94jf-hgjj
+  - https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-command-substitution-in-system-run
+  - https://github.com/advisories/GHSA-9p38-94jf-hgjj
+rule: version < "2026.2.22"
+references:
+- https://github.com/openclaw/openclaw/commit/90a378ca3a9ecbf1634cd247f17a35f4612c6ca6
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-9p38-94jf-hgjj
+- https://www.vulncheck.com/advisories/openclaw-allowlist-bypass-via-command-substitution-in-system-run
+- https://github.com/advisories/GHSA-9p38-94jf-hgjj

--- a/data/vuln_en/openclaw/CVE-2026-22180.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22180.yaml
@@ -1,0 +1,27 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22180
+  summary: 'openclaw OpenClaw: Unified root-bound write hardening for browser output and related path-boundary flows'
+  details: >-
+    OpenClaw versions prior to 2026.3.2 contain a path-confinement bypass vulnerability in browser output handling that allows
+    writes outside intended root directories. Attackers can exploit insufficient canonical path-boundary validation in file
+    write operations to escape root-bound restrictions and write files to arbitrary locations.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.3.2 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/104d32bb64cdf19d5e77f70553a511a2ae90ad1c
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-3pxq-f3cp-jmxp
+  - https://www.vulncheck.com/advisories/openclaw-path-confinement-bypass-in-browser-output-and-file-write-operations
+  - https://github.com/advisories/GHSA-3pxq-f3cp-jmxp
+rule: version <= "2026.3.1"
+references:
+- https://github.com/openclaw/openclaw/commit/104d32bb64cdf19d5e77f70553a511a2ae90ad1c
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-3pxq-f3cp-jmxp
+- https://www.vulncheck.com/advisories/openclaw-path-confinement-bypass-in-browser-output-and-file-write-operations
+- https://github.com/advisories/GHSA-3pxq-f3cp-jmxp

--- a/data/vuln_en/openclaw/CVE-2026-22181.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22181.yaml
@@ -1,0 +1,28 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22181
+  summary: openclaw OpenClaw's web tools strict URL guard could lose DNS pinning when env proxy is configured
+  details: >-
+    OpenClaw versions prior to 2026.3.2 contain a DNS pinning bypass vulnerability in strict URL fetch paths that allows attackers
+    to circumvent SSRF guards when environment proxy variables are configured. When HTTP_PROXY, HTTPS_PROXY, or ALL_PROXY
+    environment variables are present, attacker-influenced URLs can be routed through proxy behavior instead of pinned-destination
+    routing, enabling access to internal targets reachable from the proxy environment.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.3.2 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/345abf0b2e0f43b0f229e96f252ebf56f1e5549e
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-8mvx-p2r9-r375
+  - https://www.vulncheck.com/advisories/openclaw-dns-pinning-bypass-via-environment-proxy-configuration-in-web-fetch
+  - https://github.com/advisories/GHSA-8mvx-p2r9-r375
+rule: version <= "2026.3.1"
+references:
+- https://github.com/openclaw/openclaw/commit/345abf0b2e0f43b0f229e96f252ebf56f1e5549e
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-8mvx-p2r9-r375
+- https://www.vulncheck.com/advisories/openclaw-dns-pinning-bypass-via-environment-proxy-configuration-in-web-fetch
+- https://github.com/advisories/GHSA-8mvx-p2r9-r375

--- a/data/vuln_en/openclaw/CVE-2026-22217.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22217.yaml
@@ -1,0 +1,28 @@
+info:
+  name: openclaw
+  cve: CVE-2026-22217
+  summary: 'openclaw OpenClaw: shell-env trusted-prefix fallback allowed attacker-controlled binary execution via $SHELL'
+  details: >-
+    OpenClaw version 2026.2.22 prior to 2026.2.23 contain an arbitrary code execution vulnerability in shell-env that allows
+    attackers to execute attacker-controlled binaries by exploiting trusted-prefix fallback logic for the $SHELL variable.
+    An attacker can influence the $SHELL environment variable on systems with writable trusted-prefix directories such as
+    /opt/homebrew/bin to execute arbitrary binaries in the OpenClaw process context.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.23 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/ff10fe8b91670044a6bb0cd85deb736a0ec8fb55
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-p4wh-cr8m-gm6c
+  - https://www.vulncheck.com/advisories/openclaw-arbitrary-binary-execution-via-shell-environment-variable-trusted-prefix-fallback
+  - https://github.com/advisories/GHSA-p4wh-cr8m-gm6c
+rule: version >= "2026.2.22" && version < "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/ff10fe8b91670044a6bb0cd85deb736a0ec8fb55
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-p4wh-cr8m-gm6c
+- https://www.vulncheck.com/advisories/openclaw-arbitrary-binary-execution-via-shell-environment-variable-trusted-prefix-fallback
+- https://github.com/advisories/GHSA-p4wh-cr8m-gm6c

--- a/data/vuln_en/openclaw/CVE-2026-27522.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27522.yaml
@@ -1,0 +1,27 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27522
+  summary: 'openclaw OpenClaw: Message action attachment hydration bypasses local media root checks when sandboxRoot is unset'
+  details: >-
+    OpenClaw versions prior to 2026.2.24 contain a local media root bypass vulnerability in sendAttachment and setGroupIcon
+    message actions when sandboxRoot is unset. Attackers can hydrate media from local absolute paths to read arbitrary host
+    files accessible by the runtime user.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.24 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/270ab03e379f9653e15f7033c9830399b66b7e51
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-fqcm-97m6-w7rm
+  - https://www.vulncheck.com/advisories/openclaw-arbitrary-file-read-via-sendattachment-and-setgroupicon-message-actions
+  - https://github.com/advisories/GHSA-fqcm-97m6-w7rm
+rule: version <= "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/270ab03e379f9653e15f7033c9830399b66b7e51
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-fqcm-97m6-w7rm
+- https://www.vulncheck.com/advisories/openclaw-arbitrary-file-read-via-sendattachment-and-setgroupicon-message-actions
+- https://github.com/advisories/GHSA-fqcm-97m6-w7rm

--- a/data/vuln_en/openclaw/CVE-2026-27523.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27523.yaml
@@ -1,0 +1,29 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27523
+  summary: openclaw OpenClaw's sandbox bind validation could bypass allowed-root and blocked-path checks via symlink-parent
+    missing-leaf paths
+  details: >-
+    OpenClaw versions prior to 2026.2.24 contain a sandbox bind validation vulnerability allowing attackers to bypass allowed-root
+    and blocked-path checks via symlinked parent directories with non-existent leaf paths. Attackers can craft bind source
+    paths that appear within allowed roots but resolve outside sandbox boundaries once missing leaf components are created,
+    weakening bind-source isolation enforcement.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.24 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/b5787e4abba0dcc6baf09051099f6773c1679ec1
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-m8v2-6wwh-r4gc
+  - https://www.vulncheck.com/advisories/openclaw-sandbox-bind-validation-bypass-via-symlink-parent-missing-leaf-paths
+  - https://github.com/advisories/GHSA-m8v2-6wwh-r4gc
+rule: version <= "2026.2.23"
+references:
+- https://github.com/openclaw/openclaw/commit/b5787e4abba0dcc6baf09051099f6773c1679ec1
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-m8v2-6wwh-r4gc
+- https://www.vulncheck.com/advisories/openclaw-sandbox-bind-validation-bypass-via-symlink-parent-missing-leaf-paths
+- https://github.com/advisories/GHSA-m8v2-6wwh-r4gc

--- a/data/vuln_en/openclaw/CVE-2026-27524.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27524.yaml
@@ -1,0 +1,27 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27524
+  summary: openclaw OpenClaw's runtime /debug override path accepted prototype-reserved keys
+  details: >-
+    OpenClaw versions prior to 2026.2.21 accept prototype-reserved keys in runtime /debug set override object values, allowing
+    prototype pollution attacks. Authorized /debug set callers can inject __proto__, constructor, or prototype keys to manipulate
+    object prototypes and bypass command gate restrictions.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N
+  severity: LOW
+  security_advise: Upgrade to openclaw 2026.2.21 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/fbb79d4013000552d6a2c23b9613d8b3cb92f6b6
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-62f6-mrcj-v8h5
+  - https://www.vulncheck.com/advisories/openclaw-prototype-pollution-via-debug-override-path
+  - https://github.com/advisories/GHSA-62f6-mrcj-v8h5
+rule: version < "2026.2.21"
+references:
+- https://github.com/openclaw/openclaw/commit/fbb79d4013000552d6a2c23b9613d8b3cb92f6b6
+- https://github.com/openclaw/openclaw/security/advisories/GHSA-62f6-mrcj-v8h5
+- https://www.vulncheck.com/advisories/openclaw-prototype-pollution-via-debug-override-path
+- https://github.com/advisories/GHSA-62f6-mrcj-v8h5

--- a/data/vuln_en/openclaw/CVE-2026-27545.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27545.yaml
@@ -1,0 +1,30 @@
+info:
+  name: openclaw
+  cve: CVE-2026-27545
+  summary: 'openclaw OpenClaw: Node system.run approval bypass via parent-symlink cwd rebind'
+  details: >-
+    OpenClaw versions prior to 2026.2.26 contain an approval bypass vulnerability in system.run execution that allows attackers
+    to execute commands from unintended filesystem locations by rebinding writable parent symlinks in the current working
+    directory after approval. An attacker can modify mutable parent symlink path components between approval and execution
+    time to redirect command execution to a different location while preserving the visible working directory string.
+
+
+    [Exploit Maturity: LOW]
+
+    - 利用成熟度低：暂无明显公开利用
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L
+  severity: MEDIUM
+  security_advise: Upgrade to openclaw 2026.2.26 or later.
+  references:
+  - https://github.com/openclaw/openclaw/commit/4b4718c8dfce2e2c48404aa5088af7c013bed60b
+  - https://github.com/openclaw/openclaw/commit/4e690e09c746408b5e27617a20cb3fdc5190dbda
+  - https://github.com/openclaw/openclaw/commit/78a7ff2d50fb3bcef351571cb5a0f21430a340c1
+  - https://github.com/openclaw/openclaw/commit/d06632ba45a8482192792c55d5ff0b2e21abb0a7
+  - https://github.com/openclaw/openclaw/commit/d82c042b09727a6148f3ca651b254c4a677aff26
+rule: version <= "2026.2.25"
+references:
+- https://github.com/openclaw/openclaw/commit/4b4718c8dfce2e2c48404aa5088af7c013bed60b
+- https://github.com/openclaw/openclaw/commit/4e690e09c746408b5e27617a20cb3fdc5190dbda
+- https://github.com/openclaw/openclaw/commit/78a7ff2d50fb3bcef351571cb5a0f21430a340c1
+- https://github.com/openclaw/openclaw/commit/d06632ba45a8482192792c55d5ff0b2e21abb0a7
+- https://github.com/openclaw/openclaw/commit/d82c042b09727a6148f3ca651b254c4a677aff26

--- a/data/vuln_en/openclaw/CVE-2026-30741.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-30741.yaml
@@ -1,0 +1,25 @@
+info:
+  name: openclaw
+  cve: CVE-2026-30741
+  summary: OpenClaw Agent Platform RCE via request-side prompt injection in agent task execution
+  details: >-
+    OpenClaw Agent Platform v2026.2.6 and earlier contains a remote code execution
+    vulnerability (CWE-94) in the agent task execution pipeline. The platform
+    processes user-supplied prompt content without adequate sanitization, allowing
+    an unauthenticated remote attacker to inject malicious instructions via
+    request-side prompt injection. The injected content can manipulate the agent
+    runtime to execute arbitrary code on the underlying server. This vulnerability
+    does not require authentication, making it exploitable by any network-reachable
+    attacker. No public PoC has been identified; exploit maturity is LOW. The
+    vulnerability was reported via the OpenClaw GitHub repository.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade OpenClaw Agent Platform to a version later than v2026.2.6. Apply input validation and prompt sanitization controls to all user-supplied content processed by the agent task execution pipeline.
+  references:
+  - https://github.com/Named1ess/CVE-2026-30741
+  - https://github.com/OpenClaw/OpenClaw
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30741
+rule: version <= "2026.2.6"
+references:
+- https://github.com/Named1ess/CVE-2026-30741
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30741

--- a/data/vuln_en/openclaw/CVE-2026-32038.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32038.yaml
@@ -1,0 +1,26 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32038
+  summary: OpenClaw sandbox network isolation bypass via docker.network=container:<id>
+  details: >-
+    OpenClaw before version 2026.2.24 contains a sandbox network isolation bypass vulnerability
+    (CWE-284: Improper Access Control). Trusted operators can configure the docker.network
+    parameter with container:<id> values to join another container's network namespace, bypassing
+    network hardening controls. This allows an attacker to reach services in target container
+    namespaces that are otherwise isolated. The vulnerability is exploitable by any operator
+    with the ability to configure sandbox parameters.
+  cvss: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade OpenClaw to version 2026.2.24 or later. Restrict operator permissions to configure
+    docker.network parameters. Audit existing sandbox configurations for container:<id> network
+    references and remove unauthorized entries.
+  references:
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-ww6v-v748-x7g9
+    - https://github.com/openclaw/openclaw/commit/14b6eea6e
+    - https://github.com/openclaw/openclaw/commit/5552f9073
+    - https://www.vulncheck.com/advisories/openclaw-sandbox-network-isolation-bypass-via-docker-network-container-parameter
+rule: ""
+references:
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-ww6v-v748-x7g9
+  - https://www.vulncheck.com/advisories/openclaw-sandbox-network-isolation-bypass-via-docker-network-container-parameter

--- a/data/vuln_en/openclaw/CVE-2026-32059.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32059.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32059
+  summary: OpenClaw tools.exec.safeBins Allowlist Bypass via GNU Long-Option Abbreviation in sort Command
+  details: >-
+    OpenClaw version 2026.2.22-2 contains an authorization bypass vulnerability in the
+    tools.exec.safeBins validation for the sort command. The validation fails to properly
+    validate GNU long-option abbreviations, allowing attackers to bypass denied-flag checks
+    via abbreviated options in allowlist mode. Remote attackers can execute sort commands
+    with abbreviated long options to skip approval requirements.
+    This vulnerability affects the exec tool's allowlist enforcement mechanism,
+    potentially allowing unauthorized command execution with elevated permissions.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw to version 2026.2.23 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32059
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-3c6h-g97w-fg78
+rule: version >= "2026.2.22-2" && version < "2026.2.23"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32059

--- a/data/vuln_en/openclaw/CVE-2026-32060.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32060.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32060
+  summary: OpenClaw apply_patch Path Traversal Allowing Arbitrary File Write/Delete Outside Workspace
+  details: >-
+    OpenClaw versions prior to 2026.2.14 contain a path traversal vulnerability in the
+    apply_patch functionality. When apply_patch is enabled without filesystem sandbox
+    containment, attackers can exploit crafted paths including directory traversal sequences
+    (e.g., ../../) or absolute paths to escape workspace boundaries and modify or delete
+    arbitrary files accessible to the OpenClaw process user. This can lead to data
+    destruction, privilege escalation, or remote code execution by overwriting sensitive
+    system files or application configuration.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw to version 2026.2.14 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32060
+rule: version < "2026.2.14"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32060

--- a/data/vuln_en/openclaw/CVE-2026-32061.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32061.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32061
+  summary: OpenClaw $include Directive Path Traversal Allowing Arbitrary Local File Read
+  details: >-
+    OpenClaw versions prior to 2026.2.17 contain a path traversal vulnerability in the
+    $include directive resolution. Attackers with config modification capabilities can
+    exploit this by specifying absolute paths, traversal sequences, or symlinks in the
+    $include directive to access sensitive files readable by the OpenClaw process user,
+    including API keys and credentials stored outside the config directory boundary.
+    Exploitation requires high privileges (config modification access) and is a local
+    attack vector, but can lead to significant information disclosure of sensitive secrets.
+  cvss: CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: Upgrade OpenClaw to version 2026.2.17 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32061
+rule: version < "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32061

--- a/data/vuln_en/openclaw/CVE-2026-32062.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32062.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32062
+  summary: OpenClaw and @openclaw/voice-call Unauthenticated WebSocket DoS via Pre-validation Stream Upgrade
+  details: >-
+    OpenClaw versions 2026.2.21-2 prior to 2026.2.22 and @openclaw/voice-call versions
+    2026.2.21 prior to 2026.2.22 accept media-stream WebSocket upgrades before stream
+    validation is performed. This allows unauthenticated clients to establish connections
+    without completing proper validation, enabling remote attackers to hold idle
+    pre-authenticated sockets open to consume connection resources and degrade service
+    availability for legitimate streams. The vulnerability can be exploited to cause
+    denial of service against the OpenClaw voice/media streaming services.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw and @openclaw/voice-call to version 2026.2.22 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32062
+rule: version >= "2026.2.21-2" && version < "2026.2.22"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32062

--- a/data/vuln_en/openclaw/CVE-2026-32063.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32063.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32063
+  summary: OpenClaw Command Injection via CR/LF Injection in systemd Unit File Generation
+  details: >-
+    OpenClaw version 2026.2.19-2 prior to 2026.2.21 contains a command injection vulnerability
+    in the systemd unit file generation process. Attacker-controlled environment values in
+    config.env.vars are not validated for CR/LF (carriage return/line feed) characters,
+    allowing newline injection to break out of Environment= lines in the generated unit file
+    and inject arbitrary systemd directives. An attacker who can influence config.env.vars
+    and trigger service install or restart can execute arbitrary commands with the privileges
+    of the OpenClaw gateway service user. This is a local privilege escalation vector
+    requiring write access to configuration.
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade OpenClaw to version 2026.2.21 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32063
+rule: version >= "2026.2.19-2" && version < "2026.2.21"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32063

--- a/data/vuln_en/openclaw/CVE-2026-32302.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32302.yaml
@@ -1,0 +1,35 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32302
+  summary: OpenClaw WebSocket origin bypass in trusted-proxy mode enables unauthorized privileged operator session
+  details: >-
+    OpenClaw versions prior to 2026.3.11 contain a Cross-Origin Request validation
+    bypass (CWE-346) in the WebSocket connection handling when gateway.auth.mode
+    is configured as "trusted-proxy". Browser-originated WebSocket connections
+    arriving via a trusted reverse proxy with proxy-forwarded headers can bypass
+    origin validation. An untrusted web page served from a malicious origin can
+    connect through a trusted reverse proxy, inherit proxy-authenticated identity,
+    and establish a privileged operator.admin session without explicit authentication.
+    This allows an attacker to gain full administrative access to the OpenClaw
+    gateway, including access to user conversations, skills, memory files, and
+    any connected messaging channels. The vulnerability only affects deployments
+    using trusted-proxy authentication mode with a reverse proxy. Exploitation
+    maturity is LOW at publication; the official advisory references a single
+    commit fix. Severity is HIGH due to privilege escalation to operator.admin.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: >-
+    Upgrade OpenClaw to version 2026.3.11 or later, which adds strict WebSocket
+    origin validation in trusted-proxy mode. As a temporary mitigation, switch
+    gateway.auth.mode from "trusted-proxy" to "token" or "password" mode, or
+    add explicit CORS/Origin restrictions at the reverse proxy level (e.g., Nginx
+    map directives to reject requests from untrusted origins).
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+    - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11
+rule: version < "2026.3.11"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32302
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-5wcw-8jjv-m286
+  - https://github.com/openclaw/openclaw/releases/tag/v2026.3.11

--- a/data/vuln_en/openclaw/CVE-2026-4039.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-4039.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4039
+  summary: OpenClaw applySkillConfigenvOverrides Skill Env Handler Code Injection
+  details: >-
+    OpenClaw version 2026.2.19-2 contains a code injection vulnerability in the
+    applySkillConfigenvOverrides function of the Skill Env Handler component.
+    Manipulation of environment variable overrides can lead to code injection,
+    allowing remote attackers to execute arbitrary code. The vulnerability is
+    remotely exploitable and was fixed in version 2026.2.21-beta.1.
+    The patch is identified as commit 8c9f35cdb51692b650ddf05b259ccdd75cc9a83c.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: Upgrade OpenClaw to version 2026.2.21 or later (fix first included in 2026.2.21-beta.1).
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4039
+rule: version <= "2026.2.19-2"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4039

--- a/data/vuln_en/openclaw/CVE-2026-4040.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-4040.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openclaw
+  cve: CVE-2026-4040
+  summary: OpenClaw tools.exec.safeBins File Existence Information Disclosure via Timing Discrepancy
+  details: >-
+    OpenClaw versions up to 2026.2.17 contain an information disclosure vulnerability in
+    the tools.exec.safeBins File Existence Handler component. The manipulation leads to
+    information exposure through discrepancy (timing or response difference), allowing
+    local attackers to infer the existence of files on the system. This is a local attack
+    vector requiring low privileges, resulting in limited confidentiality impact.
+    Fixed in version 2026.2.19-beta.1 (patch: bafdbb6f112409a65decd3d4e7350fbd637c7754).
+  cvss: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: Upgrade OpenClaw to version 2026.2.19 or later.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-4040
+rule: version <= "2026.2.17"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-4040

--- a/data/vuln_en/openwebui/CVE-2025-15603.yaml
+++ b/data/vuln_en/openwebui/CVE-2025-15603.yaml
@@ -1,0 +1,22 @@
+info:
+  name: openwebui
+  cve: CVE-2025-15603
+  summary: Open WebUI JWT Key Handler Insufficiently Random WEBUI_SECRET_KEY Values
+  details: >-
+    Open WebUI up to version 0.6.16 contains a weak randomness vulnerability in the
+    JWT Key Handler component. The WEBUI_SECRET_KEY argument in the backend/start_windows.bat
+    file leads to insufficiently random values being used for JWT secret key generation.
+    Remote exploitation requires high attack complexity. An attacker who successfully
+    exploits this vulnerability could predict or recover the JWT secret key, potentially
+    allowing session token forgery and unauthorized access to the application.
+    The vulnerability has been publicly disclosed and may be actively exploited.
+  cvss: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: Upgrade Open WebUI to a version later than 0.6.16. Ensure WEBUI_SECRET_KEY is set to a strong, randomly generated value.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+    - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4
+rule: version <= "0.6.16"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2025-15603
+  - https://huntr.com/bounties/b9fc7fee-d25d-4100-9703-5e78a61e1ce4

--- a/data/vuln_en/ray/CVE-2026-32981.yaml
+++ b/data/vuln_en/ray/CVE-2026-32981.yaml
@@ -1,0 +1,27 @@
+info:
+  name: ray
+  cve: CVE-2026-32981
+  summary: Ray Dashboard path traversal vulnerability leading to local file disclosure
+  details: >-
+    A path traversal vulnerability (CWE-22) was identified in Ray Dashboard (default port 8265)
+    in Ray versions prior to 2.8.1. Due to improper validation and sanitization of user-supplied
+    paths in the static file handling mechanism, an unauthenticated attacker can use traversal
+    sequences (e.g., ../) to access files outside the intended static directory, resulting in
+    local file disclosure. Ray Dashboard is publicly accessible by default without authentication,
+    making this vulnerability particularly dangerous in exposed deployments. References to a
+    public PoC are available via PacketStorm.
+  cvss: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  severity: HIGH
+  security_advise: >-
+    Upgrade Ray to version 2.8.1 or later. If immediate upgrade is not possible, restrict
+    access to Ray Dashboard (default port 8265) via firewall rules or network policies to
+    prevent exposure to untrusted networks. Do not expose Ray Dashboard to the public internet.
+  references:
+    - https://github.com/ray-project/ray
+    - https://packetstorm.news/files/id/215801/
+    - https://www.vulncheck.com/advisories/ray-dashboard-path-traversal-leading-to-local-file-disclosure
+rule: ""
+references:
+  - https://github.com/ray-project/ray
+  - https://packetstorm.news/files/id/215801/
+  - https://www.vulncheck.com/advisories/ray-dashboard-path-traversal-leading-to-local-file-disclosure

--- a/data/vuln_en/vllm/CVE-2026-25960.yaml
+++ b/data/vuln_en/vllm/CVE-2026-25960.yaml
@@ -1,0 +1,34 @@
+info:
+  name: vllm
+  cve: CVE-2026-25960
+  summary: vLLM SSRF Protection Bypass via URL Parser Inconsistency
+  details: >-
+    vLLM versions 0.15.1 through 0.16.0 (fixed in 0.17.0) contain a Server-Side Request
+    Forgery (SSRF) protection bypass vulnerability in the `load_from_url_async` method
+    within `vllm/connections.py`. The SSRF fix (GHSA-qh4c-xf7m-gxfc) uses
+    `urllib3.util.parse_url()` for URL validation, but the actual HTTP request is made
+    via `aiohttp` which internally uses the `yarl` library. These two parsers handle
+    backslash characters differently: urllib3 URL-encodes `\` as `%5C` and treats the
+    remaining path as part of the URL path, while yarl interprets `\` as part of userinfo
+    and `@` as the userinfo/host separator, causing the request to be directed to a
+    different host than validated. An authenticated attacker with low privileges can craft
+    a URL such as `https://trusted-host\@evil.com/` to bypass allowlist validation and
+    force the server to make requests to arbitrary internal or external services, enabling
+    full SSRF attacks including access to cloud metadata endpoints and internal services.
+    No public PoC or exploit code has been identified at time of publication (LOW exploitation
+    maturity).
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:L
+  severity: MEDIUM
+  security_advise: Upgrade vLLM to version 0.17.0 or later. The fix is available in
+    pull request https://github.com/vllm-project/vllm/pull/34743. As a temporary
+    mitigation, restrict the URL allowlist to prevent access to internal network ranges
+    and validate URLs using a consistent URL parsing library.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+    - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+    - https://github.com/vllm-project/vllm/pull/34743
+rule: version >= "0.15.1" && version < "0.17.0"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-25960
+  - https://github.com/vllm-project/vllm/security/advisories/GHSA-v359-jj2v-j536
+  - https://github.com/vllm-project/vllm/pull/34743

--- a/data/vuln_en/weknora/CVE-2026-30860.yaml
+++ b/data/vuln_en/weknora/CVE-2026-30860.yaml
@@ -1,0 +1,29 @@
+info:
+  name: weknora
+  cve: CVE-2026-30860
+  summary: WeKnora SQL injection bypass in AI database query tool leads to unauthenticated RCE via PostgreSQL
+  details: >-
+    WeKnora is an LLM-powered framework for deep document understanding and
+    semantic retrieval. Prior to version 0.2.12, a critical RCE vulnerability
+    exists in the database query functionality (internal/utils/inject.go).
+    The application implements a 7-phase SQL validation framework using
+    PostgreSQL AST parsing, but Phase 5 (validateNode) fails to handle
+    ArrayExpr and RowExpr node types. Attackers can smuggle dangerous
+    PostgreSQL functions (e.g., lo_import, lo_export) inside array or row
+    expressions, bypassing all validation phases. By chaining large object
+    operations with pg_read_binary_file and shared library loading
+    (lo_import + CREATE FUNCTION), an attacker with only a valid account
+    (open registration, no verification required) can achieve arbitrary code
+    execution on the database server with database user privileges. The fix
+    in version 0.2.12 adds recursive AST node validation for ArrayExpr and
+    RowExpr types.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade WeKnora to version 0.2.12 or later. The patch adds ArrayExpr and RowExpr node type handling to the validateNode() function in internal/utils/inject.go to prevent SQL injection bypass.
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30860
+rule: version < "0.2.12"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-8w32-6mrw-q5wv
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30860

--- a/data/vuln_en/weknora/CVE-2026-30861.yaml
+++ b/data/vuln_en/weknora/CVE-2026-30861.yaml
@@ -1,0 +1,31 @@
+info:
+  name: weknora
+  cve: CVE-2026-30861
+  summary: WeKnora MCP stdio configuration validation bypass leads to unauthenticated RCE via command injection
+  details: >-
+    WeKnora is an LLM-powered framework for deep document understanding and
+    semantic retrieval. Versions 0.2.5 through 0.2.9 contain a critical
+    unauthenticated remote code execution vulnerability in the MCP stdio
+    configuration validation. The application implements a command whitelist
+    (npx, uvx) and argument blacklist to prevent injection, but the blacklist
+    fails to block the -p flag in npx node. An attacker can register a free
+    account (no email verification or approval required), obtain API
+    credentials, and pass arguments like ["node", "-p",
+    "require('fs').writeFileSync(...)"] to execute arbitrary JavaScript via
+    Node.js -p (print/eval) flag, fully bypassing the DangerousArgPatterns
+    validation. This results in arbitrary code execution with the
+    application's privileges. The vulnerability was silently patched in
+    version 0.2.10 without a CVE disclosure, potentially leaving operators
+    unaware across versions 0.2.6 through 0.2.9.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: Upgrade WeKnora to version 0.2.10 or later. If immediate upgrade is not possible, disable open user registration or restrict network access to the WeKnora service to prevent exploitation.
+  references:
+  - https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+  - https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-30861
+rule: version >= "0.2.5" && version < "0.2.10"
+references:
+- https://github.com/Tencent/WeKnora/security/advisories/GHSA-r55h-3rwj-hcmg
+- https://github.com/Tencent/WeKnora/commit/57d6fea8bc265ad28b385e0158957c870cff4b50
+- https://nvd.nist.gov/vuln/detail/CVE-2026-30861


### PR DESCRIPTION
## 🤖 自动生成的 AIG 规则 [2026-03-20]

本 PR 由 AIG-Bot 自动创建，包含最新发现的 CVE 漏洞检测规则。

### 📊 统计

| 类型 | 数量 |
|------|------|
| 漏洞规则 (EN + CN) | 51 条 |
| 指纹规则 | 5 条 |

### 📋 新增漏洞规则

- `CVE-2025-14287` (mlflow)
- `CVE-2025-15031` (mlflow)
- `CVE-2025-15603` (openwebui)
- `CVE-2025-41258` (librechat)
- `CVE-2026-22168` (openclaw)
- `CVE-2026-22169` (openclaw)
- `CVE-2026-22170` (openclaw)
- `CVE-2026-22171` (openclaw)
- `CVE-2026-22174` (openclaw)
- `CVE-2026-22175` (openclaw)
- `CVE-2026-22177` (openclaw)
- `CVE-2026-22178` (openclaw)
- `CVE-2026-22179` (openclaw)
- `CVE-2026-22180` (openclaw)
- `CVE-2026-22181` (openclaw)
- `CVE-2026-22217` (openclaw)
- `CVE-2026-25960` (vllm)
- `CVE-2026-27522` (openclaw)
- `CVE-2026-27523` (openclaw)
- `CVE-2026-27524` (openclaw)
- `CVE-2026-27545` (openclaw)
- `CVE-2026-27940` (llama-cpp)
- `CVE-2026-30741` (openclaw)
- `CVE-2026-30820` (flowise)
- `CVE-2026-30823` (flowise)
- `CVE-2026-30860` (weknora)
- `CVE-2026-30861` (weknora)
- `CVE-2026-31829` (flowise)
- `CVE-2026-31944` (librechat)
- `CVE-2026-31949` (librechat)
- `CVE-2026-32038` (openclaw)
- `CVE-2026-32059` (openclaw)
- `CVE-2026-32060` (openclaw)
- `CVE-2026-32061` (openclaw)
- `CVE-2026-32062` (openclaw)
- `CVE-2026-32063` (openclaw)
- `CVE-2026-32302` (openclaw)
- `CVE-2026-32617` (anythingllm)
- `CVE-2026-32626` (anythingllm)
- `CVE-2026-32628` (anythingllm)
- `CVE-2026-32715` (anythingllm)
- `CVE-2026-32717` (anythingllm)
- `CVE-2026-32719` (anythingllm)
- `CVE-2026-32981` (ray)
- `CVE-2026-33017` (langflow)
- `CVE-2026-33053` (langflow)
- `CVE-2026-33265` (librechat)
- `CVE-2026-33309` (langflow)
- `CVE-2026-4039` (openclaw)
- `CVE-2026-4040` (openclaw)
- `CVE-2026-4276` (librechat)

### 🔍 新增/更新指纹规则

- `flowise.yaml`
- `librechat.yaml`
- `mlflow.yaml`
- `openclaw.yaml`
- `weknora.yaml`

---
*由 AIG-Bot 自动生成，请人工审核后合并。*
