### PR TITLE
fix: normalize severity case and add retry mechanism for ChatStream

### DIFF
--- a/common/runner/runner.go
+++ b/common/runner/runner.go
@@ -724,9 +724,10 @@ func (r *Runner) CalcSecScore(advisories []vulstruct.Info) CallbackReportInfo {
 	var total, high, middle, low int = 0, 0, 0, 0
 	total = len(advisories)
 	for _, item := range advisories {
-		if item.Severity == "HIGH" || item.Severity == "CRITICAL" {
+		severity := strings.ToLower(strings.TrimSpace(item.Severity))
+		if severity == "high" || severity == "critical" || severity == "高危" || severity == "严重" {
 			high++
-		} else if item.Severity == "MEDIUM" {
+		} else if severity == "medium" || severity == "中危" {
 			middle++
 		} else {
 			low++

--- a/common/utils/models/openai.go
+++ b/common/utils/models/openai.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/openai/openai-go/option"
 
@@ -74,32 +75,48 @@ func (ai *OpenAI) ChatStream(ctx context.Context, history []map[string]string) <
 			chatMessages = append(chatMessages, openai.UserMessage(content))
 		}
 	}
-	stream := client.Chat.Completions.NewStreaming(ctx, openai.ChatCompletionNewParams{
-		Messages: chatMessages,
-		Seed:     openai.Int(24),
-		Model:    ai.Model,
-	})
-	// 循环读取结果
+
+	const maxRetries = 3
 	go func() {
+		defer close(resp)
 		var totalToken int64 = 0
-		for stream.Next() {
-			evt := stream.Current()
-			if len(evt.Choices) > 0 {
-				word := evt.Choices[0].Delta.Content
-				if evt.Usage.TotalTokens > 0 {
-					totalToken = evt.Usage.TotalTokens
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			if attempt > 0 {
+				waitSec := time.Duration(1<<attempt) * time.Second // 2s, 4s
+				gologger.Infof("ChatStream retry %d/%d after %v", attempt, maxRetries-1, waitSec)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(waitSec):
 				}
-				resp <- word
+			}
+			stream := client.Chat.Completions.NewStreaming(ctx, openai.ChatCompletionNewParams{
+				Messages: chatMessages,
+				Seed:     openai.Int(24),
+				Model:    ai.Model,
+			})
+			streamErr := false
+			for stream.Next() {
+				evt := stream.Current()
+				if len(evt.Choices) > 0 {
+					word := evt.Choices[0].Delta.Content
+					if evt.Usage.TotalTokens > 0 {
+						totalToken = evt.Usage.TotalTokens
+					}
+					resp <- word
+				}
+			}
+			if stream.Err() != nil {
+				gologger.WithError(stream.Err()).Errorf("ChatStream error (attempt %d/%d)", attempt+1, maxRetries)
+				streamErr = true
+			}
+			if !streamErr {
+				break
 			}
 		}
 		if totalToken > 0 {
 			ai.UseToken += totalToken
 		}
-		if stream.Err() != nil {
-			// 处理错误
-			gologger.WithError(stream.Err()).Errorln("ChatStream error")
-		}
-		close(resp)
 	}()
 	return resp
 }


### PR DESCRIPTION
## Summary

This PR fixes two community-reported issues:

### Fix #178 - Severity normalization in `CalcSecScore`

- Apply `strings.ToLower` + `strings.TrimSpace` before severity comparison
- Add Chinese severity labels (`高危`/`严重`/`中危`) to handle mixed-language AI outputs
- Previously, Chinese severity strings (e.g. from Chinese-language AI models) were always classified as `low`, leading to inflated security scores

### Fix #191 - Retry mechanism for `ChatStream`

- Add exponential backoff retry (max 3 attempts, wait 2s then 4s between retries)
- Respect context cancellation during retry wait
- Log retry attempts with attempt number for observability
- Fixes `RemoteProtocolError: peer closed connection without sending complete message body` and similar transient network errors in streaming API calls

## Changes

- `common/runner/runner.go`: normalize severity string before comparison
- `common/utils/models/openai.go`: add retry loop with exponential backoff in `ChatStream`

Closes #178
Closes #191