### PR TITLE
docs: fix incorrect license name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Experience the Pro version with advanced features and improved performance. The 
 - 🔌 **Complete API**: Full interface documentation and Swagger specifications for easy integration
 - 🌐 **Multi-Language**: Chinese and English interfaces with localized documentation
 - 🐳 **Cross-Platform**: Linux, macOS, and Windows support with Docker-based deployment
-- 🆓 **Free & Open Source**: Completely free under the MIT license
+- 🆓 **Free & Open Source**: Completely free under the Apache 2.0 license
 </details>
 
 <br />


### PR DESCRIPTION
## 变更说明

由 doc-reviewer 自动检测并修复的文档问题。

### 修复内容

- **issue-004**：README.md「其他优势」章节中 `MIT license` 改为 `Apache 2.0 license`
  - 原文：`Completely free under the MIT license`
  - 改后：`Completely free under the Apache 2.0 license`
  - 原因：项目使用 Apache 2.0 许可证，此处描述有误

> Auto-generated by doc-reviewer skill