### PR TITLE
docs: update README What's New section to v4.1, preserve v4.0 highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@
 
 <br>
 
-## 🚀 What's New in v4.1: Expanded Coverage, Efficiency & Open-Source Compliance
+## 🚀 What's New in v4.1: Expanded Detection & Task Efficiency
 
 - 🔍 **Enhanced OpenClaw Detection**: 281 new CVE/GHSA entries added to the vulnerability database
 - ⚡ **Task Efficiency**: Deleting a running task now immediately stops the underlying agent execution
-- 🔐 **Apache 2.0**: Migrated from MIT; all source files include license headers with NOTICE attribution
-- 🛠️ **Fixes & Hardening**: Resolved concurrent log corruption in Agent Scan; completed CodeQL path-injection remediation
+
+👉 [Full v4.1 Release Notes](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1) · [CHANGELOG](./CHANGELOG.md) · 🩺 [Try EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 <details>
 <summary>📌 v4.0 Highlights</summary>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -47,12 +47,12 @@
   </a>
 </p>
 
-## 🚀 A.I.G v4.1：检测覆盖扩展、效率优化与开源合规
+## 🚀 A.I.G v4.1：检测覆盖扩展与效率优化
 
 - 🔍 **OpenClaw 检测增强**：漏洞库新增 281 条 CVE/GHSA 条目
 - ⚡ **任务效率优化**：删除运行中任务时立即终止底层 Agent 执行，节省 Token 消耗
-- 🔐 **Apache 2.0**：完成从 MIT 迁移，所有源文件已添加许可证头并附 NOTICE 署名要求
-- 🛠️ **修复与加固**：修复 Agent Scan 并发日志错乱；完成 CodeQL 路径注入加固
+
+👉 [查看完整 v4.1 发布说明](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1) · [CHANGELOG](./CHANGELOG.md) · 🩺 [立即体验 EdgeOne ClawScan](https://matrix.tencent.com/clawscan/)
 
 <details>
 <summary>📌 v4.0 核心亮点</summary>


### PR DESCRIPTION
## Summary

Update the "What's New" section in both `README.md` and `README_ZH.md` to reflect the v4.1 release.

### Changes
- Replace v4.0 headline block with v4.1 feature summary (Task Pause/Resume, 281 new vuln entries, port 18789, YAML CI validation, Apache 2.0 migration)
- Preserve v4.0 highlights in a collapsible `<details>` block so history is not lost
- Update footer links to point to v4.1 Release Notes + CHANGELOG

### Why
The README still showed v4.0 as the latest release after v4.1 shipped.