### PR TITLE
feat: add AIG rules [2026-03-25]

### DIFF
--- a/data/fingerprints/blinko.yaml
+++ b/data/fingerprints/blinko.yaml
@@ -1,0 +1,13 @@
+info:
+  name: blinko
+  author: A.I.G bot
+  severity: info
+  desc: Blinko is an open-source AI-powered note-taking application with MCP (Model Context Protocol) integration support.
+  metadata:
+    product: blinko
+    vendor: blinkospace
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="<title>Blinko</title>"

--- a/data/fingerprints/new-api.yaml
+++ b/data/fingerprints/new-api.yaml
@@ -1,0 +1,25 @@
+info:
+  name: new-api
+  author: A.I.G bot
+  severity: info
+  desc: |
+    New API is a unified AI model hub and LLM gateway supporting aggregation and distribution of
+    100+ LLM providers. It converts various LLMs into OpenAI/Claude/Gemini compatible formats
+    and provides centralized model management for personal and enterprise use.
+  metadata:
+    product: new-api
+    vendor: quantumnous
+
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body='"system_name":"New API"' || body="New API</title>"
+
+version:
+  - method: GET
+    path: '/api/status'
+    extractor:
+      part: body
+      group: 1
+      regex: '"version"\s*:\s*"(v[0-9]+\.[0-9]+\.[0-9]+[^"]*)"'

--- a/data/vuln/blinko/CVE-2026-23882.yaml
+++ b/data/vuln/blinko/CVE-2026-23882.yaml
@@ -1,0 +1,19 @@
+info:
+  name: blinko
+  cve: CVE-2026-23882
+  summary: Blinko MCP Server 任意命令执行漏洞（未验证命令参数）
+  details: >-
+    AI 卡片笔记应用 Blinko 在 1.8.4 版本之前，其 MCP（模型上下文协议）服务器创建功能
+    存在远程代码执行漏洞。该功能允许用户在创建 MCP 服务器时指定任意命令及其参数，
+    当触发连接测试时，这些命令将在服务端被直接执行，缺乏充分的输入验证和沙箱隔离。
+    拥有 MCP 服务器配置权限的已认证攻击者可利用此漏洞在服务器上执行任意操作系统命令，
+    导致敏感数据泄露、权限提升或服务器完全失陷。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 Blinko 至 1.8.4 或更高版本，该版本修复了 MCP 服务器创建函数中的任意命令执行问题。
+  references:
+    - https://github.com/blinkospace/blinko/security/advisories
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23882
+rule: version < "1.8.4"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-23882

--- a/data/vuln/langflow/CVE-2026-33484.yaml
+++ b/data/vuln/langflow/CVE-2026-33484.yaml
@@ -1,0 +1,21 @@
+info:
+  name: langflow
+  cve: CVE-2026-33484
+  summary: Langflow 图片下载接口存在未授权越权访问（IDOR）漏洞，允许任意获取用户上传图片
+  details: >-
+    Langflow 1.0.0 至 1.8.1 版本中，/api/v1/files/images/{flow_id}/{file_name}
+    接口未实施任何身份认证或归属校验。攻击者无需凭据，只需提供已知或猜测到的
+    flow_id（UUID 可通过其他 API 响应泄露）和 file_name，即可以 HTTP 200 状态码
+    获取对应图片文件。在多租户部署环境中，恶意用户可下载任意其他用户上传的图片。
+    对应缺陷类型：CWE-639（通过用户可控键绕过授权）。已在 1.9.0 版本修复。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: >-
+    升级 Langflow 至 1.9.0 或更高版本。补丁为图片下载接口添加了身份认证和归属
+    校验，防止未授权访问。
+  references:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-7grx-3xcx-2xv5
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33484
+rule: version >= "1.0.0" && version < "1.9.0"
+references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-7grx-3xcx-2xv5

--- a/data/vuln/langflow/CVE-2026-33497.yaml
+++ b/data/vuln/langflow/CVE-2026-33497.yaml
@@ -1,0 +1,21 @@
+info:
+  name: langflow
+  cve: CVE-2026-33497
+  summary: Langflow 头像接口路径遍历漏洞导致 secret_key 泄露
+  details: >-
+    Langflow 1.7.1 版本之前，/profile_pictures/{folder_name}/{file_name} 接口
+    未对 folder_name 和 file_name 参数进行严格过滤，导致未认证攻击者可通过目录
+    遍历读取任意文件，包括应用程序的 secret_key。成功利用该漏洞可导致完全绕过
+    身份认证或伪造会话令牌。对应缺陷类型：CWE-22（路径遍历）。已在 1.7.1 版本
+    修复。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: >-
+    升级 Langflow 至 1.7.1 或更高版本。补丁对头像下载接口的路径参数实施了严格
+    校验，防止目录遍历攻击。
+  references:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33497
+rule: version < "1.7.1"
+references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7

--- a/data/vuln/litellm/SUPPLY-CHAIN-2025-LITELLM.yaml
+++ b/data/vuln/litellm/SUPPLY-CHAIN-2025-LITELLM.yaml
@@ -1,0 +1,30 @@
+info:
+  name: litellm
+  cve: SUPPLY-CHAIN-2025-LITELLM
+  summary: LiteLLM PyPI 供应链投毒攻击 - 恶意包注入（v1.82.7/v1.82.8）
+  details: >-
+    2025年3月24日，威胁组织 TeamPCP 在攻陷安全扫描工具 Trivy 的 CI/CD 流程并窃取 litellm 的 PyPI 发布令牌后，
+    向 PyPI 发布了 litellm 的恶意版本（v1.82.7 和 v1.82.8）。恶意包中植入了后门文件 'litellm_init.pth'，
+    该文件会在每次 Python 进程启动时自动执行（无需显式导入）。恶意代码系统性地窃取敏感数据，
+    包括：SSH 密钥、AWS/GCP/Azure 云凭证、Kubernetes 密钥、环境变量（所有 API Key）、
+    数据库配置、加密货币钱包、SSL 私钥、CI/CD 密钥、git 凭证和 shell 历史记录，
+    并将数据加密后发送至攻击者控制的服务器。在 Kubernetes 环境中，
+    恶意代码还会利用服务账户令牌在集群每个节点上部署特权 Pod 进行横向扩散。
+    因攻击者代码存在 bug（.pth 文件触发子进程指数级 fork bomb 导致内存耗尽）事件才被发现。
+    最后一个干净版本为 v1.82.6。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    立即执行 'pip show litellm' 检查已安装版本。
+    若版本为 1.82.7 或 1.82.8，应视该主机上所有凭证已泄露并立即轮换：
+    SSH 密钥、云凭证（AWS/GCP/Azure）、API 密钥（环境变量）、数据库密码、git token、CI/CD 密钥。
+    升级到 litellm >= 1.82.9 或最新稳定版本。同时排查可能自动安装了受影响版本的依赖包。
+  references:
+    - https://github.com/BerriAI/litellm
+    - https://pypi.org/project/litellm/
+    - https://x.com/karpathy/status/1904178715882086741
+rule: version >= "1.82.7" && version <= "1.82.8"
+references:
+  - https://github.com/BerriAI/litellm
+  - https://pypi.org/project/litellm/
+  - https://x.com/karpathy/status/1904178715882086741

--- a/data/vuln/new-api/CVE-2026-30886.yaml
+++ b/data/vuln/new-api/CVE-2026-30886.yaml
@@ -1,0 +1,21 @@
+info:
+  name: new-api
+  cve: CVE-2026-30886
+  summary: New API 视频代理 IDOR 漏洞 - 越权访问其他用户视频内容
+  details: >-
+    New API LLM 网关 v0.11.4-alpha.2 之前的版本，在视频代理端点（GET /v1/videos/:task_id/content）
+    存在不安全的对象直接引用（IDOR）漏洞。任意已认证用户可通过传入其他用户的 task_id，
+    访问属于其他用户的视频内容。此外，服务器会使用被访问任务所属用户的凭据向上游 AI 提供商
+    （Google Gemini、OpenAI）发起认证请求，导致跨租户凭据滥用。
+    根本原因是接口缺少对 task 所有权的校验，允许水平越权攻击。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: 升级 New API 至 v0.11.4-alpha.2 或更高版本，该版本在视频代理端点添加了所有权校验。
+  references:
+    - https://github.com/QuantumNous/new-api/security/advisories/GHSA-f35r-v9x5-r8mc
+    - https://github.com/QuantumNous/new-api/commit/50ec2bac6b341e651fc9ac4344e3bd2cdaeafdbd
+    - https://github.com/advisories/GHSA-f35r-v9x5-r8mc
+rule: version < "0.11.4-alpha.2"
+references:
+  - https://github.com/QuantumNous/new-api/security/advisories/GHSA-f35r-v9x5-r8mc
+  - https://github.com/QuantumNous/new-api/commit/50ec2bac6b341e651fc9ac4344e3bd2cdaeafdbd

--- a/data/vuln/new-api/CVE-2026-32879.yaml
+++ b/data/vuln/new-api/CVE-2026-32879.yaml
@@ -1,0 +1,21 @@
+info:
+  name: new-api
+  cve: CVE-2026-32879
+  summary: New API Passkey 二次验证绕过漏洞 - 可泄露 Root 级渠道密钥
+  details: >-
+    New API LLM 网关 v0.10.0 起引入的通用安全二次验证（Secure Verification）流程存在逻辑缺陷。
+    已认证的用户若注册了 Passkey，可在不完成 WebAuthn 断言挑战的情况下通过二次验证，
+    从而访问原本仅限 Root 用户的特权操作，包括查看渠道密钥（上游 AI 提供商的 API Key）。
+    漏洞导致攻击者只需拥有有效账户及任意 Passkey，即可窃取所有已配置渠道的 API 密钥。
+    截至披露时，尚无修复版本发布，影响所有启用 Passkey 认证的部署实例。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: >-
+    在修复版本发布前，禁用 Passkey 作为特权操作的二次验证方式。
+    同时监控渠道密钥的异常访问记录，及时轮换可能已泄露的上游 API Key。
+  references:
+    - https://github.com/QuantumNous/new-api/security/advisories/GHSA-5353-f8fq-65vc
+    - https://github.com/advisories/GHSA-5353-f8fq-65vc
+rule: version >= "0.10.0"
+references:
+  - https://github.com/QuantumNous/new-api/security/advisories/GHSA-5353-f8fq-65vc

--- a/data/vuln_en/blinko/CVE-2026-23882.yaml
+++ b/data/vuln_en/blinko/CVE-2026-23882.yaml
@@ -1,0 +1,22 @@
+info:
+  name: blinko
+  cve: CVE-2026-23882
+  summary: Blinko MCP Server arbitrary command execution via unvalidated command arguments
+  details: >-
+    Blinko, an AI-powered card note-taking application, prior to version 1.8.4
+    contains a remote code execution vulnerability in its MCP (Model Context Protocol)
+    server creation function. The function allows users to specify arbitrary commands
+    and arguments when creating an MCP server. These commands are executed server-side
+    when the connection test is triggered, without sufficient validation or sandboxing.
+    An authenticated attacker with access to the MCP server configuration can leverage
+    this to execute arbitrary OS commands on the server.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade Blinko to version 1.8.4 or later, which patches the
+    arbitrary command execution in the MCP server creation function.
+  references:
+    - https://github.com/blinkospace/blinko/security/advisories
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-23882
+rule: version < "1.8.4"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-23882

--- a/data/vuln_en/langflow/CVE-2026-33484.yaml
+++ b/data/vuln_en/langflow/CVE-2026-33484.yaml
@@ -1,0 +1,23 @@
+info:
+  name: langflow
+  cve: CVE-2026-33484
+  summary: Langflow Unauthenticated IDOR on Image Downloads allows arbitrary image access
+  details: >-
+    Langflow versions 1.0.0 through 1.8.1 expose the
+    /api/v1/files/images/{flow_id}/{file_name} endpoint without authentication
+    or ownership checks. Any unauthenticated request with a known or guessed
+    flow_id (UUIDs can be leaked through other API responses) and file_name
+    returns the image with HTTP 200. In multi-tenant deployments, attackers can
+    download other users' uploaded images without credentials. CWE-639
+    (Authorization Bypass Through User-Controlled Key). Fixed in version 1.9.0.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: >-
+    Upgrade Langflow to version 1.9.0 or later. The patch adds authentication
+    and ownership validation to the image download endpoint.
+  references:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-7grx-3xcx-2xv5
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33484
+rule: version >= "1.0.0" && version < "1.9.0"
+references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-7grx-3xcx-2xv5

--- a/data/vuln_en/langflow/CVE-2026-33497.yaml
+++ b/data/vuln_en/langflow/CVE-2026-33497.yaml
@@ -1,0 +1,24 @@
+info:
+  name: langflow
+  cve: CVE-2026-33497
+  summary: Langflow path traversal in profile picture endpoint allows secret_key disclosure
+  details: >-
+    Langflow prior to version 1.7.1 contains a path traversal vulnerability in
+    the /profile_pictures/{folder_name}/{file_name} endpoint. The folder_name
+    and file_name parameters are not strictly filtered, allowing an
+    unauthenticated attacker to traverse directories and read sensitive files,
+    including the application secret_key. Successful exploitation could lead to
+    full authentication bypass or session forgery. CWE-22 (Path Traversal).
+    Fixed in version 1.7.1.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: >-
+    Upgrade Langflow to version 1.7.1 or later. The fix applies strict path
+    validation to the profile picture download endpoint to prevent directory
+    traversal.
+  references:
+    - https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-33497
+rule: version < "1.7.1"
+references:
+  - https://github.com/langflow-ai/langflow/security/advisories/GHSA-ph9w-r52h-28p7

--- a/data/vuln_en/litellm/SUPPLY-CHAIN-2025-LITELLM.yaml
+++ b/data/vuln_en/litellm/SUPPLY-CHAIN-2025-LITELLM.yaml
@@ -1,0 +1,32 @@
+info:
+  name: litellm
+  cve: SUPPLY-CHAIN-2025-LITELLM
+  summary: LiteLLM PyPI Supply Chain Attack - Malicious Package Injection (v1.82.7/v1.82.8)
+  details: >-
+    On March 24, 2025, threat actor group TeamPCP published malicious versions of the litellm Python package
+    (v1.82.7 and v1.82.8) to PyPI after compromising the Trivy security scanner's CI/CD pipeline and stealing
+    litellm's PyPI publish token. The malicious packages contain a backdoor file 'litellm_init.pth' that
+    executes automatically on every Python process startup (no explicit import required). The malware
+    systematically exfiltrates sensitive data including SSH keys, AWS/GCP/Azure cloud credentials,
+    Kubernetes secrets, environment variables, database configs, crypto wallets, SSL private keys,
+    CI/CD secrets, git credentials, and shell history. In Kubernetes environments, it deploys privileged
+    pods across all cluster nodes using stolen service account tokens. The attack was discovered when the
+    malicious .pth file triggered a fork bomb (exponential subprocess spawning) due to an attacker coding bug.
+    The last clean version is v1.82.6.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    Immediately run 'pip show litellm' to check your installed version.
+    If version is 1.82.7 or 1.82.8, treat all credentials on the host as compromised and rotate immediately:
+    SSH keys, cloud credentials (AWS/GCP/Azure), API keys (env vars), database passwords, git tokens, CI/CD secrets.
+    Upgrade to litellm >= 1.82.9 or the latest stable release. Audit all dependent packages that may have
+    auto-installed the compromised version.
+  references:
+    - https://github.com/BerriAI/litellm
+    - https://pypi.org/project/litellm/
+    - https://x.com/karpathy/status/1904178715882086741
+rule: version >= "1.82.7" && version <= "1.82.8"
+references:
+  - https://github.com/BerriAI/litellm
+  - https://pypi.org/project/litellm/
+  - https://x.com/karpathy/status/1904178715882086741

--- a/data/vuln_en/new-api/CVE-2026-30886.yaml
+++ b/data/vuln_en/new-api/CVE-2026-30886.yaml
@@ -1,0 +1,23 @@
+info:
+  name: new-api
+  cve: CVE-2026-30886
+  summary: New API VideoProxy IDOR - Cross-user video content access via missing ownership check
+  details: >-
+    New API LLM gateway prior to v0.11.4-alpha.2 contains an Insecure Direct Object Reference (IDOR)
+    vulnerability in the video proxy endpoint (GET /v1/videos/:task_id/content). Any authenticated user
+    can access video content belonging to other users by supplying an arbitrary task_id. Additionally,
+    the server authenticates to upstream AI providers (Google Gemini, OpenAI) using credentials derived
+    from tasks they do not own, causing credential abuse across tenant boundaries.
+    Missing authorization check on task ownership allows horizontal privilege escalation.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: Upgrade New API to v0.11.4-alpha.2 or later. The fix adds ownership verification
+    before serving video proxy content.
+  references:
+    - https://github.com/QuantumNous/new-api/security/advisories/GHSA-f35r-v9x5-r8mc
+    - https://github.com/QuantumNous/new-api/commit/50ec2bac6b341e651fc9ac4344e3bd2cdaeafdbd
+    - https://github.com/advisories/GHSA-f35r-v9x5-r8mc
+rule: version < "0.11.4-alpha.2"
+references:
+  - https://github.com/QuantumNous/new-api/security/advisories/GHSA-f35r-v9x5-r8mc
+  - https://github.com/QuantumNous/new-api/commit/50ec2bac6b341e651fc9ac4344e3bd2cdaeafdbd

--- a/data/vuln_en/new-api/CVE-2026-32879.yaml
+++ b/data/vuln_en/new-api/CVE-2026-32879.yaml
@@ -1,0 +1,22 @@
+info:
+  name: new-api
+  cve: CVE-2026-32879
+  summary: New API Passkey Secure Verification Bypass - Root-only channel secret disclosure
+  details: >-
+    New API LLM gateway starting from v0.10.0 contains a logic flaw in the universal secure
+    verification flow. An authenticated user with a registered passkey can satisfy step-up
+    secure verification without actually completing a WebAuthn assertion challenge.
+    This bypass allows an attacker with a valid account and any registered passkey to access
+    root-only privileged operations such as viewing channel secrets (API keys for upstream
+    AI providers), leading to credential disclosure. As of disclosure, no patched version
+    is available. The vulnerability affects all deployments with passkey authentication enabled.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N
+  severity: MEDIUM
+  security_advise: Disable passkey as the step-up verification method for privileged secure-verification
+    actions until a patched release is available. Monitor for unauthorized access to channel secrets.
+  references:
+    - https://github.com/QuantumNous/new-api/security/advisories/GHSA-5353-f8fq-65vc
+    - https://github.com/advisories/GHSA-5353-f8fq-65vc
+rule: version >= "0.10.0"
+references:
+  - https://github.com/QuantumNous/new-api/security/advisories/GHSA-5353-f8fq-65vc


### PR DESCRIPTION
## 本次新增规则

### 新增指纹（2个）
- `new-api.yaml` — New API LLM 网关（FOFA 验证通过）
- `blinko.yaml` — Blinko AI 笔记（FOFA 精准率 100%，2733 个资产）

### 新增漏洞规则（6条，EN+CN）

**new-api**
- `CVE-2026-30886` MEDIUM — VideoProxy IDOR 越权访问其他用户视频，修复版 v0.11.4-alpha.2
- `CVE-2026-32879` MEDIUM — Passkey 二次验证绕过泄露渠道密钥，暂无修复版本

**langflow**
- `CVE-2026-33484` HIGH — 未授权 IDOR 图片下载越权，修复版 v1.9.0
- `CVE-2026-33497` HIGH — 路径遍历泄露 secret_key，修复版 v1.7.1

**litellm**
- `SUPPLY-CHAIN-2025-LITELLM` CRITICAL — PyPI 供应链投毒（v1.82.7/1.82.8），干净版本 v1.82.6

**blinko**
- `CVE-2026-23882` HIGH — MCP Server 任意命令执行 RCE，修复版 v1.8.4