### PR TITLE
fix: rename LiteLLM vuln directory to match fingerprint name casing

### DIFF
--- a/data/vuln/LiteLLM/SUPPLY-CHAIN-2025-LITELLM.yaml
+++ b/data/vuln/LiteLLM/SUPPLY-CHAIN-2025-LITELLM.yaml
@@ -1,5 +1,5 @@
 info:
-  name: litellm
+  name: LiteLLM
   cve: SUPPLY-CHAIN-2025-LITELLM
   summary: LiteLLM PyPI 供应链投毒攻击 - 恶意包注入（v1.82.7/v1.82.8）
   details: >-

--- a/data/vuln_en/LiteLLM/SUPPLY-CHAIN-2025-LITELLM.yaml
+++ b/data/vuln_en/LiteLLM/SUPPLY-CHAIN-2025-LITELLM.yaml
@@ -1,5 +1,5 @@
 info:
-  name: litellm
+  name: LiteLLM
   cve: SUPPLY-CHAIN-2025-LITELLM
   summary: LiteLLM PyPI Supply Chain Attack - Malicious Package Injection (v1.82.7/v1.82.8)
   details: >-


### PR DESCRIPTION
## 问题

`data/vuln/litellm/` 和 `data/vuln_en/litellm/` 目录使用小写，但 AIG 指纹文件中 `name: LiteLLM`（大写 L），大小写不一致导致扫描时规则无法关联指纹，漏洞检测失效。

## 修复

将目录从 `litellm/` 重命名为 `LiteLLM/`，并将规则文件中 `name` 字段统一为 `LiteLLM`，与指纹保持一致。

## 变更

- `data/vuln/litellm/` → `data/vuln/LiteLLM/`
- `data/vuln_en/litellm/` → `data/vuln_en/LiteLLM/`