### PR TITLE
docs: replace remaining AIG with A.I.G brand name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 ## 🚀 What's New in v4.1.1: LiteLLM Supply Chain Attack Detection
 
-- ☠️ **LiteLLM Supply Chain Attack** *(CRITICAL)*: AIG now detects compromised LiteLLM v1.82.7/v1.82.8 — if installed, all credentials on the host should be considered stolen. [Release Notes →](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.1)
+- ☠️ **LiteLLM Supply Chain Attack** *(CRITICAL)*: A.I.G now detects compromised LiteLLM v1.82.7/v1.82.8 — if installed, all credentials on the host should be considered stolen. [Release Notes →](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.1)
 - 🔍 **New Component Coverage**: Added fingerprints and vulnerability rules for Blinko and New-API
 - 🐛 **Bug Fix**: Mask token fields in GetTaskDetail API response to prevent credential leakage
 
@@ -168,7 +168,7 @@ Experience the Pro version with advanced features and improved performance. The 
 ## 🖼️ Showcase
 
 ### A.I.G Main Interface
-![AIG Main Page](img/aig.gif)
+![A.I.G Main Page](img/aig.gif)
 
 ### Plugin Management
 ![Plugin Management](img/plugin-gif.gif)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -49,7 +49,7 @@
 
 ## 🚀 A.I.G v4.1.1：LiteLLM 供应链攻击检测
 
-- ☠️ **LiteLLM 供应链投毒** *(CRITICAL)*：AIG 现可检测受感染的 LiteLLM v1.82.7/v1.82.8——若已安装，视该机器上所有凭证已泄露。[查看发布说明 →](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.1)
+- ☠️ **LiteLLM 供应链投毒** *(CRITICAL)*：A.I.G 现可检测受感染的 LiteLLM v1.82.7/v1.82.8——若已安装，视该机器上所有凭证已泄露。[查看发布说明 →](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.1)
 - 🔍 **新增组件覆盖**：新增 Blinko、New-API 的指纹识别和漏洞检测规则
 - 🐛 **安全修复**：GetTaskDetail 接口响应中对 token 字段做脱敏处理，防止凭证泄露
 
@@ -163,7 +163,7 @@ docker-compose up -d
 ## 🖼️ 功能展示
 
 ### A.I.G 主界面
-![AIG主界面](img/aig-zh.gif)
+![A.I.G主界面](img/aig-zh.gif)
 
 ![插件管理](img/plugin-zh.gif)
 


### PR DESCRIPTION
## 变更说明

修正 README.md 和 README_ZH.md 中遗漏的品牌名称拼写。

### 修复内容

**README.md**
- `AIG now detects...` → `A.I.G now detects...`
- `![AIG Main Page]` → `![A.I.G Main Page]`

**README_ZH.md**
- `AIG 现可检测...` → `A.I.G 现可检测...`
- `![AIG主界面]` → `![A.I.G主界面]`

> 规则：文档正文中产品名一律写 `A.I.G`，目录路径/仓库名/变量名等技术标识符除外。