### PR TITLE
fix: correct KubePi fingerprint info.name case mismatch

### DIFF
--- a/data/fingerprints/kubepi.yaml
+++ b/data/fingerprints/kubepi.yaml
@@ -1,5 +1,5 @@
 info:
-  name: kubepi
+  name: KubePi
   author: 腾讯朱雀实验室
   severity: info
   desc: 一个CLI工具，简化在Raspberry Pi设备上设置和管理Kubeflow的环境。


### PR DESCRIPTION
## 问题

`data/fingerprints/kubepi.yaml` 的 `info.name` 字段值为 `kubepi`（全小写），但 `data/vuln/kubepi/` 下全部 10 条漏洞规则的 `info.name` 均为 `KubePi`。

扫描引擎通过以下逻辑关联指纹与漏洞：
```go
advisories, err := r.advEngine.GetAdvisories(item.Name, item.Version, isInternal)
// item.Name = 指纹 info.name
// GetAdvisories 内部: ad.Info.FingerPrintName != packageName（精确匹配）
```
大小写不一致导致扫描时已识别的 KubePi 实例**无法关联任何漏洞规则**。

## 修改

**仅修改 1 个文件，1 行：**

```diff
- name: kubepi
+ name: KubePi
```

修改后 `info.name` 与全部 10 条漏洞规则一致，扫描引擎可正确关联。