### PR TITLE
fix: align fingerprint info.name with vuln rule info.name (5 products)

### DIFF
--- a/data/fingerprints/ai-chatbot.yaml
+++ b/data/fingerprints/ai-chatbot.yaml
@@ -1,5 +1,5 @@
 info:
-  name: anythingllm
+  name: ai-chatbot
   author: 腾讯朱雀实验室
   severity: info
   metadata:

--- a/data/fingerprints/kubepi.yaml
+++ b/data/fingerprints/kubepi.yaml
@@ -1,5 +1,5 @@
 info:
-  name: kubepi
+  name: KubePi
   author: 腾讯朱雀实验室
   severity: info
   desc: 一个CLI工具，简化在Raspberry Pi设备上设置和管理Kubeflow的环境。

--- a/data/fingerprints/openclaw.yaml
+++ b/data/fingerprints/openclaw.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   author: A.I.G bot
   severity: info
   desc: OpenClaw is a personal AI assistant platform with tool-use, skill management, and gateway service.

--- a/data/fingerprints/openwebui.yaml
+++ b/data/fingerprints/openwebui.yaml
@@ -1,5 +1,5 @@
 info:
-  name: open-webui
+  name: openwebui
   author: 腾讯朱雀实验室
   severity: info
   desc: 一个开源、自托管的AI平台，提供用户友好的本地运行大语言模型的界面，支持Ollama等运行器。

--- a/data/vuln/lobechat/CVE-2025-55182.yaml
+++ b/data/vuln/lobechat/CVE-2025-55182.yaml
@@ -1,5 +1,5 @@
 info:
-  name: lobechat
+  name: LobeChat
   cve: CVE-2025-55182
   summary: LobeChat 因 React 服务器函数中不安全的原型引用而存在远程代码执行 (RCE) 漏洞。
   details: |

--- a/data/vuln/openclaw/CVE-2026-22168.yaml
+++ b/data/vuln/openclaw/CVE-2026-22168.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22168
   summary: OpenClaw Windows system.run 审批不匹配（cmd.exe /c 尾随空格绕过）
   details: OpenClaw 2026.2.23 之前版本在 Windows 上存在 system.run 审批不匹配漏洞，攻击者可通过在 cmd.exe

--- a/data/vuln/openclaw/CVE-2026-22169.yaml
+++ b/data/vuln/openclaw/CVE-2026-22169.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22169
   summary: OpenClaw 非默认 safeBins 排序配置可绕过预期的执行限制
   details: OpenClaw 2026.2.23 之前版本中，非默认的 safeBins 排序配置可被绕过，导致预期的执行限制失效。

--- a/data/vuln/openclaw/CVE-2026-22170.yaml
+++ b/data/vuln/openclaw/CVE-2026-22170.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22170
   summary: OpenClaw BlueBubbles（可选插件）配对/白名单不匹配可通过硬重置绕过
   details: OpenClaw 2026.2.23 之前版本中，BlueBubbles（可选插件）存在配对/白名单不匹配漏洞，攻击者可通过硬重置绕过设备白名单限制。

--- a/data/vuln/openclaw/CVE-2026-22171.yaml
+++ b/data/vuln/openclaw/CVE-2026-22171.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22171
   summary: openclaw 飞书媒体文件临时路径命名存在路径遍历漏洞，可写入 os.tmpdir() 外的文件
   details: OpenClaw 2026.2.19 之前版本在飞书媒体下载流程中存在路径遍历漏洞，extensions/feishu/src/media.ts

--- a/data/vuln/openclaw/CVE-2026-22174.yaml
+++ b/data/vuln/openclaw/CVE-2026-22174.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22174
   summary: OpenClaw Loopback CDP 探测可向本地监听器泄露 Gateway 令牌
   details: OpenClaw 2026.2.21 之前版本中，Loopback CDP 探测功能可向本地监听器泄露 Gateway 令牌，导致敏感凭据暴露。

--- a/data/vuln/openclaw/CVE-2026-22175.yaml
+++ b/data/vuln/openclaw/CVE-2026-22175.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22175
   summary: openclaw 白名单模式下 exec 永久许可可通过未识别的多路复用 shell 包装器（busybox/toybox sh -c）绕过
   details: OpenClaw 2026.2.23 之前版本在白名单模式下存在 exec 审批绕过漏洞，攻击者可通过未被识别的多路复用 shell

--- a/data/vuln/openclaw/CVE-2026-22177.yaml
+++ b/data/vuln/openclaw/CVE-2026-22177.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22177
   summary: OpenClaw 的配置环境变量允许启动环境注入到服务运行时
   details: OpenClaw 2026.2.23 之前版本允许通过配置环境变量将启动环境注入到服务运行时，可能导致权限提升或配置篡改。

--- a/data/vuln/openclaw/CVE-2026-22178.yaml
+++ b/data/vuln/openclaw/CVE-2026-22178.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22178
   summary: OpenClaw 在处理未转义的飞书 mention 元数据时存在 ReDoS 和正则注入
   details: OpenClaw 2026.2.21 之前版本在处理未转义的飞书 mention 元数据时存在正则表达式拒绝服务（ReDoS）和正则注入漏洞。

--- a/data/vuln/openclaw/CVE-2026-22179.yaml
+++ b/data/vuln/openclaw/CVE-2026-22179.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22179
   summary: OpenClaw macOS system.run 白名单通过引号命令替换绕过
   details: OpenClaw 2026.2.23 之前版本在 macOS 上存在 system.run 白名单绕过漏洞，攻击者可通过引号命令替换技巧绕过白名单限制。

--- a/data/vuln/openclaw/CVE-2026-22180.yaml
+++ b/data/vuln/openclaw/CVE-2026-22180.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22180
   summary: OpenClaw 统一根边界写入加固（浏览器输出和相关路径）
   details: OpenClaw 2026.2.22 之前版本缺少统一的根边界写入加固机制，浏览器输出和相关路径可能写入非预期位置。

--- a/data/vuln/openclaw/CVE-2026-22181.yaml
+++ b/data/vuln/openclaw/CVE-2026-22181.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22181
   summary: OpenClaw web 工具严格 URL 守卫在环境探测禁用时可能丢失 DNS 固定
   details: OpenClaw 2026.2.21 之前版本中，web 工具的严格 URL 守卫在环境探测禁用时可能丢失 DNS 固定（DNS pinning），导致

--- a/data/vuln/openclaw/CVE-2026-22217.yaml
+++ b/data/vuln/openclaw/CVE-2026-22217.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22217
   summary: OpenClaw shell-env trusted-prefix 回退允许攻击者控制的环境注入
   details: OpenClaw 2026.2.25 之前版本中，shell-env 的 trusted-prefix 回退机制允许攻击者控制的环境注入到受信任的上下文。

--- a/data/vuln/openclaw/CVE-2026-27522.yaml
+++ b/data/vuln/openclaw/CVE-2026-27522.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27522
   summary: OpenClaw 消息操作附件水合绕过本地媒体根边界
   details: OpenClaw 2026.3.1 之前版本中，消息操作附件水合（hydration）流程可绕过本地媒体根路径边界，导致路径遍历。

--- a/data/vuln/openclaw/CVE-2026-27523.yaml
+++ b/data/vuln/openclaw/CVE-2026-27523.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27523
   summary: OpenClaw 沙箱绑定验证可绕过 allowed-root 和阻止路径检查
   details: OpenClaw 2026.3.1 之前版本中，沙箱绑定验证逻辑存在缺陷，可绕过 allowed-root 和阻止路径检查。

--- a/data/vuln/openclaw/CVE-2026-27524.yaml
+++ b/data/vuln/openclaw/CVE-2026-27524.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27524
   summary: OpenClaw 运行时 /debug 覆盖路径接受原型保留键导致污染
   details: OpenClaw 2026.3.1 之前版本中，运行时 /debug 覆盖路径接受原型保留键（如 __proto__），导致原型污染风险。

--- a/data/vuln/openclaw/CVE-2026-27545.yaml
+++ b/data/vuln/openclaw/CVE-2026-27545.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27545
   summary: OpenClaw Node system.run 审批通过父符号链接 cwd 重绑定绕过
   details: OpenClaw 2026.3.1 之前版本在 Node 环境下，system.run 审批可通过父符号链接的 cwd 重绑定绕过。

--- a/data/vuln/openclaw/CVE-2026-30741.yaml
+++ b/data/vuln/openclaw/CVE-2026-30741.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-30741
   summary: OpenClaw Agent 平台 agent 任务执行中的请求侧提示词注入导致 RCE
   details: >-

--- a/data/vuln/openclaw/CVE-2026-32038.yaml
+++ b/data/vuln/openclaw/CVE-2026-32038.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32038
   summary: OpenClaw 沙箱网络隔离绕过漏洞（docker.network=container:<id>）
   details: >-

--- a/data/vuln/openclaw/CVE-2026-32059.yaml
+++ b/data/vuln/openclaw/CVE-2026-32059.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32059
   summary: OpenClaw tools.exec.safeBins 白名单绕过漏洞（sort 命令 GNU 长选项缩写）
   details: >-

--- a/data/vuln/openclaw/CVE-2026-32060.yaml
+++ b/data/vuln/openclaw/CVE-2026-32060.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32060
   summary: OpenClaw apply_patch 路径穿越漏洞（任意文件写入/删除）
   details: >-

--- a/data/vuln/openclaw/CVE-2026-32061.yaml
+++ b/data/vuln/openclaw/CVE-2026-32061.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32061
   summary: OpenClaw $include 指令路径穿越漏洞（任意本地文件读取）
   details: >-

--- a/data/vuln/openclaw/CVE-2026-32062.yaml
+++ b/data/vuln/openclaw/CVE-2026-32062.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32062
   summary: OpenClaw 及 @openclaw/voice-call 未授权 WebSocket DoS 漏洞（流升级前置验证缺失）
   details: >-

--- a/data/vuln/openclaw/CVE-2026-32063.yaml
+++ b/data/vuln/openclaw/CVE-2026-32063.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32063
   summary: OpenClaw systemd 单元文件生成中的 CR/LF 注入命令执行漏洞
   details: >-

--- a/data/vuln/openclaw/CVE-2026-32302.yaml
+++ b/data/vuln/openclaw/CVE-2026-32302.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32302
   summary: OpenClaw 在 trusted-proxy 模式下 WebSocket 来源验证绕过，允许未授权建立特权 operator 会话
   details: >-

--- a/data/vuln/openclaw/CVE-2026-4039.yaml
+++ b/data/vuln/openclaw/CVE-2026-4039.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-4039
   summary: OpenClaw Skill Env Handler applySkillConfigenvOverrides 代码注入漏洞
   details: >-

--- a/data/vuln/openclaw/CVE-2026-4040.yaml
+++ b/data/vuln/openclaw/CVE-2026-4040.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-4040
   summary: OpenClaw tools.exec.safeBins 文件存在性信息泄露漏洞（差异侧信道）
   details: >-

--- a/data/vuln_en/lobechat/CVE-2025-55182.yaml
+++ b/data/vuln_en/lobechat/CVE-2025-55182.yaml
@@ -1,5 +1,5 @@
 info:
-  name: lobechat
+  name: LobeChat
   cve: CVE-2025-55182
   summary: LobeChat is vulnerable to Remote Code Execution (RCE) due to insecure prototype references in React server functions.
   details: |

--- a/data/vuln_en/openclaw/CVE-2026-22168.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22168.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22168
   summary: openclaw OpenClaw has Windows system.run approval mismatch on cmd.exe /c trailing arguments
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22169.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22169.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22169
   summary: openclaw OpenClaw's non-default safeBins sort configuration can bypass intended allowlist approval constraints
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22170.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22170.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22170
   summary: 'openclaw OpenClaw: BlueBubbles (optional plugin) pairing/allowlist mismatch when allowFrom is empty'
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22171.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22171.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22171
   summary: openclaw OpenClaw vulnerable to path traversal in Feishu media temp-file naming allows writes outside os.tmpdir()
   details: OpenClaw versions prior to 2026.2.19 contain a path traversal vulnerability in the Feishu media download flow where

--- a/data/vuln_en/openclaw/CVE-2026-22174.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22174.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22174
   summary: openclaw OpenClaw Loopback CDP probe can leak Gateway token to local listener
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22175.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22175.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22175
   summary: openclaw OpenClaw's exec allow-always can be bypassed via unrecognized multiplexer shell wrappers (busybox/toybox
     sh -c)

--- a/data/vuln_en/openclaw/CVE-2026-22177.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22177.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22177
   summary: openclaw OpenClaw's config env vars allowed startup env injection into service runtime
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22178.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22178.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22178
   summary: openclaw OpenClaw has ReDoS and regex injection via unescaped Feishu mention metadata in RegExp construction
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22179.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22179.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22179
   summary: openclaw OpenClaw has macOS `system.run` allowlist bypass via quoted command substitution
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22180.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22180.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22180
   summary: 'openclaw OpenClaw: Unified root-bound write hardening for browser output and related path-boundary flows'
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22181.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22181.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22181
   summary: openclaw OpenClaw's web tools strict URL guard could lose DNS pinning when env proxy is configured
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-22217.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-22217.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-22217
   summary: 'openclaw OpenClaw: shell-env trusted-prefix fallback allowed attacker-controlled binary execution via $SHELL'
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-27522.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27522.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27522
   summary: 'openclaw OpenClaw: Message action attachment hydration bypasses local media root checks when sandboxRoot is unset'
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-27523.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27523.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27523
   summary: openclaw OpenClaw's sandbox bind validation could bypass allowed-root and blocked-path checks via symlink-parent
     missing-leaf paths

--- a/data/vuln_en/openclaw/CVE-2026-27524.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27524.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27524
   summary: openclaw OpenClaw's runtime /debug override path accepted prototype-reserved keys
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-27545.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-27545.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-27545
   summary: 'openclaw OpenClaw: Node system.run approval bypass via parent-symlink cwd rebind'
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-30741.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-30741.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-30741
   summary: OpenClaw Agent Platform RCE via request-side prompt injection in agent task execution
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-32038.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32038.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32038
   summary: OpenClaw sandbox network isolation bypass via docker.network=container:<id>
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-32059.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32059.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32059
   summary: OpenClaw tools.exec.safeBins Allowlist Bypass via GNU Long-Option Abbreviation in sort Command
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-32060.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32060.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32060
   summary: OpenClaw apply_patch Path Traversal Allowing Arbitrary File Write/Delete Outside Workspace
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-32061.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32061.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32061
   summary: OpenClaw $include Directive Path Traversal Allowing Arbitrary Local File Read
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-32062.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32062.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32062
   summary: OpenClaw and @openclaw/voice-call Unauthenticated WebSocket DoS via Pre-validation Stream Upgrade
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-32063.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32063.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32063
   summary: OpenClaw Command Injection via CR/LF Injection in systemd Unit File Generation
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-32302.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-32302.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-32302
   summary: OpenClaw WebSocket origin bypass in trusted-proxy mode enables unauthorized privileged operator session
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-4039.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-4039.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-4039
   summary: OpenClaw applySkillConfigenvOverrides Skill Env Handler Code Injection
   details: >-

--- a/data/vuln_en/openclaw/CVE-2026-4040.yaml
+++ b/data/vuln_en/openclaw/CVE-2026-4040.yaml
@@ -1,5 +1,5 @@
 info:
-  name: openclaw
+  name: OpenClaw
   cve: CVE-2026-4040
   summary: OpenClaw tools.exec.safeBins File Existence Information Disclosure via Timing Discrepancy
   details: >-


### PR DESCRIPTION
## 问题背景

扫描引擎通过**精确字符串匹配**将指纹结果与漏洞规则关联：

```go
// pkg/vulstruct/advisory.go
func (ae *AdvisoryEngine) GetAdvisories(packageName string, ...) {
    for _, ad := range ae.ads {
        if ad.Info.FingerPrintName != packageName { // 精确匹配，区分大小写
            continue
        }
    }
}
// packageName 来自指纹的 fp.Info.Name（即 info.name 字段）
```

`指纹 info.name` ≠ `漏洞规则 info.name` → 扫到产品但**报不出任何漏洞**。

注：`metadata.product` / `metadata.vendor` 为人类可读元数据，引擎不使用，不在本 PR 修改范围内。

## 修改详情（58 个文件，均为单字段 info.name 修改）

### 1. ai-chatbot 指纹（1 个文件）

`data/fingerprints/ai-chatbot.yaml`：`info.name: anythingllm` → `ai-chatbot`

**原因**：`anythingllm` 已有独立指纹文件（`anythingllm.yaml`），`ai-chatbot.yaml` 是另一个产品，name 字段填错了。全部 2 条漏洞规则使用 `ai-chatbot`。

### 2. lobechat 漏洞规则（2 个文件）

`data/vuln/lobechat/CVE-2025-55182.yaml`、`data/vuln_en/lobechat/CVE-2025-55182.yaml`：`name: lobechat` → `LobeChat`

**原因**：指纹 `info.name` 为 `LobeChat`，其余 4/6 条规则已正确使用 `LobeChat`，这 2 条为漏网之鱼。

### 3. openwebui 指纹（1 个文件）

`data/fingerprints/openwebui.yaml`：`info.name: open-webui` → `openwebui`

**原因**：全部 2 条漏洞规则使用 `openwebui`（无连字符），改指纹对齐多数，改动最小。

### 4. kubepi 指纹（1 个文件）

`data/fingerprints/kubepi.yaml`：`info.name: kubepi` → `KubePi`

**原因**：全部 10 条漏洞规则使用 `KubePi`，指纹全小写不匹配。

### 5. openclaw（53 个文件）

- `data/fingerprints/openclaw.yaml`：`info.name: openclaw` → `OpenClaw`
- `data/vuln/openclaw/` 26 条规则：`name: openclaw` → `OpenClaw`
- `data/vuln_en/openclaw/` 26 条规则：`name: openclaw` → `OpenClaw`

**原因**：562 条规则中 510 条（91%）已使用 `OpenClaw`（产品官方名称），52 条少数派 + 指纹统一对齐。

## 影响范围

- **58 个文件**，每处仅修改 `info.name` 字段 1 行
- 不涉及检测逻辑、matcher、版本规则等
- 修复后 5 个产品的漏洞扫描结果可正常输出