### PR TITLE
docs: refine OpenClaw aig-scanner install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ Once the service is running, you can access the A.I.G web interface at:
 `http://localhost:8088`
 <br>
 
+### Use from OpenClaw
+
+You can also call A.I.G directly from OpenClaw chat via the `aig-scanner` skill.
+
+```bash
+clawhub install aig-scanner
+```
+
+Then configure `AIG_BASE_URL` to point to your running A.I.G service.
+
+For more details, see [OpenClaw integration](./integrations/openclaw/README.md).
+
 <details>
 <summary><strong>📦 More installation options</strong></summary>
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -107,6 +107,18 @@ docker-compose -f docker-compose.images.yml up -d
 `http://localhost:8088`
 <br>
 
+### 在 OpenClaw 中使用
+
+你也可以通过 OpenClaw 的 `aig-scanner` skill 直接调用 A.I.G 服务。
+
+```bash
+clawhub install aig-scanner
+```
+
+然后将 `AIG_BASE_URL` 配置为正在运行的 A.I.G 服务地址。
+
+更多说明见：[OpenClaw 集成文档](./integrations/openclaw/README.zh-CN.md)
+
 <details>
 <summary><strong>📦 更多安装方式</strong></summary>
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -8,10 +8,8 @@ Invoke all [A.I.G (AI-Infra-Guard)](https://github.com/Tencent/AI-Infra-Guard/) 
 
 ### Install
 
-In OpenClaw chat, say:
-
-```text
-Install A.I.G Scanner from ClawHub
+```bash
+clawhub install aig-scanner
 ```
 
 Alternative:
@@ -20,8 +18,6 @@ Alternative:
 Install this skill from source:
 https://github.com/Tencent/AI-Infra-Guard/tree/main/integrations/openclaw/aig-scanner
 ```
-
-Manual fallback path: `~/.openclaw/skills/aig-scanner/`
 
 ### Usage
 

--- a/integrations/openclaw/README.zh-CN.md
+++ b/integrations/openclaw/README.zh-CN.md
@@ -8,10 +8,8 @@
 
 ### 安装
 
-在 OpenClaw 对话里直接说：
-
-```text
-从 ClawHub 安装 A.I.G Scanner
+```bash
+clawhub install aig-scanner
 ```
 
 备选方案：
@@ -20,8 +18,6 @@
 从这个源码目录安装 skill：
 https://github.com/Tencent/AI-Infra-Guard/tree/main/integrations/openclaw/aig-scanner
 ```
-
-手动回退目录：`~/.openclaw/skills/aig-scanner/`
 
 ### 使用
 


### PR DESCRIPTION
## Summary

- add a short OpenClaw entry to the main README and README_ZH
- simplify `integrations/openclaw` install guidance to two paths only: ClawHub and source-directory install
- keep `aig-scanner` source-first and remove release/archive assumptions from the docs

## Validation

- `python3 -m py_compile integrations/openclaw/aig-scanner/scripts/aig_client.py`
