### PR TITLE
fix: restore bundled data on container startup for cross-platform Docker support (issue #119)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,11 @@ COPY --from=builder /app/ai-infra-guard .
 COPY --from=builder /app/trpc_go.yaml .
 COPY --from=builder /app/CHANGELOG.md .
 
-# 复制数据文件到容器中
+# Copy data files into container
+# Also keep a bundled backup so start.sh can restore missing files
+# when the host volume mount (macOS/Windows Docker Desktop) overwrites /app/data
 COPY --from=builder /app/data ./data
+COPY --from=builder /app/data ./data_bundled
 
 # 复制agent-scan目录并安装Python依赖
 COPY ./agent-scan /app/agent-scan

--- a/start.sh
+++ b/start.sh
@@ -10,18 +10,42 @@ warn_or_continue() { echo "Warning: $1" >&2; }
 
 echo 正在初始化 AI-Infra-Guard 服务...
 # 创建必要的目录
-mkdir -p /ai-infra-guard/db /ai-infra-guard/uploads /ai-infra-guard/logs
+mkdir -p /app/db /app/uploads /app/logs
+
+# ── Cross-platform data init ──────────────────────────────────────────────────
+# On macOS/Windows Docker Desktop, volume mounts (./data:/app/data) overwrite
+# the files that were baked into the image during build, leaving /app/data/mcp
+# empty and causing "no plugins loaded" errors (GitHub issue #119).
+#
+# Fix: the Dockerfile keeps a bundled copy at /app/data_bundled.
+# At startup we do a one-way rsync/cp that only fills in *missing* files,
+# so user-added plugins are never deleted.
+if [ -d "/app/data_bundled" ]; then
+  echo "Checking bundled data files..."
+  # Use cp -n (no-clobber) to copy bundled files without overwriting existing ones.
+  # Works on both Alpine (busybox cp) and standard GNU/BSD cp.
+  find /app/data_bundled -type f | while read src; do
+    rel="${src#/app/data_bundled/}"
+    dst="/app/data/${rel}"
+    if [ ! -f "$dst" ]; then
+      mkdir -p "$(dirname "$dst")"
+      cp "$src" "$dst"
+    fi
+  done
+  echo "Bundled data sync complete."
+fi
+# ─────────────────────────────────────────────────────────────────────────────
 
 # 设置文件权限
 echo 设置文件权限...
-chmod 755 /ai-infra-guard/db || warn_or_continue "Skip permission change on mounted volume"
-chmod 755 /ai-infra-guard/uploads || warn_or_continue "Skip permission change on mounted volume"
-chmod 755 /ai-infra-guard/logs || warn_or_continue "Skip permission change on mounted volume"
+chmod 755 /app/db || warn_or_continue "Skip permission change on mounted volume"
+chmod 755 /app/uploads || warn_or_continue "Skip permission change on mounted volume"
+chmod 755 /app/logs || warn_or_continue "Skip permission change on mounted volume"
 
 # 创建日志文件
 echo 初始化日志文件...
-touch /ai-infra-guard/logs/trpc.log
-chmod 644 /ai-infra-guard/logs/trpc.log
+touch /app/logs/trpc.log
+chmod 644 /app/logs/trpc.log
 
 echo 启动AI-Infra-Guard Web 服务...
 exec ./ai-infra-guard webserver --server 0.0.0.0:8088


### PR DESCRIPTION
## Problem

On macOS and Windows, Docker Desktop volume mounts (`./data:/app/data`) overwrite the files baked into the image during build. This leaves `/app/data/mcp` empty and causes the plugin list to appear empty — while the same setup works fine on Linux (issue #119).

## Root Cause

The `Dockerfile` bakes `data/` into the image, but then `docker-compose.yml` mounts the host `./data` directory over `/app/data` at runtime. On Docker Desktop (macOS/Windows), an empty or non-existent host directory results in an empty mount rather than merging with image contents.

Additionally, `start.sh` was referencing `/ai-infra-guard/` paths which do not exist; the correct working directory is `/app`.

## Fix

**`Dockerfile`**: Add a second `COPY` of `data/` to `/app/data_bundled/` as a read-only reference that is never overwritten by volume mounts.

**`start.sh`**: At container startup, scan `data_bundled/` and copy any missing files into `/app/data` (no-clobber: existing files are never overwritten, so user-added plugins are preserved).

**`start.sh`**: Also corrects the working directory path from `/ai-infra-guard/` → `/app/`.

## Testing

- Linux: `/app/data/mcp` already populated → bundled sync skips all files (no-op)
- macOS/Windows: `/app/data/mcp` is empty after mount → bundled sync fills in all plugin YAML files automatically

Fixes #119