### PR TITLE
fix(fingerprint): add version extractor to openclaw fingerprint

### DIFF
--- a/data/fingerprints/openclaw.yaml
+++ b/data/fingerprints/openclaw.yaml
@@ -11,3 +11,10 @@ http:
     path: '/'
     matchers:
       - body="<openclaw-app>" || body="<title>OpenClaw Control</title>" || body="<title>Clawdbot Control</title>"
+version:
+  - method: GET
+    path: '/__openclaw/control-ui-config.json'
+    extractor:
+      part: body
+      group: 1
+      regex: '"serverVersion":\s?"([\d.]+[^"]*)"'


### PR DESCRIPTION
## Problem

Fixes #286

The `data/fingerprints/openclaw.yaml` fingerprint was missing a `version:` extraction block. When AIG cannot detect the installed version, the advisory engine falls back to returning **all** vulnerability entries regardless of the version rule:

```go
// pkg/vulstruct/advisory.go
if version != "" && ad.Rule != "" {
    // evaluate rule only when both version AND rule exist
} else {
    ret = append(ret, ad)  // version unknown → return ALL vulns
}
```

This caused users to see all ~451 OpenClaw vulnerabilities reported as applicable, regardless of their actual installed version.

## Solution

OpenClaw's control UI HTTP server exposes an unauthenticated JSON endpoint:

```
GET /__openclaw/control-ui-config.json
```

Example response:
```json
{
  "basePath": "",
  "assistantName": "...",
  "assistantAvatar": null,
  "assistantAgentId": null,
  "serverVersion": "2026.4.8"
}
```

This endpoint is served by the control UI HTTP handler and does **not** require authentication. It includes `serverVersion` with the installed OpenClaw version.

## Changes

- Added `version:` extractor block to `data/fingerprints/openclaw.yaml` targeting `/__openclaw/control-ui-config.json`

## Expected result

For a user running OpenClaw `2026.4.5`, the scan will now correctly report only the applicable vulnerabilities (those with `version <= "2026.4.1"` or earlier rules) instead of all 451 entries.