### PR TITLE
fix(vuln): fill empty rule fields and add 13 new CVE rules

### DIFF
--- a/data/vuln/LiteLLM/CVE-2026-35030.yaml
+++ b/data/vuln/LiteLLM/CVE-2026-35030.yaml
@@ -1,0 +1,22 @@
+info:
+  name: litellm
+  cve: CVE-2026-35030
+  summary: LiteLLM OIDC userinfo cache key collision allows authentication bypass
+  details: 'LiteLLM is a proxy server (AI Gateway) to call LLM APIs in OpenAI (or
+    native) format. Prior to 1.83.0, when JWT authentication is enabled (enable_jwt_auth:
+    true), the OIDC userinfo cache uses token[:20] as the cache key. JWT headers produced
+    by the same signing algorithm generate identical first 20 characters. This configuration
+    option is not enabled by default. Most instances are not affected. An unauthenticated
+    attacker can craft a token whose first 20 characters match a legitimate user''s
+    cached token. On cache hit, the attacker inherits the legitimate user''s identity
+    and permissions. This affects deployments with JWT/OIDC authentication enabled.
+    Fixed in v1.83.0.'
+  cvss: ''
+  severity: MEDIUM
+  security_advise: Upgrade LiteLLM to version 1.83.0 or later. If immediate upgrade
+    is not possible, disable JWT authentication (enable_jwt_auth) as a temporary mitigation.
+  references:
+  - https://github.com/BerriAI/litellm/security/advisories/GHSA-jjhc-v7c2-5hh6
+rule: 'version < "1.83.0"'
+references:
+- https://github.com/BerriAI/litellm/security/advisories/GHSA-jjhc-v7c2-5hh6

--- a/data/vuln/crewai/CVE-2026-2275.yaml
+++ b/data/vuln/crewai/CVE-2026-2275.yaml
@@ -1,0 +1,42 @@
+info:
+  name: crewai
+  cve: CVE-2026-2275
+  summary: CrewAI CodeInterpreterTool SandboxPython Fallback Remote Code Execution
+  details: >-
+    The CrewAI CodeInterpreterTool falls back to SandboxPython when Docker is
+    unavailable or unreachable. This fallback environment fails to block the
+    ctypes module and related C-extension mechanisms, allowing arbitrary C
+    function calls that result in Remote Code Execution (RCE). The vulnerability
+    is triggered when: (1) allow_code_execution=True is set in the agent
+    configuration, or (2) the CodeInterpreterTool is manually added to an agent.
+    An attacker who can influence a CrewAI agent via prompt injection can exploit
+    this fallback behavior to escape the intended sandboxed execution context and
+    execute arbitrary code on the host system. This vulnerability is part of a
+    broader set of four CrewAI vulnerabilities (CVE-2026-2275, CVE-2026-2285,
+    CVE-2026-2286, CVE-2026-2287) reported by Yarden Porat of Cyata. The vendor
+    acknowledges the issue and plans to add ctypes and related modules to
+    BLOCKED_MODULES in a future release. No complete patch is available at the
+    time of disclosure (2026-03-30). CWE-749: Exposed Dangerous Method or Function.
+    OSINT: No public PoC or exploit code observed as of 2026-04-03; risk level is
+    moderate given no patch and active community awareness.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    1. Disable the CodeInterpreterTool wherever possible until a patch is released.
+    2. Remove or avoid enabling allow_code_execution=True in agent configuration
+    unless absolutely necessary.
+    3. Ensure Docker is installed and running to prevent fallback to SandboxPython;
+    configure the agent to fail-closed if Docker is unavailable rather than
+    silently falling back.
+    4. Limit agent exposure to untrusted user input and sanitize inputs appropriately.
+    5. Monitor for an updated release of crewai[tools] that adds ctypes and related
+    modules to BLOCKED_MODULES, and upgrade as soon as it is available.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2275
+    - https://www.kb.cert.org/vuls/id/221883
+    - https://docs.crewai.com/en/tools/ai-ml/codeinterpretertool
+rule: 'version <= "1.14.1"'
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-2275
+  - https://www.kb.cert.org/vuls/id/221883
+  - https://docs.crewai.com/en/tools/ai-ml/codeinterpretertool

--- a/data/vuln/crewai/CVE-2026-2286.yaml
+++ b/data/vuln/crewai/CVE-2026-2286.yaml
@@ -1,0 +1,27 @@
+info:
+  name: crewai
+  cve: CVE-2026-2286
+  summary: CrewAI Server-Side Request Forgery (SSRF) allows access to internal and cloud metadata endpoints
+  details: >-
+    CrewAI contains a server-side request forgery (SSRF) vulnerability in its RAG search
+    tool functionality. An attacker can exploit this vulnerability to make the CrewAI
+    server perform HTTP requests to internal network resources and cloud service metadata
+    endpoints (e.g., AWS/GCP/Azure IMDS at 169.254.169.254). This can lead to exposure
+    of sensitive internal services, cloud credentials via metadata APIs, and internal
+    infrastructure reconnaissance. The vulnerability requires no authentication and
+    achieves a CVSS score of 9.8 (CRITICAL).
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    Update CrewAI to the latest available version which includes SSRF mitigations.
+    As a workaround, restrict outbound network access from the CrewAI server to block
+    access to internal network ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+    and cloud metadata endpoints (169.254.169.254). Validate and sanitize all URLs
+    passed to CrewAI RAG search tools before processing.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2286
+    - https://github.com/crewAIInc/crewAI
+rule: 'version <= "1.14.1"'
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-2286
+  - https://github.com/crewAIInc/crewAI

--- a/data/vuln/crewai/CVE-2026-2287.yaml
+++ b/data/vuln/crewai/CVE-2026-2287.yaml
@@ -1,0 +1,33 @@
+info:
+  name: crewai
+  cve: CVE-2026-2287
+  summary: CrewAI Docker runtime check bypass leads to remote code execution via insecure sandbox fallback
+  details: >-
+    CrewAI does not properly verify that Docker is still running during runtime.
+    When Docker becomes unavailable mid-session, the framework silently falls back
+    to an insecure sandbox mode (SandboxPython) that allows for remote code execution
+    (RCE) exploitation. This vulnerability is part of a chain of four vulnerabilities
+    (CVE-2026-2275, CVE-2026-2285, CVE-2026-2286, CVE-2026-2287) disclosed in
+    CrewAI by researcher Yarden Porat of Cyata. An attacker who can interact with
+    a CrewAI agent that has the Code Interpreter Tool enabled (allow_code_execution=True)
+    may exploit this vulnerability through prompt injection to chain these issues and
+    achieve arbitrary code execution on the host. The vendor has acknowledged the issue
+    and plans to fail-closed rather than fall back to sandbox mode in an upcoming release,
+    but no complete patch is available at time of disclosure.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    No complete patch is available at time of disclosure. Mitigations include:
+    (1) Remove or disable the Code Interpreter Tool wherever possible;
+    (2) Avoid enabling allow_code_execution=True unless absolutely necessary;
+    (3) Limit agent exposure to untrusted input or sanitize input appropriately;
+    (4) Monitor Docker availability and prevent fallback to insecure sandbox modes;
+    (5) Monitor the CrewAI project for a patched release that fails closed when
+    Docker is unavailable.
+  references:
+    - https://www.kb.cert.org/vuls/id/221883
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2287
+rule: 'version <= "1.14.1"'
+references:
+  - https://www.kb.cert.org/vuls/id/221883
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-2287

--- a/data/vuln/kubeai/CVE-2026-34940.yaml
+++ b/data/vuln/kubeai/CVE-2026-34940.yaml
@@ -1,0 +1,25 @@
+info:
+  name: kubeai
+  cve: CVE-2026-34940
+  summary: KubeAI Ollama Engine Startup Probe OS Command Injection
+  details: >
+    KubeAI is an AI inference operator for Kubernetes. Prior to version 0.23.2,
+    the ollamaStartupProbeScript() function in internal/modelcontroller/engine_ollama.go
+    constructs a shell command string using fmt.Sprintf with unsanitized model URL
+    components (ref, modelParam). This shell command is executed via bash -c as a
+    Kubernetes startup probe. An attacker who can create or update Model custom resources
+    can inject arbitrary shell commands that execute inside model server pods.
+    This vulnerability is fixed in version 0.23.2.
+  cvss: ''
+  severity: HIGH
+  security_advise: Upgrade KubeAI to version 0.23.2 or later. Restrict RBAC permissions
+    to prevent untrusted users from creating or updating Model custom resources.
+  references:
+    - https://github.com/kubeai-project/kubeai/security/advisories/GHSA-324q-cwx9-7crr
+rule: 'version < "0.23.2"'
+# NOTE: No HTTP-level detection rule is possible for this vulnerability.
+# Exploitation requires Kubernetes RBAC permissions to create/update Model CRDs.
+# Detection requires audit of Kubernetes API server logs for Model resource mutations
+# with suspicious URL patterns (shell metacharacters: ;, |, $(), backticks in spec.url).
+references:
+  - https://github.com/kubeai-project/kubeai/security/advisories/GHSA-324q-cwx9-7crr

--- a/data/vuln/librechat/CVE-2025-41258.yaml
+++ b/data/vuln/librechat/CVE-2025-41258.yaml
@@ -10,7 +10,7 @@ info:
   references:
     - https://github.com/danny-avila/LibreChat
     - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
-rule: ""
+rule: 'version == "0.8.1-rc2"'
 references:
   - https://github.com/danny-avila/LibreChat
   - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass

--- a/data/vuln/librechat/CVE-2026-33265.yaml
+++ b/data/vuln/librechat/CVE-2026-33265.yaml
@@ -10,7 +10,7 @@ info:
   references:
     - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
     - https://www.openwall.com/lists/oss-security/2026/03/18/3
-rule: ""
+rule: 'version == "0.8.1-rc2"'
 references:
   - https://github.com/sbaresearch/advisories/tree/public/2025/SBA-ADV-20251205-01_LibreChat_RAG_API_Authentication_Bypass
   - https://www.openwall.com/lists/oss-security/2026/03/18/3

--- a/data/vuln/librechat/CVE-2026-4276.yaml
+++ b/data/vuln/librechat/CVE-2026-4276.yaml
@@ -10,7 +10,7 @@ info:
   references:
     - https://kb.cert.org/vuls/id/624941
     - https://www.kb.cert.org/vuls/id/624941
-rule: ""
+rule: 'version == "0.7.0"'
 references:
   - https://kb.cert.org/vuls/id/624941
   - https://www.kb.cert.org/vuls/id/624941

--- a/data/vuln/llama-cpp/CVE-2026-33298.yaml
+++ b/data/vuln/llama-cpp/CVE-2026-33298.yaml
@@ -18,7 +18,7 @@ info:
     - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-96jg-mvhq-q7q7
     - https://github.com/ggml-org/llama.cpp/releases/tag/b7824
     - https://nvd.nist.gov/vuln/detail/CVE-2026-33298
-rule: ""
+rule: 'version < "b7824"'
 references:
   - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-96jg-mvhq-q7q7
   - https://nvd.nist.gov/vuln/detail/CVE-2026-33298

--- a/data/vuln/llama-cpp/CVE-2026-34159.yaml
+++ b/data/vuln/llama-cpp/CVE-2026-34159.yaml
@@ -1,0 +1,39 @@
+info:
+  name: llama-cpp
+  cve: CVE-2026-34159
+  summary: llama.cpp RPC Backend Unauthenticated Remote Code Execution via deserialize_tensor() Buffer=0 Bypass
+  details: >-
+    llama.cpp prior to build b8492 contains a critical memory corruption vulnerability in the RPC
+    backend's deserialize_tensor() function. When a tensor's buffer field is set to 0, all bounds
+    validation is skipped. An unauthenticated attacker with TCP access to the RPC server port
+    (default: 50052) can send crafted GRAPH_COMPUTE messages to read and write arbitrary process
+    memory. Combined with pointer leaks from ALLOC_BUFFER/BUFFER_GET_BASE RPC commands (which
+    return raw heap addresses), this enables full ASLR bypass and remote code execution without
+    any credentials. The exploit chain: (1) leak heap/code pointers via ALLOC_BUFFER/BUFFER_GET_BASE,
+    (2) achieve arbitrary read/write via GRAPH_COMPUTE with buffer=0 tensors, (3) overwrite a
+    buffer iface.clear function pointer with system(), (4) trigger BUFFER_CLEAR to execute
+    attacker-controlled commands. A working public PoC was disclosed alongside the advisory.
+    This vulnerability is a bypass of the incomplete fixes for CVE-2024-42478 and CVE-2024-42479,
+    which patched GET_TENSOR and SET_TENSOR handlers but left the GRAPH_COMPUTE code path unprotected.
+    CWE-119 (Improper Restriction of Operations within the Bounds of a Memory Buffer).
+    CVSS 9.8 CRITICAL. Public PoC available.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade llama.cpp to build b8492 or later, which patches the bounds validation bypass in
+    deserialize_tensor() for the GRAPH_COMPUTE code path. If upgrade is not immediately possible,
+    apply network-level mitigations: restrict access to the RPC server port (default 50052) via
+    firewall rules to trusted hosts only. Do not expose the RPC port to untrusted networks or
+    the internet. The RPC backend must be explicitly compiled with -DGGML_RPC=ON; if distributed
+    inference is not required, rebuild without RPC support.
+  references:
+    - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-j8rj-fmpv-wcxw
+    - https://github.com/ggml-org/llama.cpp/commit/39bf0d3c6a95803e0f41aaba069ffbee26721042
+    - https://github.com/ggml-org/llama.cpp/pull/20908
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-34159
+rule: 'version < "b8492"'
+references:
+  - https://github.com/ggml-org/llama.cpp/security/advisories/GHSA-j8rj-fmpv-wcxw
+  - https://github.com/ggml-org/llama.cpp/commit/39bf0d3c6a95803e0f41aaba069ffbee26721042
+  - https://github.com/ggml-org/llama.cpp/pull/20908
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-34159

--- a/data/vuln/lobehub/CVE-2026-39411.yaml
+++ b/data/vuln/lobehub/CVE-2026-39411.yaml
@@ -1,0 +1,23 @@
+info:
+  name: lobehub
+  cve: CVE-2026-39411
+  summary: LobeHub is a work-and-lifestyle space to find, build, and collaborate with agent teammates that grow with you
+  details: LobeHub is a work-and-lifestyle space to find, build, and collaborate with agent teammates that grow with you.
+    Prior to 2.1.48, the webapi authentication layer trusts a client-controlled X-lobe-chat-auth header that is only XOR-obfuscated,
+    not signed or otherwise authenticated. Because the XOR key is hardcoded in the repository, an attacker can forge arbitrary
+    auth payloads and bypass authentication on protected webapi routes. Affected routes include /webapi/chat/[provider], /webapi/models/[provider],
+    /webapi/models/[provider]/pull, and /webapi/create-image/comfyui. This vulnerability is fixed in 2.1.48.
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/lobehub/lobehub/commit/3327b293d66c013f076cbc16cdbd05a61a3d0428
+  - https://github.com/lobehub/lobehub/pull/13535
+  - https://github.com/lobehub/lobehub/releases/tag/v2.1.48
+  - https://github.com/lobehub/lobehub/security/advisories/GHSA-5mwj-v5jw-5c97
+rule: 'version < "2.1.48"'
+references:
+- https://github.com/lobehub/lobehub/commit/3327b293d66c013f076cbc16cdbd05a61a3d0428
+- https://github.com/lobehub/lobehub/pull/13535
+- https://github.com/lobehub/lobehub/releases/tag/v2.1.48
+- https://github.com/lobehub/lobehub/security/advisories/GHSA-5mwj-v5jw-5c97

--- a/data/vuln/mlflow/CVE-2025-15031.yaml
+++ b/data/vuln/mlflow/CVE-2025-15031.yaml
@@ -11,6 +11,6 @@ info:
   security_advise: 升级到 MLflow 最新的修复版本，并避免摄入不可信的 tar.gz 构件。
   references:
     - https://huntr.com/bounties/09856f77-f968-446f-a930-657d126efe4e
-rule: ""
+rule: 'version < "3.9.0rc0"'
 references:
   - https://huntr.com/bounties/09856f77-f968-446f-a930-657d126efe4e

--- a/data/vuln/mlflow/CVE-2026-0545.yaml
+++ b/data/vuln/mlflow/CVE-2026-0545.yaml
@@ -1,0 +1,31 @@
+info:
+  name: mlflow
+  cve: CVE-2026-0545
+  summary: MLflow FastAPI job endpoints lack authentication bypass, allowing unauthenticated
+    RCE via /ajax-api/3.0/jobs/* when basic-auth is enabled.
+  details: >-
+    In mlflow/mlflow, the FastAPI job endpoints under `/ajax-api/3.0/jobs/*` are
+    not protected by authentication or authorization when the `basic-auth` app is
+    enabled. This vulnerability affects the latest version of the repository. If
+    job execution is enabled (`MLFLOW_SERVER_ENABLE_JOB_EXECUTION=true`) and any
+    job function is allowlisted, any network client can submit, read, search, and
+    cancel jobs without credentials, bypassing basic-auth entirely. This can lead
+    to unauthenticated remote code execution if allowed jobs perform privileged
+    actions such as shell execution or filesystem changes. Even if jobs are deemed
+    safe, this still constitutes an authentication bypass, potentially resulting in
+    job spam, denial of service (DoS), or data exposure in job results. CWE-306:
+    Missing Authentication for Critical Function.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade MLflow to the latest patched version. As a temporary mitigation,
+    disable job execution by setting `MLFLOW_SERVER_ENABLE_JOB_EXECUTION=false`
+    or restrict network access to the `/ajax-api/3.0/jobs/*` endpoints via
+    firewall/reverse proxy rules. Monitor for unauthorized job submissions.
+  references:
+    - https://huntr.com/bounties/b2e5b028-9541-4d29-8703-a76f1a3734d8
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0545
+rule: 'version <= "3.10.1"'
+references:
+  - https://huntr.com/bounties/b2e5b028-9541-4d29-8703-a76f1a3734d8
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-0545

--- a/data/vuln/mlflow/CVE-2026-0596.yaml
+++ b/data/vuln/mlflow/CVE-2026-0596.yaml
@@ -1,0 +1,26 @@
+info:
+  name: mlflow
+  cve: CVE-2026-0596
+  summary: Command injection in MLflow model serving via unsanitized model_uri with enable_mlserver=True
+  details: >-
+    A command injection vulnerability exists in MLflow when serving a model with `enable_mlserver=True`.
+    The `model_uri` parameter is embedded directly into a shell command executed via `bash -c` without
+    proper sanitization. If `model_uri` contains shell metacharacters such as `$()` or backticks, it
+    allows command substitution and execution of attacker-controlled commands. This can lead to privilege
+    escalation if a higher-privileged service serves models from a directory writable by lower-privileged
+    users. The vulnerability affects the latest version of mlflow/mlflow (CWE-78: OS Command Injection).
+  cvss: ''
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade MLflow to the latest patched version when available. As a workaround, avoid using
+    `enable_mlserver=True` with untrusted `model_uri` values, and ensure strict input validation
+    and sanitization of model URIs before passing them to shell commands. Follow the official
+    MLflow security advisory at https://huntr.com/bounties/2e905add-f9f5-4309-a3db-b17de5981285
+    for patch details.
+  references:
+    - https://huntr.com/bounties/2e905add-f9f5-4309-a3db-b17de5981285
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-0596
+rule: 'version < "3.9.0"'
+references:
+  - https://huntr.com/bounties/2e905add-f9f5-4309-a3db-b17de5981285
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-0596

--- a/data/vuln/mlflow/CVE-2026-33865.yaml
+++ b/data/vuln/mlflow/CVE-2026-33865.yaml
@@ -1,0 +1,19 @@
+info:
+  name: mlflow
+  cve: CVE-2026-33865
+  summary: MLflow is vulnerable to Stored Cross-Site Scripting (XSS) caused by unsafe parsing of YAML-based MLmodel artifacts
+    in...
+  details: "MLflow is vulnerable to Stored Cross-Site Scripting (XSS) caused by unsafe parsing of YAML-based MLmodel artifacts\
+    \ in its web interface. An authenticated attacker can upload a malicious MLmodel file containing a payload that executes\
+    \ when another user views the artifact in the UI. This allows actions such as session hijacking or performing operations\
+    \ on behalf of the victim. \n\nThis issue affects MLflow version through 3.10.1"
+  cvss: ''
+  severity: MEDIUM
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://cert.pl/en/posts/2026/04/CVE-2026-33865/
+  - https://github.com/mlflow/mlflow/pull/21435
+rule: 'version <= "3.10.1"'
+references:
+- https://cert.pl/en/posts/2026/04/CVE-2026-33865/
+- https://github.com/mlflow/mlflow/pull/21435

--- a/data/vuln/mlflow/CVE-2026-33866.yaml
+++ b/data/vuln/mlflow/CVE-2026-33866.yaml
@@ -1,0 +1,17 @@
+info:
+  name: MLflow
+  cve: CVE-2026-33866
+  summary: MLflow is vulnerable to an authorization bypass affecting the AJAX endpoint used to download saved model artifacts
+  details: "MLflow is vulnerable to an authorization bypass affecting the AJAX endpoint used to download saved model artifacts.\
+    \ Due to missing access‑control validation, a user without permissions to a given experiment can directly query this endpoint\
+    \ and retrieve model artifacts they are not authorized to access.\n\n \nThis issue affects MLflow version through 3.10.1"
+  cvss: ''
+  severity: MEDIUM
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://cert.pl/en/posts/2026/04/CVE-2026-33865/
+  - https://github.com/mlflow/mlflow/pull/21708
+rule: 'version <= "3.10.1"'
+references:
+- https://cert.pl/en/posts/2026/04/CVE-2026-33865/
+- https://github.com/mlflow/mlflow/pull/21708

--- a/data/vuln/ollama/CVE-2026-5530.yaml
+++ b/data/vuln/ollama/CVE-2026-5530.yaml
@@ -1,0 +1,26 @@
+info:
+  name: ollama
+  cve: CVE-2026-5530
+  summary: Ollama Model Pull API Server-Side Request Forgery (SSRF)
+  details: >-
+    A Server-Side Request Forgery (SSRF) vulnerability has been found in Ollama up to
+    version 0.1.18.1. The flaw exists in the file server/download.go within the Model Pull
+    API component. An authenticated remote attacker can manipulate the pull request to
+    cause the server to make arbitrary HTTP requests to internal or external resources,
+    potentially accessing internal services or exfiltrating sensitive data. The vendor
+    was contacted early about this disclosure but did not respond. No public PoC or patch
+    is available at the time of writing.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  severity: MEDIUM
+  security_advise: >-
+    Upgrade Ollama to the latest available version. As a mitigation, restrict network
+    access to the Ollama API to trusted clients only. Implement egress filtering on the
+    host running Ollama to prevent outbound requests to internal network segments.
+    Monitor the Model Pull API endpoint for suspicious or unexpected model registry URLs.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-5530
+    - https://vuldb.com/vuln/355283
+rule: 'version <= "0.1.18.1"'
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-5530
+  - https://vuldb.com/vuln/355283

--- a/data/vuln/openclaw/CVE-2026-32038.yaml
+++ b/data/vuln/openclaw/CVE-2026-32038.yaml
@@ -17,7 +17,7 @@ info:
     - https://github.com/openclaw/openclaw/commit/14b6eea6e
     - https://github.com/openclaw/openclaw/commit/5552f9073
     - https://www.vulncheck.com/advisories/openclaw-sandbox-network-isolation-bypass-via-docker-network-container-parameter
-rule: ""
+rule: 'version < "2026.2.24"'
 references:
   - https://github.com/openclaw/openclaw/security/advisories/GHSA-ww6v-v748-x7g9
   - https://www.vulncheck.com/advisories/openclaw-sandbox-network-isolation-bypass-via-docker-network-container-parameter

--- a/data/vuln/openclaw/CVE-2026-32846.yaml
+++ b/data/vuln/openclaw/CVE-2026-32846.yaml
@@ -11,7 +11,7 @@ info:
   - https://github.com/openclaw/openclaw/pull/54642
   - https://github.com/openclaw/openclaw/security/advisories/GHSA-f6pf-4gjx-c94r
   - https://www.vulncheck.com/advisories/openclaw-media-parsing-path-traversal-to-arbitrary-file-read
-rule: ''
+rule: 'version < "2026.3.23"'
 references:
 - https://github.com/openclaw/openclaw/commit/4797bbc5b96e2cca5532e43b58915c051746fe37
 - https://github.com/openclaw/openclaw/pull/54642

--- a/data/vuln/openclaw/CVE-2026-32913.yaml
+++ b/data/vuln/openclaw/CVE-2026-32913.yaml
@@ -18,7 +18,7 @@ info:
     - https://github.com/openclaw/openclaw/commit/46715371b0612a6f9114dffd1466941ac476cef5
     - https://github.com/openclaw/openclaw/releases/tag/v2026.3.7
     - https://nvd.nist.gov/vuln/detail/CVE-2026-32913
-rule: ""
+rule: 'version < "2026.3.7"'
 references:
   - https://github.com/openclaw/openclaw/security/advisories/GHSA-6mgf-v5j7-45cr
   - https://nvd.nist.gov/vuln/detail/CVE-2026-32913

--- a/data/vuln/openclaw/CVE-2026-32917.yaml
+++ b/data/vuln/openclaw/CVE-2026-32917.yaml
@@ -1,0 +1,29 @@
+info:
+  name: openclaw
+  cve: CVE-2026-32917
+  summary: OpenClaw < 2026.3.13 - Remote Command Injection via Unsanitized iMessage Attachment Paths in SCP
+  details: >-
+    OpenClaw before 2026.3.13 contains a remote command injection vulnerability in the iMessage
+    attachment staging flow. When remote attachment staging is enabled, unsanitized remote
+    attachment paths containing shell metacharacters (e.g., backticks, semicolons, pipes) are
+    passed directly to the SCP remote operand without validation, enabling arbitrary command
+    execution on configured remote hosts. A remote attacker can exploit this by sending a crafted
+    iMessage attachment with a malicious filename to the victim's OpenClaw instance.
+    CVSS 4.0 vector: AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N (AT:P indicates
+    the remote attachment staging feature must be enabled). No public PoC or nuclei template
+    found at time of analysis. Patch commit is publicly available.
+  cvss: "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+  severity: CRITICAL
+  security_advise: >-
+    Upgrade OpenClaw to version 2026.3.13 or later. If immediate upgrade is not possible,
+    disable remote attachment staging as a temporary mitigation. Review and sanitize all
+    external input passed to shell commands, especially filenames from messaging channels.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-32917
+    - https://github.com/openclaw/openclaw/security/advisories/GHSA-g2f6-pwvx-r275
+    - https://github.com/openclaw/openclaw/commit/a54bf71b4c0cbe554a84340b773df37ee8e959de
+    - https://www.vulncheck.com/advisories/openclaw-remote-command-injection-via-unsanitized-imessage-attachment-paths-in-scp
+rule: 'version < "2026.3.13"'
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-32917
+  - https://github.com/openclaw/openclaw/security/advisories/GHSA-g2f6-pwvx-r275

--- a/data/vuln/ray/CVE-2026-32981.yaml
+++ b/data/vuln/ray/CVE-2026-32981.yaml
@@ -16,7 +16,7 @@ info:
     - https://github.com/ray-project/ray
     - https://packetstorm.news/files/id/215801/
     - https://www.vulncheck.com/advisories/ray-dashboard-path-traversal-leading-to-local-file-disclosure
-rule: ""
+rule: 'version < "2.8.1"'
 references:
   - https://github.com/ray-project/ray
   - https://packetstorm.news/files/id/215801/

--- a/data/vuln/triton-inference-server/CVE-2025-33238.yaml
+++ b/data/vuln/triton-inference-server/CVE-2025-33238.yaml
@@ -13,7 +13,7 @@ info:
   references:
     - https://nvidia.custhelp.com/app/answers/detail/a_id/5790
     - https://nvd.nist.gov/vuln/detail/CVE-2025-33238
-rule: ""
+rule: 'version < "26.01"'
 references:
   - https://nvidia.custhelp.com/app/answers/detail/a_id/5790
   - https://nvd.nist.gov/vuln/detail/CVE-2025-33238


### PR DESCRIPTION
## Summary

Fix 10 existing rules with empty `rule` fields, and add 13 new CVE rules.

## Changes

### Fix empty rule fields (10 files)

| CVE | Product | Rule |
|-----|---------|------|
| CVE-2025-15031 | mlflow | `version < "3.9.0rc0"` |
| CVE-2025-33238 | triton-inference-server | `version < "26.01"` |
| CVE-2025-41258 | librechat | `version == "0.8.1-rc2"` |
| CVE-2026-32038 | openclaw | `version < "2026.2.24"` |
| CVE-2026-32846 | openclaw | `version < "2026.3.23"` |
| CVE-2026-32913 | openclaw | `version < "2026.3.7"` |
| CVE-2026-32981 | ray | `version < "2.8.1"` |
| CVE-2026-33265 | librechat | `version == "0.8.1-rc2"` |
| CVE-2026-33298 | llama-cpp | `version < "b7824"` |
| CVE-2026-4276 | librechat | `version == "0.7.0"` |

### Add new CVE rules (13 files)

| CVE | Product | Rule |
|-----|---------|------|
| CVE-2026-0545 | mlflow | `version <= "3.10.1"` |
| CVE-2026-0596 | mlflow | `version < "3.9.0"` |
| CVE-2026-2275 | crewai | `version <= "1.14.1"` |
| CVE-2026-2286 | crewai | `version <= "1.14.1"` |
| CVE-2026-2287 | crewai | `version <= "1.14.1"` |
| CVE-2026-32917 | openclaw | `version < "2026.3.13"` |
| CVE-2026-33865 | mlflow | `version <= "3.10.1"` |
| CVE-2026-33866 | mlflow | `version <= "3.10.1"` |
| CVE-2026-34159 | llama-cpp | `version < "b8492"` |
| CVE-2026-34940 | kubeai | `version < "0.23.2"` |
| CVE-2026-35030 | litellm | `version < "1.83.0"` |
| CVE-2026-39411 | lobehub | `version < "2.1.48"` |
| CVE-2026-5530 | ollama | `version <= "0.1.18.1"` |