### PR TITLE
fix runtime path resolution for source startup

### DIFF
--- a/common/agent/agent_task.go
+++ b/common/agent/agent_task.go
@@ -29,8 +29,6 @@ import (
 	"github.com/Tencent/AI-Infra-Guard/common/utils"
 )
 
-const AgentScanDir = "/app/agent-scan"
-
 type AgentTask struct {
 	Server string
 }
@@ -117,8 +115,16 @@ func (m *AgentTask) Execute(ctx context.Context, request TaskRequest, callbacks 
 	}
 	callbacks.PlanUpdateCallback(tasks)
 	config := CmdConfig{StatusId: ""}
-	err = utils.RunCmdWithContext(ctx, AgentScanDir, NAME, argv, func(line string) {
-		ParseStdoutLine(m.Server, AgentScanDir, tasks, line, callbacks, &config, false)
+	agentScanDir, err := utils.ResolveAgentScanDir()
+	if err != nil {
+		return fmt.Errorf("resolve agent-scan directory: %v", err)
+	}
+	uvBin, err := utils.ResolveUvBin()
+	if err != nil {
+		return fmt.Errorf("resolve uv binary: %v", err)
+	}
+	err = utils.RunCmdWithContext(ctx, agentScanDir, uvBin, argv, func(line string) {
+		ParseStdoutLine(m.Server, agentScanDir, tasks, line, callbacks, &config, false)
 	})
 	return err
 }

--- a/common/agent/mcp_task.go
+++ b/common/agent/mcp_task.go
@@ -33,8 +33,6 @@ import (
 	"github.com/Tencent/AI-Infra-Guard/internal/gologger"
 )
 
-const McpDir = "/app/mcp-scan"
-
 type McpTask struct {
 	Server string
 }
@@ -177,9 +175,16 @@ func (m *McpTask) Execute(ctx context.Context, request TaskRequest, callbacks Ta
 	}
 	callbacks.PlanUpdateCallback(tasks)
 	config := CmdConfig{StatusId: ""}
-
-	err := utils.RunCmdWithContext(ctx, McpDir, NAME, argv, func(line string) {
-		ParseStdoutLine(m.Server, McpDir, tasks, line, callbacks, &config, false)
+	mcpDir, err := utils.ResolveMcpScanDir()
+	if err != nil {
+		return fmt.Errorf("resolve mcp-scan directory: %v", err)
+	}
+	uvBin, err := utils.ResolveUvBin()
+	if err != nil {
+		return fmt.Errorf("resolve uv binary: %v", err)
+	}
+	err = utils.RunCmdWithContext(ctx, mcpDir, uvBin, argv, func(line string) {
+		ParseStdoutLine(m.Server, mcpDir, tasks, line, callbacks, &config, false)
 	})
 	return err
 }

--- a/common/agent/prompt_tasks.go
+++ b/common/agent/prompt_tasks.go
@@ -33,11 +33,6 @@ import (
 	"github.com/Tencent/AI-Infra-Guard/internal/gologger"
 )
 
-const (
-	DIR  = "/app/AIG-PromptSecurity"
-	NAME = "/usr/local/bin/uv"
-)
-
 type ModelRedteamReport struct {
 	Server string
 }
@@ -213,8 +208,16 @@ func (m *ModelRedteamReport) Execute(ctx context.Context, request TaskRequest, c
 	}
 	callbacks.PlanUpdateCallback(tasks)
 	config := CmdConfig{StatusId: ""}
-	err = utils.RunCmdWithContext(ctx, DIR, NAME, argv, func(line string) {
-		ParseStdoutLine(m.Server, DIR, tasks, line, callbacks, &config, true)
+	promptSecurityDir, err := utils.ResolvePromptSecurityDir()
+	if err != nil {
+		return fmt.Errorf("resolve AIG-PromptSecurity directory: %v", err)
+	}
+	uvBin, err := utils.ResolveUvBin()
+	if err != nil {
+		return fmt.Errorf("resolve uv binary: %v", err)
+	}
+	err = utils.RunCmdWithContext(ctx, promptSecurityDir, uvBin, argv, func(line string) {
+		ParseStdoutLine(m.Server, promptSecurityDir, tasks, line, callbacks, &config, true)
 	})
 	return err
 }

--- a/common/utils/runtime_paths.go
+++ b/common/utils/runtime_paths.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	AgentScanDirEnv      = "AIG_AGENT_SCAN_DIR"
+	McpScanDirEnv        = "AIG_MCP_SCAN_DIR"
+	PromptSecurityDirEnv = "AIG_PROMPT_SECURITY_DIR"
+	UvBinEnv             = "AIG_UV_BIN"
+)
+
+func ResolveAgentScanDir() (string, error) {
+	return resolveRuntimeDir(AgentScanDirEnv, "/app/agent-scan", "agent-scan")
+}
+
+func ResolveMcpScanDir() (string, error) {
+	return resolveRuntimeDir(McpScanDirEnv, "/app/mcp-scan", "mcp-scan")
+}
+
+func ResolvePromptSecurityDir() (string, error) {
+	return resolveRuntimeDir(PromptSecurityDirEnv, "/app/AIG-PromptSecurity", "AIG-PromptSecurity")
+}
+
+func ResolveUvBin() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(UvBinEnv)); override != "" {
+		return override, nil
+	}
+	if uvPath, err := exec.LookPath("uv"); err == nil {
+		return uvPath, nil
+	}
+	const containerUvPath = "/usr/local/bin/uv"
+	if info, err := os.Stat(containerUvPath); err == nil && !info.IsDir() {
+		return containerUvPath, nil
+	}
+	return "", fmt.Errorf("unable to locate uv; set %s to override the path", UvBinEnv)
+}
+
+func resolveRuntimeDir(envName, containerPath, relativePath string) (string, error) {
+	candidates := collectRuntimeDirCandidates(envName, containerPath, relativePath, runtimeSearchBases()...)
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err == nil && info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("unable to locate %s; set %s to override the path", relativePath, envName)
+}
+
+func runtimeSearchBases() []string {
+	var bases []string
+	if wd, err := os.Getwd(); err == nil {
+		bases = append(bases, wd)
+	}
+	if execPath, err := os.Executable(); err == nil {
+		bases = append(bases, filepath.Dir(execPath))
+	}
+	return bases
+}
+
+func collectRuntimeDirCandidates(envName, containerPath, relativePath string, bases ...string) []string {
+	var candidates []string
+	seen := make(map[string]struct{})
+	addCandidate := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return
+		}
+		path = filepath.Clean(path)
+		if !filepath.IsAbs(path) {
+			if absPath, err := filepath.Abs(path); err == nil {
+				path = absPath
+			}
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		candidates = append(candidates, path)
+	}
+
+	addCandidate(os.Getenv(envName))
+	addCandidate(containerPath)
+
+	for _, base := range bases {
+		base = strings.TrimSpace(base)
+		if base == "" {
+			continue
+		}
+		current := filepath.Clean(base)
+		for i := 0; i < 8; i++ {
+			addCandidate(filepath.Join(current, relativePath))
+			parent := filepath.Dir(current)
+			if parent == current {
+				break
+			}
+			current = parent
+		}
+	}
+
+	return candidates
+}

--- a/common/utils/runtime_paths_test.go
+++ b/common/utils/runtime_paths_test.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveRuntimeDirUsesEnvOverride(t *testing.T) {
+	overrideDir := t.TempDir()
+	t.Setenv(AgentScanDirEnv, overrideDir)
+
+	resolved, err := resolveRuntimeDir(AgentScanDirEnv, "/app/agent-scan", "agent-scan")
+	if err != nil {
+		t.Fatalf("resolveRuntimeDir returned error: %v", err)
+	}
+
+	expected, err := filepath.Abs(overrideDir)
+	if err != nil {
+		t.Fatalf("filepath.Abs returned error: %v", err)
+	}
+	if resolved != expected {
+		t.Fatalf("expected %q, got %q", expected, resolved)
+	}
+}
+
+func TestCollectRuntimeDirCandidatesSearchesParentDirectories(t *testing.T) {
+	rootDir := t.TempDir()
+	nestedDir := filepath.Join(rootDir, "cmd", "cli")
+	targetDir := filepath.Join(rootDir, "agent-scan")
+
+	t.Setenv(AgentScanDirEnv, "")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatalf("failed to create target dir: %v", err)
+	}
+
+	candidates := collectRuntimeDirCandidates(AgentScanDirEnv, "/app/agent-scan", "agent-scan", nestedDir)
+	expected, err := filepath.Abs(targetDir)
+	if err != nil {
+		t.Fatalf("filepath.Abs returned error: %v", err)
+	}
+
+	for _, candidate := range candidates {
+		if candidate == expected {
+			return
+		}
+	}
+	t.Fatalf("expected candidates to include %q, got %v", expected, candidates)
+}
+
+func TestResolveUvBinUsesEnvOverride(t *testing.T) {
+	overridePath := filepath.Join(t.TempDir(), "uv")
+	if err := os.WriteFile(overridePath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatalf("failed to create uv override: %v", err)
+	}
+	t.Setenv(UvBinEnv, overridePath)
+
+	resolved, err := ResolveUvBin()
+	if err != nil {
+		t.Fatalf("ResolveUvBin returned error: %v", err)
+	}
+
+	expected, err := filepath.Abs(overridePath)
+	if err != nil {
+		t.Fatalf("filepath.Abs returned error: %v", err)
+	}
+	if resolved != expected {
+		t.Fatalf("expected %q, got %q", expected, resolved)
+	}
+}

--- a/common/websocket/knowledge2_api.go
+++ b/common/websocket/knowledge2_api.go
@@ -28,16 +28,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Tencent/AI-Infra-Guard/common/agent"
 	"github.com/Tencent/AI-Infra-Guard/common/utils"
 	"github.com/Tencent/AI-Infra-Guard/internal/gologger"
 	"github.com/Tencent/AI-Infra-Guard/internal/mcp"
 	"github.com/gin-gonic/gin"
 	"gopkg.in/yaml.v3"
 )
-
-const AgentScanDir = "/app/agent-scan"
-const UvBin = "/usr/local/bin/uv"
 
 func HandleList(root string, loadFile func(filePath string) (interface{}, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -333,7 +329,15 @@ func promptCollectionDeleteFunc(id string) error {
 	return os.Remove(filePath)
 }
 func GetJailBreak(c *gin.Context) {
-	dataPath := filepath.Join(agent.DIR, "utils", "strategy_map.json")
+	promptSecurityDir, err := utils.ResolvePromptSecurityDir()
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"status":  1,
+			"message": "error" + err.Error(),
+		})
+		return
+	}
+	dataPath := filepath.Join(promptSecurityDir, "utils", "strategy_map.json")
 	data, err := os.ReadFile(dataPath)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
@@ -446,6 +450,14 @@ func HandleGetAgentConfig(c *gin.Context) {
 // testAgentConnectivity 测试Agent配置的连通性
 // 返回 (success, message, error)
 func testAgentConnectivity(content string) (bool, string, error) {
+	agentScanDir, err := utils.ResolveAgentScanDir()
+	if err != nil {
+		return false, "", fmt.Errorf("解析 agent-scan 目录失败: %v", err)
+	}
+	uvBin, err := utils.ResolveUvBin()
+	if err != nil {
+		return false, "", fmt.Errorf("解析 uv 路径失败: %v", err)
+	}
 	// Create temporary file for the YAML content
 	tmpFile, err := os.CreateTemp("", "agent_connect_*.yaml")
 	if err != nil {
@@ -463,8 +475,8 @@ func testAgentConnectivity(content string) (bool, string, error) {
 	// Run Python connectivity test script using uv
 	var lastLine string
 	err = utils.RunCmd(
-		AgentScanDir,
-		UvBin,
+		agentScanDir,
+		uvBin,
 		[]string{"run", "test_client_connect.py", "--client_file", tmpFile.Name()},
 		func(line string) {
 			lastLine += line
@@ -895,10 +907,26 @@ func HandleAgentPromptTest(c *gin.Context) {
 	tmpFile.Close()
 
 	// Run Python prompt test script using uv
+	agentScanDir, err := utils.ResolveAgentScanDir()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"status":  1,
+			"message": "Failed to resolve agent-scan directory: " + err.Error(),
+		})
+		return
+	}
+	uvBin, err := utils.ResolveUvBin()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"status":  1,
+			"message": "Failed to resolve uv binary: " + err.Error(),
+		})
+		return
+	}
 	var lastLine string
 	err = utils.RunCmd(
-		AgentScanDir,
-		UvBin,
+		agentScanDir,
+		uvBin,
 		[]string{"run", "test_client_connect.py", "--client_file", tmpFile.Name(), "--prompt", req.Prompt},
 		func(line string) {
 			lastLine += line

--- a/common/websocket/knowledge2_api.go
+++ b/common/websocket/knowledge2_api.go
@@ -333,7 +333,7 @@ func GetJailBreak(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"status":  1,
-			"message": "error" + err.Error(),
+			"message": "Failed to resolve prompt security directory: " + err.Error(),
 		})
 		return
 	}
@@ -342,7 +342,7 @@ func GetJailBreak(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"status":  1,
-			"message": "error" + err.Error(),
+			"message": "Failed to read strategy map: " + err.Error(),
 		})
 		return
 	}
@@ -351,7 +351,7 @@ func GetJailBreak(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"status":  1,
-			"message": "error" + err.Error(),
+			"message": "Failed to parse strategy map: " + err.Error(),
 		})
 		return
 	}
@@ -447,28 +447,28 @@ func HandleGetAgentConfig(c *gin.Context) {
 	})
 }
 
-// testAgentConnectivity 测试Agent配置的连通性
-// 返回 (success, message, error)
+// testAgentConnectivity verifies Agent configuration connectivity.
+// Returns (success, message, error).
 func testAgentConnectivity(content string) (bool, string, error) {
 	agentScanDir, err := utils.ResolveAgentScanDir()
 	if err != nil {
-		return false, "", fmt.Errorf("解析 agent-scan 目录失败: %v", err)
+		return false, "", fmt.Errorf("failed to resolve agent-scan directory: %v", err)
 	}
 	uvBin, err := utils.ResolveUvBin()
 	if err != nil {
-		return false, "", fmt.Errorf("解析 uv 路径失败: %v", err)
+		return false, "", fmt.Errorf("failed to resolve uv binary: %v", err)
 	}
 	// Create temporary file for the YAML content
 	tmpFile, err := os.CreateTemp("", "agent_connect_*.yaml")
 	if err != nil {
-		return false, "", fmt.Errorf("创建临时文件失败: %v", err)
+		return false, "", fmt.Errorf("failed to create temporary config file: %v", err)
 	}
 	defer os.Remove(tmpFile.Name())
 
 	// Write YAML content to temp file
 	if _, err := tmpFile.WriteString(content); err != nil {
 		tmpFile.Close()
-		return false, "", fmt.Errorf("写入配置文件失败: %v", err)
+		return false, "", fmt.Errorf("failed to write config file: %v", err)
 	}
 	tmpFile.Close()
 
@@ -484,7 +484,7 @@ func testAgentConnectivity(content string) (bool, string, error) {
 	)
 
 	if err != nil {
-		return false, "", fmt.Errorf("连通性测试执行失败: %v", err)
+		return false, "", fmt.Errorf("connectivity test execution failed: %v", err)
 	}
 	if lastLine != "" {
 		gologger.Infoln("test_agent_connect", lastLine)
@@ -493,7 +493,7 @@ func testAgentConnectivity(content string) (bool, string, error) {
 	// Parse the JSON output from Python script
 	var result ConnectResultUpdate
 	if err := json.Unmarshal([]byte(lastLine), &result); err != nil {
-		return false, "", fmt.Errorf("解析测试结果失败: %v", err)
+		return false, "", fmt.Errorf("failed to parse connectivity test result: %v", err)
 	}
 
 	return result.Content.Success, result.Content.Message, nil
@@ -533,19 +533,19 @@ func HandleSaveAgentConfig(c *gin.Context) {
 		return
 	}
 
-	// 检测Agent连通性
+	// Validate Agent connectivity before saving the config.
 	success, message, err := testAgentConnectivity(content)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"status":  1,
-			"message": "连通性检测失败: " + err.Error(),
+			"message": "Connectivity check failed: " + err.Error(),
 		})
 		return
 	}
 	if !success {
 		c.JSON(http.StatusOK, gin.H{
 			"status":  1,
-			"message": "连通性检测失败: " + message,
+			"message": "Connectivity check failed: " + message,
 		})
 		return
 	}
@@ -579,7 +579,7 @@ func HandleSaveAgentConfig(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":  0,
-		"message": "保存成功，连通性验证通过",
+		"message": "Saved successfully and connectivity check passed",
 	})
 }
 


### PR DESCRIPTION
## Problem

When A.I.G is started from source, some backend flows still assume Docker-only runtime paths such as `/app/agent-scan` and a fixed `uv` binary path. This causes agent connectivity checks to fail with errors like:

`chdir /app/agent-scan: no such file or directory`

## Fix

This PR replaces those hardcoded runtime assumptions with runtime path resolution that works for:

- source startup
- existing Docker deployments
- explicit environment variable overrides when needed

The same resolution logic is applied consistently to Agent Scan, MCP Scan, and Prompt Security related flows.

## Impact

- source deployments no longer need local code patches just to make Agent-related checks run
- Docker deployments remain compatible with the current `/app/...` layout
- runtime behavior is more portable across local and container environments

## Validation

- verified source startup locally
- verified Docker rebuild and startup locally
- verified Agent connectivity check succeeds in both startup modes
