### PR TITLE
fix(i18n): propagate language field in AI-Infra-Scan and MCP-Scan task creation

### DIFF
--- a/common/agent/tasks.go
+++ b/common/agent/tasks.go
@@ -355,6 +355,10 @@ func (t *AIInfraScanAgent) executeScan(ctx context.Context, request TaskRequest,
 	callbacks.StepStatusUpdateCallback(step01, statusId01, AgentStatusRunning, "Thinking", "")
 
 	// 配置选项
+	language := request.Language
+	if language == "" {
+		language = "zh"
+	}
 	opts := &options.Options{
 		TimeOut:      reqScan.Timeout,
 		RateLimit:    200,
@@ -363,6 +367,7 @@ func (t *AIInfraScanAgent) executeScan(ctx context.Context, request TaskRequest,
 		WebServer:    false,
 		Target:       reqScan.Target,
 		LoadRemote:   true,
+		Language:     language,
 	}
 
 	headers := make([]string, 0)

--- a/common/websocket/api.go
+++ b/common/websocket/api.go
@@ -69,10 +69,11 @@ type MCPTaskRequest struct {
 // AIInfraScanTaskRequest represents AI infrastructure scan task request structure
 // @Description AI infrastructure security scan task parameters: target URLs, custom headers, and optional model config for result analysis
 type AIInfraScanTaskRequest struct {
-	Target  []string          `json:"target" example:"https://example.com"`                   // List of scan target URLs
-	Headers map[string]string `json:"headers" example:"{\"Authorization\":\"Bearer token\"}"` // Custom request headers
-	Timeout int               `json:"timeout" example:"30"`                                   // Request timeout in seconds
-	Model   struct {
+	Target   []string          `json:"target" example:"https://example.com"`                   // List of scan target URLs
+	Headers  map[string]string `json:"headers" example:"{\"Authorization\":\"Bearer token\"}"` // Custom request headers
+	Timeout  int               `json:"timeout" example:"30"`                                   // Request timeout in seconds
+	Language string            `json:"language,omitempty" example:"zh"`                        // Language code - optional
+	Model    struct {
 		Model   string `json:"model" binding:"required" example:"gpt-4"`               // Model name - required
 		Token   string `json:"token" binding:"required" example:"sk-xxx"`              // API key - required
 		BaseUrl string `json:"base_url,omitempty" example:"https://api.openai.com/v1"` // Base URL - optional
@@ -302,14 +303,15 @@ func SubmitTask(c *gin.Context, tm *TaskManager) {
 
 		// Build TaskCreateRequest
 		taskReq = TaskCreateRequest{
-			ID:          messageId,
-			SessionID:   sessionId,
-			Username:    username,
-			Task:        agent.TaskTypeMcpScan,
-			Timestamp:   time.Now().UnixMilli(),
-			Content:     req.Prompt,
-			Params:      params,
-			Attachments: attachments,
+			ID:             messageId,
+			SessionID:      sessionId,
+			Username:       username,
+			Task:           agent.TaskTypeMcpScan,
+			Timestamp:      time.Now().UnixMilli(),
+			Content:        req.Prompt,
+			Params:         params,
+			Attachments:    attachments,
+			CountryIsoCode: req.Language,
 		}
 	case "ai_infra_scan":
 		var req AIInfraScanTaskRequest
@@ -333,14 +335,15 @@ func SubmitTask(c *gin.Context, tm *TaskManager) {
 		}
 
 		taskReq = TaskCreateRequest{
-			ID:          messageId,
-			SessionID:   sessionId,
-			Username:    username,
-			Task:        agent.TaskTypeAIInfraScan,
-			Timestamp:   time.Now().UnixMilli(),
-			Params:      scanParams,
-			Content:     strings.Join(req.Target, "\n"),
-			Attachments: []string{},
+			ID:             messageId,
+			SessionID:      sessionId,
+			Username:       username,
+			Task:           agent.TaskTypeAIInfraScan,
+			Timestamp:      time.Now().UnixMilli(),
+			Params:         scanParams,
+			Content:        strings.Join(req.Target, "\n"),
+			Attachments:    []string{},
+			CountryIsoCode: req.Language,
 		}
 	case "model_redteam_report":
 		var req PromptSecurityTaskRequest


### PR DESCRIPTION
## Summary

Fixes #324

Re-submission of the language fix after rebasing onto current main (the original PR #325 was closed due to a CodeQL alert that was caused by a stale TLS code path — no longer present in main after PR #306 simplified TLS handling).

## Root Causes Fixed

### Bug 1 — API path: `language` field not propagated

When creating tasks via the REST API (`SubmitTask` handler):
1. `AIInfraScanTaskRequest` struct was missing the `Language` field entirely
2. Both `ai_infra_scan` and `mcp_scan` cases in `SubmitTask()` built `TaskCreateRequest` without setting `CountryIsoCode`, so the language preference was silently dropped before reaching the task executor

### Bug 2 — Web path: executeScan() ignores language

`executeScan()` built `options.Options` without setting the `Language` field, so the runner always loaded Chinese vuln descriptions from `data/vuln/` regardless of user language selection.

## Changes

- `common/websocket/api.go`: Add `Language` field to `AIInfraScanTaskRequest`; set `CountryIsoCode: req.Language` in `TaskCreateRequest` for both `mcp_scan` and `ai_infra_scan` cases
- `common/agent/tasks.go`: Derive language from `request.Language` inside `executeScan()` and pass it as `opts.Language`

## Testing

- Built cleanly against current main (`go build ./common/websocket/... ./common/agent/...`)
- No CodeQL issues (the stale `openCAFile` path-injection taint is not present in this branch — it was resolved in PR #306 by simplifying TLS to always-skip mode)