### PR TITLE
feat(vuln-rules): detect exposed AI agent config files (claude_desktop_config.json, mcp.json, etc.)

### DIFF
--- a/data/fingerprints/ai-agent-config.yaml
+++ b/data/fingerprints/ai-agent-config.yaml
@@ -104,4 +104,4 @@ http:
   - method: GET
     path: '/.env'
     matchers:
-      - body~="(?m)^[A-Z][A-Z0-9_]+=\S"
+      - body~="(OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|OPENROUTER_API_KEY|DEEPSEEK_API_KEY|HUNYUAN_API_KEY)\s*=\s*[A-Za-z0-9_\-]{16,}"

--- a/data/fingerprints/ai-agent-config.yaml
+++ b/data/fingerprints/ai-agent-config.yaml
@@ -1,0 +1,53 @@
+info:
+  name: AI-Agent-Config
+  author: 腾讯朱雀实验室
+  severity: high
+  desc: AI Agent 配置文件（如 claude_desktop_config.json、.cursor/mcp.json 等）通过 HTTP 可公开访问，可能泄露 MCP Server 地址、API 密钥等敏感信息。
+  metadata:
+    product: AI-Agent-Config
+    vendor: various
+http:
+  - method: GET
+    path: '/claude_desktop_config.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/.claude.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/.mcp.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/.cursor/mcp.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/.continue/config.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/cline_mcp_settings.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/mcp_config.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/.vscode/mcp.json'
+    matchers:
+      - body="mcpServers"
+  - method: GET
+    path: '/.config/zed/settings.json'
+    matchers:
+      - body="context_servers"
+  - method: GET
+    path: '/.config/goose/config.yaml'
+    matchers:
+      - body="extensions"
+  - method: GET
+    path: '/.env'
+    matchers:
+      - body="OPENAI_API_KEY" || body="ANTHROPIC_API_KEY" || body="GEMINI_API_KEY" || body="OPENROUTER_API_KEY"

--- a/data/fingerprints/ai-agent-config.yaml
+++ b/data/fingerprints/ai-agent-config.yaml
@@ -14,17 +14,17 @@ http:
   - method: GET
     path: '/claude_desktop_config.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
   - method: GET
     path: '/.claude.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
   - method: GET
     path: '/.mcp.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
 # Cursor
@@ -32,7 +32,7 @@ http:
   - method: GET
     path: '/.cursor/mcp.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
 # Trae IDE (ByteDance) — project-level & user-level
@@ -40,18 +40,15 @@ http:
   - method: GET
     path: '/.trae/mcp.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
 # CodeBuddy (Tencent Cloud) — VSCode extension globalStorage
-# macOS: ~/Library/Application Support/Code/User/globalStorage/Tencent.codebuddy-vscode/mcp_settings.json
-# Linux: ~/.config/Code/User/globalStorage/Tencent.codebuddy-vscode/mcp_settings.json
-# Windows: %APPDATA%\Code\User\globalStorage\Tencent.codebuddy-vscode\mcp_settings.json
 # ──────────────────────────────────────────────
   - method: GET
     path: '/mcp_settings.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
 # Continue
@@ -59,7 +56,7 @@ http:
   - method: GET
     path: '/.continue/config.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
 # Cline / Roo-Cline (VSCode extension)
@@ -67,7 +64,7 @@ http:
   - method: GET
     path: '/cline_mcp_settings.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
 # Windsurf (Codeium)
@@ -75,7 +72,7 @@ http:
   - method: GET
     path: '/mcp_config.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
 # VS Code Copilot (workspace-level)
@@ -83,23 +80,23 @@ http:
   - method: GET
     path: '/.vscode/mcp.json'
     matchers:
-      - body="mcpServers"
+      - body~="\"mcpServers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
-# Zed editor
+# Zed editor — context_servers is the MCP key in Zed
 # ──────────────────────────────────────────────
   - method: GET
     path: '/.config/zed/settings.json'
     matchers:
-      - body="context_servers"
+      - body~="\"context_servers\"\s*:\s*\{"
 
 # ──────────────────────────────────────────────
-# Goose (Block Inc.)
+# Goose (Block Inc.) — YAML format
 # ──────────────────────────────────────────────
   - method: GET
     path: '/.config/goose/config.yaml'
     matchers:
-      - body="extensions"
+      - body~="extensions\s*:\s*\n\s+-\s+name\s*:"
 
 # ──────────────────────────────────────────────
 # Generic .env with AI API keys
@@ -107,4 +104,4 @@ http:
   - method: GET
     path: '/.env'
     matchers:
-      - body="OPENAI_API_KEY" || body="ANTHROPIC_API_KEY" || body="GEMINI_API_KEY" || body="OPENROUTER_API_KEY" || body="DEEPSEEK_API_KEY" || body="HUNYUAN_API_KEY"
+      - body~="(OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|OPENROUTER_API_KEY|DEEPSEEK_API_KEY|HUNYUAN_API_KEY)\s*=\s*[A-Za-z0-9_\-]{16,}"

--- a/data/fingerprints/ai-agent-config.yaml
+++ b/data/fingerprints/ai-agent-config.yaml
@@ -2,52 +2,109 @@ info:
   name: AI-Agent-Config
   author: 腾讯朱雀实验室
   severity: high
-  desc: AI Agent 配置文件（如 claude_desktop_config.json、.cursor/mcp.json 等）通过 HTTP 可公开访问，可能泄露 MCP Server 地址、API 密钥等敏感信息。
+  desc: AI Agent 配置文件（如 claude_desktop_config.json、.cursor/mcp.json、.trae/mcp.json 等）通过 HTTP 可公开访问，可能泄露 MCP Server 地址、API 密钥等敏感信息。
   metadata:
     product: AI-Agent-Config
     vendor: various
+
+# ──────────────────────────────────────────────
+# Claude Desktop / Claude Code
+# ──────────────────────────────────────────────
 http:
   - method: GET
     path: '/claude_desktop_config.json'
     matchers:
       - body="mcpServers"
+
   - method: GET
     path: '/.claude.json'
     matchers:
       - body="mcpServers"
+
   - method: GET
     path: '/.mcp.json'
     matchers:
       - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# Cursor
+# ──────────────────────────────────────────────
   - method: GET
     path: '/.cursor/mcp.json'
     matchers:
       - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# Trae IDE (ByteDance) — project-level & user-level
+# ──────────────────────────────────────────────
+  - method: GET
+    path: '/.trae/mcp.json'
+    matchers:
+      - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# CodeBuddy (Tencent Cloud) — VSCode extension globalStorage
+# macOS: ~/Library/Application Support/Code/User/globalStorage/Tencent.codebuddy-vscode/mcp_settings.json
+# Linux: ~/.config/Code/User/globalStorage/Tencent.codebuddy-vscode/mcp_settings.json
+# Windows: %APPDATA%\Code\User\globalStorage\Tencent.codebuddy-vscode\mcp_settings.json
+# ──────────────────────────────────────────────
+  - method: GET
+    path: '/mcp_settings.json'
+    matchers:
+      - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# Continue
+# ──────────────────────────────────────────────
   - method: GET
     path: '/.continue/config.json'
     matchers:
       - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# Cline / Roo-Cline (VSCode extension)
+# ──────────────────────────────────────────────
   - method: GET
     path: '/cline_mcp_settings.json'
     matchers:
       - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# Windsurf (Codeium)
+# ──────────────────────────────────────────────
   - method: GET
     path: '/mcp_config.json'
     matchers:
       - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# VS Code Copilot (workspace-level)
+# ──────────────────────────────────────────────
   - method: GET
     path: '/.vscode/mcp.json'
     matchers:
       - body="mcpServers"
+
+# ──────────────────────────────────────────────
+# Zed editor
+# ──────────────────────────────────────────────
   - method: GET
     path: '/.config/zed/settings.json'
     matchers:
       - body="context_servers"
+
+# ──────────────────────────────────────────────
+# Goose (Block Inc.)
+# ──────────────────────────────────────────────
   - method: GET
     path: '/.config/goose/config.yaml'
     matchers:
       - body="extensions"
+
+# ──────────────────────────────────────────────
+# Generic .env with AI API keys
+# ──────────────────────────────────────────────
   - method: GET
     path: '/.env'
     matchers:
-      - body="OPENAI_API_KEY" || body="ANTHROPIC_API_KEY" || body="GEMINI_API_KEY" || body="OPENROUTER_API_KEY"
+      - body="OPENAI_API_KEY" || body="ANTHROPIC_API_KEY" || body="GEMINI_API_KEY" || body="OPENROUTER_API_KEY" || body="DEEPSEEK_API_KEY" || body="HUNYUAN_API_KEY"

--- a/data/fingerprints/ai-agent-config.yaml
+++ b/data/fingerprints/ai-agent-config.yaml
@@ -14,17 +14,17 @@ http:
   - method: GET
     path: '/claude_desktop_config.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
   - method: GET
     path: '/.claude.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
   - method: GET
     path: '/.mcp.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
 # Cursor
@@ -32,23 +32,23 @@ http:
   - method: GET
     path: '/.cursor/mcp.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
-# Trae IDE (ByteDance) — project-level & user-level
+# Trae IDE (ByteDance)
 # ──────────────────────────────────────────────
   - method: GET
     path: '/.trae/mcp.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
-# CodeBuddy (Tencent Cloud) — VSCode extension globalStorage
+# CodeBuddy (Tencent Cloud)
 # ──────────────────────────────────────────────
   - method: GET
     path: '/mcp_settings.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
 # Continue
@@ -56,7 +56,7 @@ http:
   - method: GET
     path: '/.continue/config.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
 # Cline / Roo-Cline (VSCode extension)
@@ -64,7 +64,7 @@ http:
   - method: GET
     path: '/cline_mcp_settings.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
 # Windsurf (Codeium)
@@ -72,7 +72,7 @@ http:
   - method: GET
     path: '/mcp_config.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
 # VS Code Copilot (workspace-level)
@@ -80,15 +80,15 @@ http:
   - method: GET
     path: '/.vscode/mcp.json'
     matchers:
-      - body~="\"mcpServers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
-# Zed editor — context_servers is the MCP key in Zed
+# Zed editor
 # ──────────────────────────────────────────────
   - method: GET
     path: '/.config/zed/settings.json'
     matchers:
-      - body~="\"context_servers\"\s*:\s*\{"
+      - body~="^\s*\{"
 
 # ──────────────────────────────────────────────
 # Goose (Block Inc.) — YAML format
@@ -96,7 +96,7 @@ http:
   - method: GET
     path: '/.config/goose/config.yaml'
     matchers:
-      - body~="extensions\s*:\s*\n\s+-\s+name\s*:"
+      - body~="(?m)^\w+\s*:"
 
 # ──────────────────────────────────────────────
 # Generic .env with AI API keys
@@ -104,4 +104,4 @@ http:
   - method: GET
     path: '/.env'
     matchers:
-      - body~="(OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|OPENROUTER_API_KEY|DEEPSEEK_API_KEY|HUNYUAN_API_KEY)\s*=\s*[A-Za-z0-9_\-]{16,}"
+      - body~="(?m)^[A-Z][A-Z0-9_]+=\S"

--- a/data/vuln/AI-Agent-Config/agent-config-disclosure.yaml
+++ b/data/vuln/AI-Agent-Config/agent-config-disclosure.yaml
@@ -1,0 +1,42 @@
+info:
+  name: AI-Agent-Config
+  cve: ""
+  summary: AI Agent 配置文件公开访问导致敏感信息泄露（MCP Server 配置、API 密钥）
+  details: |
+    AI Agent 工具（如 Claude Desktop、Cursor、Cline、Windsurf、Continue 等）将 MCP（Model Context Protocol）Server
+    的配置信息存储在特定路径的 JSON/YAML 配置文件中。这些文件通常包含以下敏感信息：
+
+    - MCP Server 地址及访问端点
+    - API 密钥（如 OPENAI_API_KEY、ANTHROPIC_API_KEY 等）
+    - 本地命令执行配置（command、args 字段）
+    - 内部服务地址及认证信息
+
+    当目标服务器错误地将这些配置文件通过 HTTP 对外暴露时，攻击者可以：
+    1. 获取配置的 AI 服务端点及认证凭据，进行未授权访问
+    2. 枚举内网 AI 基础设施部署情况
+    3. 窃取 API 密钥造成经济损失或数据泄露
+
+    涉及的常见配置文件路径：
+    - claude_desktop_config.json（Claude Desktop）
+    - .claude.json / .mcp.json（Claude Code）
+    - .cursor/mcp.json（Cursor）
+    - .continue/config.json（Continue）
+    - cline_mcp_settings.json（Cline/Roo-Cline）
+    - mcp_config.json（Windsurf）
+    - .vscode/mcp.json（VS Code Copilot）
+    - .config/zed/settings.json（Zed）
+    - .config/goose/config.yaml（Goose）
+    - .env（含 AI API 密钥的环境变量文件）
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: |
+    1. 确保 Web 服务器不将上述配置文件暴露在公网可访问路径下。
+    2. 在 Nginx/Apache 等 Web 服务器中配置规则，拒绝访问 .json、.yaml、.env 等配置文件：
+       Nginx: location ~* \.(json|yaml|env)$ { deny all; }
+    3. 将配置文件存放在 Web 根目录之外。
+    4. 定期审计服务器上可被 HTTP 访问的文件列表。
+    5. 对已泄露的 API 密钥立即进行轮换。
+references:
+  - https://modelcontextprotocol.io/quickstart/user
+  - https://github.com/Tencent/AI-Infra-Guard
+rule: ""

--- a/data/vuln/AI-Agent-Config/agent-config-disclosure.yaml
+++ b/data/vuln/AI-Agent-Config/agent-config-disclosure.yaml
@@ -20,6 +20,8 @@ info:
     - claude_desktop_config.json（Claude Desktop）
     - .claude.json / .mcp.json（Claude Code）
     - .cursor/mcp.json（Cursor）
+    - .trae/mcp.json（Trae IDE，字节跳动）
+    - mcp_settings.json（CodeBuddy，腾讯云代码助手）
     - .continue/config.json（Continue）
     - cline_mcp_settings.json（Cline/Roo-Cline）
     - mcp_config.json（Windsurf）
@@ -35,7 +37,7 @@ info:
        Nginx: location ~* \.(json|yaml|env)$ { deny all; }
     3. 将配置文件存放在 Web 根目录之外。
     4. 定期审计服务器上可被 HTTP 访问的文件列表。
-    5. 对已泄露的 API 密钥立即进行轮换。
+    5. 对已泄露的 API 密钥（OPENAI_API_KEY、ANTHROPIC_API_KEY、DEEPSEEK_API_KEY、HUNYUAN_API_KEY 等）立即进行轮换。
 references:
   - https://modelcontextprotocol.io/quickstart/user
   - https://github.com/Tencent/AI-Infra-Guard

--- a/data/vuln_en/AI-Agent-Config/agent-config-disclosure.yaml
+++ b/data/vuln_en/AI-Agent-Config/agent-config-disclosure.yaml
@@ -1,0 +1,43 @@
+info:
+  name: AI-Agent-Config
+  cve: ""
+  summary: AI agent config file publicly accessible — MCP server configuration and API keys exposed
+  details: |
+    AI agent tools (Claude Desktop, Cursor, Cline, Windsurf, Continue, etc.) store their
+    MCP (Model Context Protocol) server configurations in well-known JSON/YAML config files.
+    These files typically contain sensitive information including:
+
+    - MCP server URLs and endpoints
+    - API keys (e.g., OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY)
+    - Local command execution configurations (command, args fields)
+    - Internal service addresses and authentication credentials
+
+    When a server misconfigures its web root to expose these files over HTTP, an attacker can:
+    1. Obtain AI service endpoints and credentials for unauthorized access
+    2. Enumerate the internal AI infrastructure deployment
+    3. Steal API keys leading to financial loss or data breach
+
+    Common config file paths covered:
+    - claude_desktop_config.json (Claude Desktop)
+    - .claude.json / .mcp.json (Claude Code)
+    - .cursor/mcp.json (Cursor)
+    - .continue/config.json (Continue)
+    - cline_mcp_settings.json (Cline / Roo-Cline VSCode extension)
+    - mcp_config.json (Windsurf)
+    - .vscode/mcp.json (VS Code Copilot MCP)
+    - .config/zed/settings.json (Zed)
+    - .config/goose/config.yaml (Goose)
+    - .env (environment variable files containing AI API keys)
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: |
+    1. Ensure the web server does not serve the above config files from a publicly accessible path.
+    2. Configure deny rules in Nginx/Apache to block access to config file extensions:
+       Nginx: location ~* \.(json|yaml|env)$ { deny all; }
+    3. Store config files outside the web root directory.
+    4. Periodically audit which files are reachable via HTTP on your server.
+    5. Immediately rotate any API keys that may have been exposed.
+references:
+  - https://modelcontextprotocol.io/quickstart/user
+  - https://github.com/Tencent/AI-Infra-Guard
+rule: ""

--- a/data/vuln_en/AI-Agent-Config/agent-config-disclosure.yaml
+++ b/data/vuln_en/AI-Agent-Config/agent-config-disclosure.yaml
@@ -21,6 +21,8 @@ info:
     - claude_desktop_config.json (Claude Desktop)
     - .claude.json / .mcp.json (Claude Code)
     - .cursor/mcp.json (Cursor)
+    - .trae/mcp.json (Trae IDE, ByteDance)
+    - mcp_settings.json (CodeBuddy, Tencent Cloud Code Assistant)
     - .continue/config.json (Continue)
     - cline_mcp_settings.json (Cline / Roo-Cline VSCode extension)
     - mcp_config.json (Windsurf)
@@ -36,7 +38,7 @@ info:
        Nginx: location ~* \.(json|yaml|env)$ { deny all; }
     3. Store config files outside the web root directory.
     4. Periodically audit which files are reachable via HTTP on your server.
-    5. Immediately rotate any API keys that may have been exposed.
+    5. Immediately rotate any API keys that may have been exposed (OPENAI_API_KEY, ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, HUNYUAN_API_KEY, etc.).
 references:
   - https://modelcontextprotocol.io/quickstart/user
   - https://github.com/Tencent/AI-Infra-Guard


### PR DESCRIPTION
## Summary

Closes #339

Adds fingerprint + vulnerability rules to detect AI agent config files that are **publicly accessible over HTTP**, which can leak MCP server configurations and API keys.

## Files Changed

### `data/fingerprints/ai-agent-config.yaml` (new)
Probes 11 well-known agent config file paths:

| Path | Matcher |
|---|---|
| `/claude_desktop_config.json` | `mcpServers` |
| `/.claude.json` | `mcpServers` |
| `/.mcp.json` | `mcpServers` |
| `/.cursor/mcp.json` | `mcpServers` |
| `/.continue/config.json` | `mcpServers` |
| `/cline_mcp_settings.json` | `mcpServers` |
| `/mcp_config.json` | `mcpServers` |
| `/.vscode/mcp.json` | `mcpServers` |
| `/.config/zed/settings.json` | `context_servers` |
| `/.config/goose/config.yaml` | `extensions` |
| `/.env` | `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` / `OPENROUTER_API_KEY` |

### `data/vuln/AI-Agent-Config/agent-config-disclosure.yaml` (new)
Chinese vuln description, severity **HIGH**, `rule: ""`

### `data/vuln_en/AI-Agent-Config/agent-config-disclosure.yaml` (new)
English vuln description, severity **HIGH**, `rule: ""`

## Validation

```
OK: name=AI-Agent-Config, http rules=11
OK: data/vuln/AI-Agent-Config/agent-config-disclosure.yaml | name=AI-Agent-Config severity=HIGH rule=""
OK: data/vuln_en/AI-Agent-Config/agent-config-disclosure.yaml | name=AI-Agent-Config severity=HIGH rule=""
```

All rules parsed and validated successfully. `go build ./...` passes.