### PR TITLE
fix(tools): make tool name lookup case-insensitive

### DIFF
--- a/agent-scan/tools/registry.py
+++ b/agent-scan/tools/registry.py
@@ -109,7 +109,16 @@ def register_tool(
 
 
 def get_tool_by_name(name: str) -> Callable[..., Any] | None:
-    return _tools_by_name.get(name)
+    # Try exact match first
+    tool = _tools_by_name.get(name)
+    if tool is not None:
+        return tool
+    # Fallback: case-insensitive lookup (LLMs may capitalize tool names)
+    name_lower = name.lower()
+    for key, func in _tools_by_name.items():
+        if key.lower() == name_lower:
+            return func
+    return None
 
 
 def get_tool_names() -> list[str]:
@@ -134,8 +143,9 @@ def needs_context(tool_name: str) -> bool:
 
 
 def should_execute_in_sandbox(tool_name: str) -> bool:
+    tool_name_lower = tool_name.lower()
     for tool in tools:
-        if tool.get("name") == tool_name:
+        if tool.get("name", "").lower() == tool_name_lower:
             return bool(tool.get("sandbox_execution", True))
     return True
 

--- a/mcp-scan/tools/registry.py
+++ b/mcp-scan/tools/registry.py
@@ -107,7 +107,16 @@ def register_tool(
 
 
 def get_tool_by_name(name: str) -> Callable[..., Any] | None:
-    return _tools_by_name.get(name)
+    # Try exact match first
+    tool = _tools_by_name.get(name)
+    if tool is not None:
+        return tool
+    # Fallback: case-insensitive lookup (LLMs may capitalize tool names)
+    name_lower = name.lower()
+    for key, func in _tools_by_name.items():
+        if key.lower() == name_lower:
+            return func
+    return None
 
 
 def get_tool_names() -> list[str]:
@@ -132,8 +141,9 @@ def needs_context(tool_name: str) -> bool:
 
 
 def should_execute_in_sandbox(tool_name: str) -> bool:
+    tool_name_lower = tool_name.lower()
     for tool in tools:
-        if tool.get("name") == tool_name:
+        if tool.get("name", "").lower() == tool_name_lower:
             return bool(tool.get("sandbox_execution", True))
     return True
 


### PR DESCRIPTION
## Summary

Fixes #359

LLMs may return tool names with different capitalization (e.g., `Read_file` instead of `read_file`). The previous exact-match lookup in `get_tool_by_name()` would fail in these cases, causing tool execution to silently fail.

## Changes

- **`agent-scan/tools/registry.py`**: `get_tool_by_name()` now tries exact match first for performance, then falls back to case-insensitive comparison
- **`mcp-scan/tools/registry.py`**: Same fix applied
- Both modules: `should_execute_in_sandbox()` also updated for consistency

## Testing

- Exact match still works (no performance regression)
- Case-insensitive fallback correctly matches `Read_file`, `READ_FILE`, etc.
- Non-existent tools still return `None`