### PR TITLE
fix(chromium): add defer Close() to prevent zombie processes

### DIFF
--- a/common/runner/ai.go
+++ b/common/runner/ai.go
@@ -111,6 +111,7 @@ func ScreenShot(url string) ([]byte, error) {
 		gologger.WithError(err).Errorf("new screenshot instance error: %s", err)
 		return nil, err
 	}
+	defer instance.Close()
 	shotData, err := instance.Screen(url)
 	if err != nil {
 		gologger.WithError(err).Errorf("get screenshot error: %s", err)


### PR DESCRIPTION
## Problem

When running AI Infrastructure Scan with many targets (100+ URLs), the backend reports Chrome launch failures and chromium zombie processes accumulate, causing tasks to hang indefinitely.

**Root Cause:** `ScreenShot()` in `common/runner/ai.go` creates a new Chrome browser instance via `NewWebScreenShotWithOptions()` for each URL but never calls `instance.Close()`. This leads to resource exhaustion as chromium processes are never cleaned up.

## Fix

Add `defer instance.Close()` immediately after successful browser instance creation.

## Impact

- Prevents chromium zombie process accumulation
- Fixes task hang when scanning many targets
- Minimal change, single line addition

Closes #374