### PR TITLE
fix(scan): resolve uv run failures in Docker and improve dify version detection

### DIFF
--- a/common/agent/agent_task.go
+++ b/common/agent/agent_task.go
@@ -95,7 +95,7 @@ func (m *AgentTask) Execute(ctx context.Context, request TaskRequest, callbacks 
 
 	// Build command arguments
 	var argv []string
-	argv = append(argv, "run", "main.py")
+	argv = append(argv, "run", "--no-project", "main.py")
 	argv = append(argv, "-m", params.EvalModel.Model)
 	argv = append(argv, "-k", params.EvalModel.ApiKey)
 	argv = append(argv, "-u", params.EvalModel.BaseUrl)

--- a/common/agent/mcp_task.go
+++ b/common/agent/mcp_task.go
@@ -132,7 +132,7 @@ func (m *McpTask) Execute(ctx context.Context, request TaskRequest, callbacks Ta
 	}
 
 	var argv []string = make([]string, 0)
-	argv = append(argv, "run", "main.py")
+	argv = append(argv, "run", "--no-project", "main.py")
 	argv = append(argv, "--model", params.Model.Model)
 	argv = append(argv, "--base_url", params.Model.BaseUrl)
 	argv = append(argv, "--api_key", params.Model.Token)

--- a/common/agent/prompt_tasks.go
+++ b/common/agent/prompt_tasks.go
@@ -91,7 +91,7 @@ func (m *ModelRedteamReport) Execute(ctx context.Context, request TaskRequest, c
 		request.Language = "zh"
 	}
 	var argv []string = make([]string, 0)
-	argv = append(argv, "run", "cli_run.py")
+	argv = append(argv, "run", "--no-project", "cli_run.py")
 	argv = append(argv, "--async_mode")
 
 	for _, model := range param.Model {

--- a/data/fingerprints/dify.yaml
+++ b/data/fingerprints/dify.yaml
@@ -13,8 +13,14 @@ http:
       - body="content=\"Dify"
 version:
   - method: GET
+    path: '/health'
+    extractor:
+      part: header
+      group: 1
+      regex: 'x-version:\s*(\d+\.\d+\.?\d*)'
+  - method: GET
     path: '/console/api/version'
     extractor:
       part: header
       group: 1
-      regex: 'x-version:\s*(\d+\.\d+\.?\d+?)'
+      regex: 'x-version:\s*(\d+\.\d+\.?\d*)'


### PR DESCRIPTION
## Summary

Fixes two user-reported issues:

### Issue #385: MCP Scan Skills zip scan reports "exit status 2"

**Root Cause:** `uv run main.py` attempts to resolve `pyproject.toml` and create/sync a virtual environment. In Docker containers where dependencies are installed via `pip install -r requirements.txt` to the system Python, this fails with exit status 2 (especially in offline/restricted environments or when `.venv` creation has permission issues).

**Fix:** Add `--no-project` flag to all `uv run` commands (`mcp_task.go`, `agent_task.go`, `prompt_tasks.go`). This tells uv to skip project resolution and use the system Python directly, which already has all required dependencies installed.

### Issue #375: Dify vulnerabilities not detected when version cannot be obtained

**Root Cause:** The version extractor uses `/console/api/version` which requires authentication in most dify deployments. When accessed without auth, the endpoint returns a redirect/401, and the `x-version` header is absent.

**Fix:**
- Add `/health` as the primary version extraction endpoint (does not require authentication, and dify injects `X-Version` header on ALL responses via `after_request` middleware)
- Keep `/console/api/version` as fallback
- Improve regex to use greedy quantifier for more reliable version matching (`\\d*` instead of `\\d+?`)

**Note on #375:** Code analysis confirms that when version is empty, `GetAdvisories()` correctly returns ALL advisories for the component. The actual issue is likely that the user's AIG version is outdated (missing latest vuln rules) or the fingerprint failed to match. With this fix, version extraction should work more reliably across different dify deployments.

Closes #385
Ref #375