### PR TITLE
fix(scoring): replace weighted ratio with absolute deduction model (Closes #403)

### DIFF
--- a/common/runner/runner.go
+++ b/common/runner/runner.go
@@ -22,7 +22,6 @@ package runner
 import (
 	"bufio"
 	"fmt"
-	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -721,24 +720,15 @@ func (r *Runner) CalcSecScore(advisories []vulstruct.Info) CallbackReportInfo {
 			LowRisk:    0,
 		}
 	}
-	// 计算加权风险比例
-	weightedRisk := (float64(high)/float64(total))*0.7 +
-		(float64(middle)/float64(total))*0.5 +
-		(float64(low)/float64(total))*0.3
-
-	// 计算安全评分（百分制）
-	safetyScore := 100 - weightedRisk*100
-
-	// 确保评分在0-100范围内
+	// 绝对扣分制：每个 critical/high -70，medium -30，low -10，扣到 0 为止
+	deduction := high*70 + middle*30 + low*10
+	safetyScore := 100 - deduction
 	if safetyScore < 0 {
 		safetyScore = 0
 	}
-	if safetyScore >= 100 {
-		safetyScore = 100
-	}
 
 	ret := CallbackReportInfo{
-		SecScore:   int(math.Round(safetyScore)),
+		SecScore:   safetyScore,
 		HighRisk:   high,
 		MediumRisk: middle,
 		LowRisk:    low,


### PR DESCRIPTION
## Summary

Fixes #403 — Scoring system produces counter-intuitive results when using the weighted-ratio formula.

## Root Cause

The previous formula:
```
weightedRisk = (high/total)*0.7 + (medium/total)*0.5 + (low/total)*0.3
safetyScore  = 100 - weightedRisk*100
```
used **proportions**, meaning adding low-severity vulns could dilute the ratio and paradoxically raise the score.

## Fix

Switch to an **absolute deduction model** — each vulnerability deducts a fixed number of points from 100, floor at 0:

| Severity | Deduction |
|---|---|
| critical / high | −70 pts each |
| medium | −30 pts each |
| low | −10 pts each |

This guarantees: more vulnerabilities → score stays same or goes down, never up.

## Test cases

| Scenario | Old score | New score |
|---|---|---|
| 1 high vuln | 30 | 30 |
| 1 high + 19 low vulns | 68 ❌ | 0 (capped) ✅ |
| 20 high vulns | 30 ❌ | 0 (capped) ✅ |
| 1 medium vuln | 50 | 70 |
| 2 low vulns | 70 | 80 |