### PR TITLE
fix(agent-scan): register 4 new detection skills in _DETECTION_SKILLS

### DIFF
--- a/agent-scan/core/agent.py
+++ b/agent-scan/core/agent.py
@@ -56,6 +56,10 @@ _DETECTION_SKILLS: List[str] = [
     "tool-abuse-detection",
     "indirect-injection-detection",
     "authorization-bypass-detection",
+    "direct-injection-detection",
+    "file-path-traversal-detection",
+    "hardcoded-secret-detection",
+    "memory-poisoning-detection",
 ]
 
 # Maximum number of skill workers allowed to call ``dialogue()`` simultaneously.


### PR DESCRIPTION
## Summary

Four detection skills added in PR #444 were never registered in `_DETECTION_SKILLS` in `agent-scan/core/agent.py`, so they were silently never executed during agent scans.

## Root Cause

PR #444 added 4 new skill files under `agent-scan/prompt/skills/` but did not update the `_DETECTION_SKILLS` list in `agent.py`. This list controls which skills are actually spawned as workers during Stage 2 of an agent scan.

## Fix

Added the 4 missing skills to `_DETECTION_SKILLS`:

```python
_DETECTION_SKILLS: List[str] = [
    "data-leakage-detection",
    "tool-abuse-detection",
    "indirect-injection-detection",
    "authorization-bypass-detection",
    # Newly registered (were present but not executed):
    "direct-injection-detection",
    "file-path-traversal-detection",
    "hardcoded-secret-detection",
    "memory-poisoning-detection",
]
```

## Impact

After this fix, agent scans will detect:
- **Direct Prompt Injection** (`direct-injection-detection`) — ASI01
- **File Path Traversal** (`file-path-traversal-detection`) — ASI05
- **Hardcoded Secrets** (`hardcoded-secret-detection`) — ASI06
- **Memory Poisoning** (`memory-poisoning-detection`) — ASI06

These are critical security detection capabilities that were previously available but silently skipped.

**Reference**: PR #429 (by @DevamShah) correctly demonstrated the pattern — both SKILL.md + agent.py registration in the same PR.