### PR TITLE
feat: add CVE rules

### DIFF
--- a/data/vuln/jan/CVE-2024-36857.yaml
+++ b/data/vuln/jan/CVE-2024-36857.yaml
@@ -1,0 +1,19 @@
+info:
+  name: jan
+  cve: CVE-2024-36857
+  summary: Jan 任意文件读取漏洞
+  details: |
+    Jan v0.4.12 的 /v1/app/readFileSync 接口存在任意文件读取漏洞。
+    攻击者可以通过该接口读取服务器上的任意文件，无需身份验证即可利用。
+    这可能导致敏感配置文件、密钥等机密信息泄露。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: |
+    1. 升级到 Jan v0.5.2 或更高版本
+    2. 对 readFileSync 接口实施路径白名单校验，限制可访问的文件范围
+    3. 添加身份验证机制，防止未授权访问
+rule: version <= "0.4.12"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-36857
+  - https://github.com/HackAllSec/CVEs/tree/main/Jan%20AFR%20vulnerability
+  - https://github.com/janhq/jan

--- a/data/vuln/jan/CVE-2024-36858.yaml
+++ b/data/vuln/jan/CVE-2024-36858.yaml
@@ -1,0 +1,21 @@
+info:
+  name: jan
+  cve: CVE-2024-36858
+  summary: Jan 任意文件上传导致远程代码执行漏洞
+  details: |
+    Jan v0.4.12 的 /v1/app/writeFileSync 接口存在任意文件上传漏洞。
+    攻击者可以通过上传恶意构造的文件来执行任意代码，无需身份验证即可利用。
+    攻击者可以上传恶意脚本文件到服务器的任意路径，从而在宿主系统上实现远程代码执行，
+    完全控制服务器，可能导致敏感数据泄露、权限提升或系统破坏。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: |
+    1. 升级到 Jan v0.5.2 或更高版本
+    2. 对 writeFileSync 接口实施严格的路径限制和文件类型白名单
+    3. 添加身份验证机制，防止未授权访问
+    4. 禁止向可执行文件目录写入文件
+rule: version <= "0.4.12"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-36858
+  - https://github.com/HackAllSec/CVEs/tree/main/Jan%20Arbitrary%20File%20Upload%20vulnerability
+  - https://github.com/janhq/jan

--- a/data/vuln/jan/CVE-2024-36858.yaml
+++ b/data/vuln/jan/CVE-2024-36858.yaml
@@ -14,8 +14,9 @@ info:
     2. 对 writeFileSync 接口实施严格的路径限制和文件类型白名单
     3. 添加身份验证机制，防止未授权访问
     4. 禁止向可执行文件目录写入文件
-rule: version <= "0.4.12"
+rule: version > "0" && version < "0.5.2"
 references:
+  - https://github.com/advisories/GHSA-qfjh-mvq6-c5p8
   - https://nvd.nist.gov/vuln/detail/CVE-2024-36858
   - https://github.com/HackAllSec/CVEs/tree/main/Jan%20Arbitrary%20File%20Upload%20vulnerability
   - https://github.com/janhq/jan

--- a/data/vuln/localai/CVE-2024-3135.yaml
+++ b/data/vuln/localai/CVE-2024-3135.yaml
@@ -1,0 +1,20 @@
+info:
+  name: localai
+  cve: CVE-2024-3135
+  summary: LocalAI 跨站请求伪造漏洞（CSRF）
+  details: |
+    mudler/localai 应用程序中存在跨站请求伪造（CSRF）漏洞。
+    攻击者可以构造恶意网页，当受害者访问时，可以在未经其同意的情况下对受害者的本地 LocalAI 实例执行未经授权的操作。
+    此漏洞使攻击者能够利用受害者的本地 LocalAI 实例生成不当内容或消耗计算资源。
+    该漏洞目前未被修复，所有已知版本均受影响。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L
+  severity: LOW
+  security_advise: |
+    1. 在 LocalAI API 请求中添加 CSRF Token 验证机制
+    2. 对敏感操作实施 SameSite Cookie 属性
+    3. 验证请求的 Origin 和 Referer 头部
+rule: ""
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-3135
+  - https://huntr.com/bounties/7afdc4d3-4b68-45ea-96d0-cf9ed3712ae8
+  - https://github.com/mudler/LocalAI

--- a/data/vuln_en/jan/CVE-2024-36857.yaml
+++ b/data/vuln_en/jan/CVE-2024-36857.yaml
@@ -1,0 +1,20 @@
+info:
+  name: jan
+  cve: CVE-2024-36857
+  summary: Jan Arbitrary File Read Vulnerability
+  details: |
+    Jan v0.4.12 was discovered to contain an arbitrary file read vulnerability
+    via the /v1/app/readFileSync interface. An attacker can read arbitrary files
+    on the server without authentication, potentially exposing sensitive
+    configuration files, credentials, and other confidential information.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: |
+    1. Upgrade to Jan v0.5.2 or later
+    2. Implement path whitelist validation for the readFileSync interface to restrict accessible file scope
+    3. Add authentication mechanisms to prevent unauthorized access
+rule: version <= "0.4.12"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-36857
+  - https://github.com/HackAllSec/CVEs/tree/main/Jan%20AFR%20vulnerability
+  - https://github.com/janhq/jan

--- a/data/vuln_en/jan/CVE-2024-36858.yaml
+++ b/data/vuln_en/jan/CVE-2024-36858.yaml
@@ -1,0 +1,23 @@
+info:
+  name: jan
+  cve: CVE-2024-36858
+  summary: Jan Arbitrary File Upload Leading to Remote Code Execution
+  details: |
+    An arbitrary file upload vulnerability in the /v1/app/writeFileSync interface
+    of Jan v0.4.12 allows attackers to execute arbitrary code via uploading a
+    crafted file. An attacker can upload malicious script files to arbitrary paths
+    on the server without authentication, achieving remote code execution on the
+    host system. This can lead to complete server compromise, sensitive data
+    exfiltration, privilege escalation, or system destruction.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: |
+    1. Upgrade to Jan v0.5.2 or later
+    2. Implement strict path restrictions and file type whitelists for the writeFileSync interface
+    3. Add authentication mechanisms to prevent unauthorized access
+    4. Prohibit writing files to executable directories
+rule: version <= "0.4.12"
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-36858
+  - https://github.com/HackAllSec/CVEs/tree/main/Jan%20Arbitrary%20File%20Upload%20vulnerability
+  - https://github.com/janhq/jan

--- a/data/vuln_en/jan/CVE-2024-36858.yaml
+++ b/data/vuln_en/jan/CVE-2024-36858.yaml
@@ -16,8 +16,9 @@ info:
     2. Implement strict path restrictions and file type whitelists for the writeFileSync interface
     3. Add authentication mechanisms to prevent unauthorized access
     4. Prohibit writing files to executable directories
-rule: version <= "0.4.12"
+rule: version > "0" && version < "0.5.2"
 references:
+  - https://github.com/advisories/GHSA-qfjh-mvq6-c5p8
   - https://nvd.nist.gov/vuln/detail/CVE-2024-36858
   - https://github.com/HackAllSec/CVEs/tree/main/Jan%20Arbitrary%20File%20Upload%20vulnerability
   - https://github.com/janhq/jan

--- a/data/vuln_en/localai/CVE-2024-3135.yaml
+++ b/data/vuln_en/localai/CVE-2024-3135.yaml
@@ -1,0 +1,22 @@
+info:
+  name: localai
+  cve: CVE-2024-3135
+  summary: LocalAI Cross-Site Request Forgery (CSRF)
+  details: |
+    A Cross-Site Request Forgery (CSRF) vulnerability exists in the mudler/localai application,
+    allowing attackers to craft malicious webpages that, when visited by a victim, perform
+    unauthorized actions on the victim's local LocalAI instance without their consent.
+    This vulnerability enables attackers to leverage the victim's local LocalAI instance
+    to generate inappropriate content or consume computational resources.
+    This vulnerability is currently unpatched and all known versions are affected.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L
+  severity: LOW
+  security_advise: |
+    1. Implement CSRF Token validation for LocalAI API requests
+    2. Enforce SameSite Cookie attributes for sensitive operations
+    3. Validate the Origin and Referer headers of requests
+rule: ""
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-3135
+  - https://huntr.com/bounties/7afdc4d3-4b68-45ea-96d0-cf9ed3712ae8
+  - https://github.com/mudler/LocalAI


### PR DESCRIPTION


Add vulnerability detection rules for two AI components that previously had fingerprints but no corresponding CVE rules:

- Jan CVE-2024-36857: Arbitrary file read via /v1/app/readFileSync (CVSS 7.5, HIGH)
- Jan CVE-2024-36858: Arbitrary file upload RCE via /v1/app/writeFileSync (CVSS 9.8, CRITICAL)
- LocalAI CVE-2024-3135: Cross-Site Request Forgery (CSRF) (CVSS 3.0, LOW)

All rules include both Chinese (data/vuln/) and English (data/vuln_en/) versions. CVSS scores and descriptions are sourced from NVD API. All YAML files pass yamlcheck validation.