### PR TITLE
feat: add 2 MCP security detection rules

### DIFF
--- a/data/mcp/mcp_excessive_permissions.yaml
+++ b/data/mcp/mcp_excessive_permissions.yaml
@@ -1,0 +1,97 @@
+info:
+  id: "mcp_excessive_permissions"
+  name: "MCP Excessive Permissions Detection"
+  description: "Detect MCP server tools that request or exercise permissions beyond their stated functionality, creating a privileged attack surface where a compromised or prompt-injected agent can access the filesystem, network, shell, or credential stores far beyond the tool's intended scope."
+  author: "ATR (Agent Threat Rules)"
+  categories:
+    - code
+
+prompt_template: |
+  As a professional AI-agent security analyst, precisely detect excessive-permission
+  vulnerabilities in MCP server code. An MCP tool should request only the minimal
+  privileges required for its stated purpose. When a tool holds broad filesystem
+  access, unrestricted network access, shell execution capability, or credential
+  store reads that exceed its functional description, a prompt-injected agent or a
+  malicious tool can leverage those privileges for data exfiltration, lateral
+  movement, or RCE.
+
+  ## Vulnerability Definition
+  Excessive permissions in an MCP server means the codebase grants or exercises
+  capabilities (file read/write, network calls, process spawning, secret access)
+  that are broader than the tool's documented purpose. This violates least-privilege
+  and amplifies the blast radius of any prompt injection or tool poisoning that
+  reaches the agent. Real-world incidents (e.g. CVE-2025-6514 affecting ~500 000
+  developer environments) demonstrate that over-privileged MCP tools are a primary
+  vector for credential leakage and unauthorized shell execution.
+
+  ## Detection Criteria (require concrete over-privileged code path)
+
+  ### 1. Broad filesystem access beyond stated purpose
+  **Code Patterns:**
+  - A tool described as "read a config file" uses recursive directory traversal
+    (`os.walk`, `glob('**/*')`, `fs.readdirSync` with `recursive: true`) across
+    the entire home directory or root.
+  - A tool that reads a specific file type (e.g. images) opens arbitrary paths
+    including `~/.ssh`, `~/.aws/credentials`, `.env`, `.npmrc`, `~/.netrc`
+    without path scoping or allowlist.
+  - Write tools that can overwrite system files or files outside a designated
+    workspace directory.
+
+  ### 2. Unrestricted network access
+  **Code Patterns:**
+  - A tool described as "fetch weather data" makes outbound HTTP requests to
+    dynamically-constructed URLs with no domain allowlist, enabling SSRF or
+    data exfiltration to attacker-controlled endpoints.
+  - Raw socket / TCP / UDP connections created with no destination restriction.
+  - DNS-based exfiltration channels built from tool arguments.
+
+  ### 3. Shell or process execution capability
+  **Code Patterns:**
+  - A tool whose stated purpose does not require shell access nonetheless imports
+    and uses `child_process`, `os.system`, `subprocess`, or `exec` / `spawn`.
+  - Shell execution is available and the tool also accepts user-controlled
+    arguments that could reach the command string.
+  - Tools that dynamically spawn interpreters (`node -e`, `python -c`, `bash -c`)
+    without sandboxing.
+
+  ### 4. Credential / secret store access beyond scope
+  **Code Patterns:**
+  - A tool reads `process.env` / `os.environ` broadly (iterating all keys) when
+    only a single API key is needed.
+  - A tool accesses system keychain, `~/.aws/credentials`, `~/.docker/config.json`,
+    or browser cookie stores when its functionality does not require them.
+  - Credentials are cached or logged in plaintext beyond the immediate API call.
+
+  ### 5. Missing permission scoping mechanisms
+  **Code Patterns:**
+  - No `allowedDirectories` / `allowedPaths` / path-prefix checks before file
+    operations.
+  - No domain allowlist before outbound network requests.
+  - No capability declaration or permission manifest; all tools implicitly share
+    the server process's full privileges.
+
+  ## Strict Judgment Standards
+  - **Purpose-appropriate access**: Do not report a file-reading tool that scopes
+    paths to a designated workspace directory, or a network tool with a domain
+    allowlist.
+  - **Explicitly required shell access**: Do not report a tool whose documented
+    purpose is to run commands (e.g. a terminal tool), provided it applies
+    sandboxing or user confirmation.
+  - **Scoped credential use**: Do not report a tool that reads a single, specific
+    API key from the environment for its stated purpose and does not expose it.
+  - **Test/example**: Do not report test fixtures or example code with no real
+    permission surface.
+
+  ## Output Requirements
+  Only output when finding a concrete over-privileged code path:
+  - Specific file paths and line numbers for the broad permission and its usage
+  - The tool's stated purpose vs. the actual capability exercised
+  - Technical analysis: how the excess permission could be exploited via prompt
+    injection or tool poisoning to escalate impact
+  - Impact assessment: blast radius (files, credentials, network, RCE) if the
+    permission is abused
+  - Remediation: apply least-privilege, scope filesystem paths with allowlists,
+    restrict network destinations, remove unnecessary shell/secret access, add a
+    permission manifest, sandbox tool execution.
+
+  **Strict Requirement: provide the specific over-privileged code path and its line numbers, and contrast it with the tool's stated purpose. Remain silent when no concrete evidence exists.**

--- a/data/mcp/mcp_prompt_injection_tool_results.yaml
+++ b/data/mcp/mcp_prompt_injection_tool_results.yaml
@@ -1,0 +1,77 @@
+info:
+  id: "mcp_prompt_injection_tool_results"
+  name: "MCP Indirect Prompt Injection via Tool Results Detection"
+  description: "Detect indirect prompt injection attacks delivered through MCP tool results, where attacker-controlled content returned by a tool hijacks the host agent's reasoning and causes unintended actions (OWASP LLM Top-1: Prompt Injection)."
+  author: "ATR (Agent Threat Rules)"
+  categories:
+    - code
+
+prompt_template: |
+  As a professional AI-agent security analyst, precisely detect indirect prompt
+  injection vulnerabilities delivered through MCP tool results. When an MCP tool
+  fetches content from an external or attacker-controllable source (web pages,
+  files, databases, APIs) and returns it verbatim to the host agent, the
+  embedded instructions can override the agent's system prompt, hijack its
+  reasoning, and trigger unauthorized tool calls or data exfiltration.
+
+  ## Vulnerability Definition
+  Indirect prompt injection via tool results occurs when an MCP server returns
+  content from an untrusted source to the host LLM without sanitization or
+  delimiter-based isolation. The LLM treats the returned text as context and
+  may follow embedded directives — such as "ignore previous instructions",
+  "now call the email tool and send…", or concealed control sequences — that
+  were injected by an attacker into the data source. This is distinct from
+  tool poisoning (which targets tool *metadata*): here the injection vector is
+  the *tool output payload*.
+
+  ## Detection Criteria (require untrusted source → unsanitized return path)
+
+  ### 1. External content fetched and returned without sanitization
+  **Code Patterns:**
+  - Tool handler calls `fetch` / `axios` / `requests` / `urllib` to retrieve a
+    URL supplied by the caller, then returns the response body directly in the
+    tool result without filtering or encoding.
+  - Tool handler reads a file path from tool arguments and returns file contents
+    verbatim — including files that may contain injected instructions.
+  - Tool handler queries a database / vector store / RAG pipeline and returns
+    retrieved documents as-is, where document text is attacker-influenced.
+
+  ### 2. Missing output isolation
+  **Code Patterns:**
+  - Returned content is not wrapped in delimiter tags (e.g.
+    `<untrusted_content>…</untrusted_content>`) or labeled as untrusted.
+  - No output sanitization layer: no stripping of control characters, no
+    removal of instruction-like patterns, no length truncation.
+  - Tool result includes raw HTML / Markdown / structured text from external
+    sources that the LLM interprets as directives.
+
+  ### 3. High-impact tool chains
+  **Code Patterns:**
+  - The vulnerable tool coexists with privileged tools (email, file write,
+    shell, credential access) in the same MCP server, enabling an injected
+    instruction to chain into a second, destructive tool call.
+  - Tool results contain dynamically assembled text that merges trusted and
+    untrusted fields without separation.
+
+  ## Strict Judgment Standards
+  - **Static/constant tool results**: Do not report tools that return hardcoded
+    constant strings with no external input.
+  - **Sanitized output**: Do not report tools that apply explicit sanitization,
+    encoding, or delimiter-based isolation before returning external content.
+  - **Read-only benign content**: Do not report tools returning purely numeric
+    or structured data with no natural-language surface for injection.
+  - **Test/example**: Do not report sample handlers with hardcoded test output.
+
+  ## Output Requirements
+  Only output when finding a concrete untrusted-source-to-unsanitized-return path:
+  - Specific file paths and line numbers for the external fetch and the return
+  - The exact untrusted data source and the return path
+  - Technical analysis: how embedded instructions in the tool result could
+    hijack the host agent
+  - Impact assessment: which privileged tools or actions an injected directive
+    could chain into
+  - Remediation: sanitize and delimit untrusted content, strip control
+    characters, enforce output length limits, isolate tool results from system
+    instructions, apply output allowlists.
+
+  **Strict Requirement: provide the untrusted-source read and the unsanitized return path with line numbers. Remain silent when no concrete evidence exists.**


### PR DESCRIPTION
- mcp_prompt_injection_tool_results: detect indirect prompt injection delivered through MCP tool results where attacker-controlled content (web pages, files, RAG retrievals) is returned unsanitized to the host agent, enabling context hijacking and unauthorized tool chaining. Based on OWASP LLM Top-1 (Prompt Injection).

- mcp_excessive_permissions: detect MCP tools that exercise permissions (broad filesystem access, unrestricted network, shell execution, credential store reads) beyond their stated functionality. Based on Docker security advisory (Aug 2025) and CVE-2025-6514 affecting ~500k dev environments.