### PR TITLE
Add ai component fingerprints

### DIFF
--- a/data/fingerprints/autogen-studio.yaml
+++ b/data/fingerprints/autogen-studio.yaml
@@ -1,0 +1,17 @@
+info:
+  name: autogen-studio
+  author: 腾讯朱雀实验室
+  severity: info
+  desc: 微软 AutoGen 多智能体框架的 Web UI 平台，支持团队编排、会话管理和多智能体工作流可视化调试。
+  metadata:
+    product: autogen-studio
+    vendor: microsoft
+http:
+  - method: GET
+    path: '/api/version'
+    matchers:
+      - body="AutoGen Studio API"
+  - method: GET
+    path: '/api/health'
+    matchers:
+      - body="Service is healthy"

--- a/data/fingerprints/autogen-studio.yaml
+++ b/data/fingerprints/autogen-studio.yaml
@@ -1,8 +1,8 @@
 info:
   name: autogen-studio
-  author: 腾讯朱雀实验室
+  author: Elwood Ying
   severity: info
-  desc: 微软 AutoGen 多智能体框架的 Web UI 平台，支持团队编排、会话管理和多智能体工作流可视化调试。
+  desc: Web UI platform for Microsoft AutoGen multi-agent framework, supporting team orchestration, session management, and visual debugging of multi-agent workflows.
   metadata:
     product: autogen-studio
     vendor: microsoft

--- a/data/fingerprints/hayhooks.yaml
+++ b/data/fingerprints/hayhooks.yaml
@@ -1,0 +1,17 @@
+info:
+  name: hayhooks
+  author: 腾讯朱雀实验室
+  severity: info
+  desc: deepset Haystack 的 REST API 服务，用于部署和管理 Haystack 流水线，支持管道部署、状态查询和 OpenAI 兼容接口。
+  metadata:
+    product: hayhooks
+    vendor: deepset
+http:
+  - method: GET
+    path: '/status'
+    matchers:
+      - body="Hayhooks"
+  - method: GET
+    path: '/docs'
+    matchers:
+      - body="Hayhooks"

--- a/data/fingerprints/hayhooks.yaml
+++ b/data/fingerprints/hayhooks.yaml
@@ -1,8 +1,8 @@
 info:
   name: hayhooks
-  author: 腾讯朱雀实验室
+  author: Elwood Ying
   severity: info
-  desc: deepset Haystack 的 REST API 服务，用于部署和管理 Haystack 流水线，支持管道部署、状态查询和 OpenAI 兼容接口。
+  desc: REST API service for deepset Haystack, used for deploying and managing Haystack pipelines with support for pipeline deployment, status queries, and OpenAI-compatible endpoints.
   metadata:
     product: hayhooks
     vendor: deepset

--- a/data/fingerprints/langserve.yaml
+++ b/data/fingerprints/langserve.yaml
@@ -1,8 +1,8 @@
 info:
   name: langserve
-  author: 腾讯朱雀实验室
+  author: Elwood Ying
   severity: info
-  desc: LangChain 官方的 LLM 应用部署工具，基于 FastAPI 将链和代理暴露为 REST API，内置 Playground 交互界面。
+  desc: LangChain's official LLM application deployment tool, built on FastAPI to expose chains and agents as REST APIs with a built-in interactive Playground UI.
   metadata:
     product: langserve
     vendor: langchain-ai

--- a/data/fingerprints/langserve.yaml
+++ b/data/fingerprints/langserve.yaml
@@ -1,0 +1,17 @@
+info:
+  name: langserve
+  author: 腾讯朱雀实验室
+  severity: info
+  desc: LangChain 官方的 LLM 应用部署工具，基于 FastAPI 将链和代理暴露为 REST API，内置 Playground 交互界面。
+  metadata:
+    product: langserve
+    vendor: langchain-ai
+http:
+  - method: GET
+    path: '/docs'
+    matchers:
+      - body="langserve"
+  - method: GET
+    path: '/playground/index.html'
+    matchers:
+      - body="____LANGSERVE_BASE_URL"


### PR DESCRIPTION


Added fingerprinting rules for three popular AI components to expand the scope of component detection. 

## New Fingerprints

### 1. hayhooks (deepset Haystack REST API)
- **Vendor**: deepset
- **Description**: Haystack's REST API service for deploying and managing Haystack pipelines
- **Detection Paths**:
- `GET /status` → Response body contains `Hayhooks`
- `GET /docs` → Response body contains `Hayhooks`
- **Default Port**: 1416
- **Source Basis**: [deepset-ai/hayhooks](https://github.com/deepset-ai/hayhooks) - `APP_TITLE = "Hayhooks"` in `src/hayhooks/settings.py`, `/status` route in `src/hayhooks/server/routers/status.py`

### 2. langserve (LangChain Deployment Tool)
- **Vendor**: langchain-ai
- **Description**: LangChain's official LLM application deployment tool; built on FastAPI and includes a built-in Playground
- **Detection Paths**:
- `GET /docs` → Response body contains `langserve`
- `GET /playground/index.html` → Response body contains `____LANGSERVE_BASE_URL`
- **Source Basis**: [langchain-ai/langserve](https://github.com/langchain-ai/langserve) - Playground route registration logic in `langserve/server.py`, `____LANGSERVE_BASE_URL` variable in HTML templates

### 3. autogen-studio (Microsoft AutoGen Multi-Agent Platform)
- **Vendor**: microsoft
- **Description**: Web UI platform for the Microsoft AutoGen multi-agent framework
- **Detection Paths**:
- `GET /api/version` → Response body contains `AutoGen Studio API`
- `GET /api/health` → Response body contains `Service is healthy`
- **Default Port**: 8081
- **Source Basis**: [microsoft/autogen](https://github.com/microsoft/autogen) - `FastAPI(title="AutoGen Studio API")` in `python/packages/autogen-studio/autogenstudio/web/app.py`, along with the `/api/version` and `/api/health` routes.
