### PR TITLE
feat: add missing English vuln rules for crewai and lobehub

### DIFF
--- a/data/vuln_en/crewai/CVE-2026-2275.yaml
+++ b/data/vuln_en/crewai/CVE-2026-2275.yaml
@@ -1,0 +1,42 @@
+info:
+  name: crewai
+  cve: CVE-2026-2275
+  summary: CrewAI CodeInterpreterTool SandboxPython Fallback Remote Code Execution
+  details: >-
+    The CrewAI CodeInterpreterTool falls back to SandboxPython when Docker is
+    unavailable or unreachable. This fallback environment fails to block the
+    ctypes module and related C-extension mechanisms, allowing arbitrary C
+    function calls that result in Remote Code Execution (RCE). The vulnerability
+    is triggered when: (1) allow_code_execution=True is set in the agent
+    configuration, or (2) the CodeInterpreterTool is manually added to an agent.
+    An attacker who can influence a CrewAI agent via prompt injection can exploit
+    this fallback behavior to escape the intended sandboxed execution context and
+    execute arbitrary code on the host system. This vulnerability is part of a
+    broader set of four CrewAI vulnerabilities (CVE-2026-2275, CVE-2026-2285,
+    CVE-2026-2286, CVE-2026-2287) reported by Yarden Porat of Cyata. The vendor
+    acknowledges the issue and plans to add ctypes and related modules to
+    BLOCKED_MODULES in a future release. No complete patch is available at the
+    time of disclosure (2026-03-30). CWE-749: Exposed Dangerous Method or Function.
+    OSINT: No public PoC or exploit code observed as of 2026-04-03; risk level is
+    moderate given no patch and active community awareness.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    1. Disable the CodeInterpreterTool wherever possible until a patch is released.
+    2. Remove or avoid enabling allow_code_execution=True in agent configuration
+    unless absolutely necessary.
+    3. Ensure Docker is installed and running to prevent fallback to SandboxPython;
+    configure the agent to fail-closed if Docker is unavailable rather than
+    silently falling back.
+    4. Limit agent exposure to untrusted user input and sanitize inputs appropriately.
+    5. Monitor for an updated release of crewai[tools] that adds ctypes and related
+    modules to BLOCKED_MODULES, and upgrade as soon as it is available.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2275
+    - https://www.kb.cert.org/vuls/id/221883
+    - https://docs.crewai.com/en/tools/ai-ml/codeinterpretertool
+rule: 'version <= "1.14.1"'
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-2275
+  - https://www.kb.cert.org/vuls/id/221883
+  - https://docs.crewai.com/en/tools/ai-ml/codeinterpretertool

--- a/data/vuln_en/crewai/CVE-2026-2286.yaml
+++ b/data/vuln_en/crewai/CVE-2026-2286.yaml
@@ -1,0 +1,27 @@
+info:
+  name: crewai
+  cve: CVE-2026-2286
+  summary: CrewAI Server-Side Request Forgery (SSRF) allows access to internal and cloud metadata endpoints
+  details: >-
+    CrewAI contains a server-side request forgery (SSRF) vulnerability in its RAG search
+    tool functionality. An attacker can exploit this vulnerability to make the CrewAI
+    server perform HTTP requests to internal network resources and cloud service metadata
+    endpoints (e.g., AWS/GCP/Azure IMDS at 169.254.169.254). This can lead to exposure
+    of sensitive internal services, cloud credentials via metadata APIs, and internal
+    infrastructure reconnaissance. The vulnerability requires no authentication and
+    achieves a CVSS score of 9.8 (CRITICAL).
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    Update CrewAI to the latest available version which includes SSRF mitigations.
+    As a workaround, restrict outbound network access from the CrewAI server to block
+    access to internal network ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+    and cloud metadata endpoints (169.254.169.254). Validate and sanitize all URLs
+    passed to CrewAI RAG search tools before processing.
+  references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2286
+    - https://github.com/crewAIInc/crewAI
+rule: 'version <= "1.14.1"'
+references:
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-2286
+  - https://github.com/crewAIInc/crewAI

--- a/data/vuln_en/crewai/CVE-2026-2287.yaml
+++ b/data/vuln_en/crewai/CVE-2026-2287.yaml
@@ -1,0 +1,33 @@
+info:
+  name: crewai
+  cve: CVE-2026-2287
+  summary: CrewAI Docker runtime check bypass leads to remote code execution via insecure sandbox fallback
+  details: >-
+    CrewAI does not properly verify that Docker is still running during runtime.
+    When Docker becomes unavailable mid-session, the framework silently falls back
+    to an insecure sandbox mode (SandboxPython) that allows for remote code execution
+    (RCE) exploitation. This vulnerability is part of a chain of four vulnerabilities
+    (CVE-2026-2275, CVE-2026-2285, CVE-2026-2286, CVE-2026-2287) disclosed in
+    CrewAI by researcher Yarden Porat of Cyata. An attacker who can interact with
+    a CrewAI agent that has the Code Interpreter Tool enabled (allow_code_execution=True)
+    may exploit this vulnerability through prompt injection to chain these issues and
+    achieve arbitrary code execution on the host. The vendor has acknowledged the issue
+    and plans to fail-closed rather than fall back to sandbox mode in an upcoming release,
+    but no complete patch is available at time of disclosure.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+  severity: CRITICAL
+  security_advise: >-
+    No complete patch is available at time of disclosure. Mitigations include:
+    (1) Remove or disable the Code Interpreter Tool wherever possible;
+    (2) Avoid enabling allow_code_execution=True unless absolutely necessary;
+    (3) Limit agent exposure to untrusted input or sanitize input appropriately;
+    (4) Monitor Docker availability and prevent fallback to insecure sandbox modes;
+    (5) Monitor the CrewAI project for a patched release that fails closed when
+    Docker is unavailable.
+  references:
+    - https://www.kb.cert.org/vuls/id/221883
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2287
+rule: 'version <= "1.14.1"'
+references:
+  - https://www.kb.cert.org/vuls/id/221883
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-2287

--- a/data/vuln_en/lobehub/CVE-2026-39411.yaml
+++ b/data/vuln_en/lobehub/CVE-2026-39411.yaml
@@ -7,7 +7,7 @@ info:
     not signed or otherwise authenticated. Because the XOR key is hardcoded in the repository, an attacker can forge arbitrary
     auth payloads and bypass authentication on protected webapi routes. Affected routes include /webapi/chat/[provider], /webapi/models/[provider],
     /webapi/models/[provider]/pull, and /webapi/create-image/comfyui. This vulnerability is fixed in 2.1.48.
-  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:C/L:I:L/A:L
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L
   severity: MEDIUM
   security_advise: Follow official security advisories and upgrade to the latest patched version.
   references:

--- a/data/vuln_en/lobehub/CVE-2026-39411.yaml
+++ b/data/vuln_en/lobehub/CVE-2026-39411.yaml
@@ -1,0 +1,23 @@
+info:
+  name: lobehub
+  cve: CVE-2026-39411
+  summary: LobeHub is a work-and-lifestyle space to find, build, and collaborate with agent teammates that grow with you
+  details: LobeHub is a work-and-lifestyle space to find, build, and collaborate with agent teammates that grow with you.
+    Prior to 2.1.48, the webapi authentication layer trusts a client-controlled X-lobe-chat-auth header that is only XOR-obfuscated,
+    not signed or otherwise authenticated. Because the XOR key is hardcoded in the repository, an attacker can forge arbitrary
+    auth payloads and bypass authentication on protected webapi routes. Affected routes include /webapi/chat/[provider], /webapi/models/[provider],
+    /webapi/models/[provider]/pull, and /webapi/create-image/comfyui. This vulnerability is fixed in 2.1.48.
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:C/L:I:L/A:L
+  severity: MEDIUM
+  security_advise: Follow official security advisories and upgrade to the latest patched version.
+  references:
+  - https://github.com/lobehub/lobehub/commit/3327b293d66c013f076cbc16cdbd05a61a3d0428
+  - https://github.com/lobehub/lobehub/pull/13535
+  - https://github.com/lobehub/lobehub/releases/tag/v2.1.48
+  - https://github.com/lobehub/lobehub/security/advisories/GHSA-5mwj-v5jw-5c97
+rule: 'version < "2.1.48"'
+references:
+- https://github.com/lobehub/lobehub/commit/3327b293d66c013f076cbc16cdbd05a61a3d0428
+- https://github.com/lobehub/lobehub/pull/13535
+- https://github.com/lobehub/lobehub/releases/tag/v2.1.48
+- https://github.com/lobehub/lobehub/security/advisories/GHSA-5mwj-v5jw-5c97


### PR DESCRIPTION
Add the missing English vulnerability rule files to `data/vuln_en/` to ensure the Chinese and English vulnerability databases remain synchronized.

## Missing Files

A comparison between `data/vuln/` and `data/vuln_en/` revealed that the following components have Chinese vulnerability rules but lack corresponding English versions:

### crewai (3 files)
- `CVE-2026-2275.yaml`: RCE caused by `CodeInterpreterTool` SandboxPython fallback
- `CVE-2026-2286.yaml`: SSRF vulnerability allowing access to internal networks and cloud metadata endpoints
- `CVE-2026-2287.yaml`: Docker runtime check bypass leading to RCE via insecure sandbox fallback

### lobehub (1 file)
- `CVE-2026-39411.yaml`: Authentication bypass in the webapi layer due to trust in a client-controlled XOR obfuscation header

## Description

These 4 components already have corresponding files in `data/vuln/` (Chinese version) but were missing from `data/vuln_en/` (English version).
This PR adds the missing English versions, keeping the content consistent with the Chinese versions to ensure the integrity of the bilingual vulnerability databases.