### PR TITLE
docs: add aig-skill-scan and SkillTrustBench to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Help us improve A.I.G! Please take 3-5 minutes to fill out our [User Feedback Su
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — Coverage expanded to 68 AI components (added junoclaw, lollms, sglang); 600+ new CVE rules; WebSocket agent provider support for Agent Scan.
 
 
-👉 [Earlier releases](./CHANGELOG.md) · 🩺 [Try EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
+👉 [Earlier releases](./CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## Table of Contents
@@ -92,7 +92,7 @@ Help us improve A.I.G! Please take 3-5 minutes to fill out our [User Feedback Su
 - [⚖️ License & Attribution](#️-license--attribution)
 <br><br>
 ## 🚀 Quick Start
-### Deployment with Docker
+### 🐳 Deploy A.I.G with Docker
 
 | Docker | RAM | Disk Space |
 |:-------|:----|:----------|
@@ -110,7 +110,7 @@ Once the service is running, you can access the A.I.G web interface at:
 `http://localhost:8088`
 <br>
 
-### Use from OpenClaw
+#### Use from OpenClaw
 
 You can also call A.I.G directly from OpenClaw chat via the `aig-scanner` skill.
 
@@ -123,7 +123,7 @@ Then configure `AIG_BASE_URL` to point to your running A.I.G service.
 For more details, see the [`aig-scanner` README](./skills/aig-scanner/README.md).
 
 <details>
-<summary><strong>📦 More installation options</strong></summary>
+<summary><strong>More installation options</strong></summary>
 
 ### Other Installation Methods
 
@@ -148,16 +148,61 @@ For more information, see: [https://tencent.github.io/AI-Infra-Guard/?menu=getti
 
 </details>
 
-### Try the Online Pro Version
+
+### ⚡ Install aig-skill-scan with a Single Command
+
+Agent Skill security audit tool, easily integrated into enterprise CI/CD pipelines. Vulnerability classification aligns with [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09 taxonomy. [Learn more →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# Set API key via environment variable
+export LLM_API_KEY="your-api-key"
+
+# Scan a local Skill project directory
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 Try the Online Pro Version
 Experience the Pro version with advanced features and improved performance. The Pro version requires an [invitation code](https://wj.qq.com/s2/25099467/25vn/) and is prioritized for contributors who have submitted issues, pull requests, or discussions, or actively help grow the community. Visit: [https://aigsec.ai/](https://aigsec.ai/).
+
 <br>
 <br>
 
 ## ✨ Features
 
+### 🔍 aig-skill-scan Performance & Coverage
+
+Performance on [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) with different LLMs:
+
+| # | Model | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+Covers 9 categories of Skill security risks (SkillTrustBench T01–T09):
+
+| Layer | Risks |
+|:------|:--------|
+| A · Instruction & Memory | T01 Skill Instruction Hijacking, T02 Memory Poisoning |
+| B · Code Execution | T03 Remote Payload Download & Execution, T04 Embedded Malicious Code |
+| C · System Privilege | T05 Privilege Escalation & Unauthorized Access, T06 System Persistence |
+| D · Toolchain & Dependencies | T07 Tool Hijacking & Spoofing, T08 Insecure Dependencies |
+| E · Skill Code Quality | T09 Insecure Coding Practices |
+
+For full leaderboard and details, visit [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/).
+
+### 🔬 Security Scanning & Evaluation
+
 | Feature | More Info |
 |:--------|:------------|
-| **ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)** | Supports one-click evaluation of OpenClaw security risks. It detects insecure configurations, Skill risks, CVE vulnerabilities, and privacy leakage.  |
+| **[ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | Supports one-click evaluation of OpenClaw security risks. It detects insecure configurations, Skill risks, CVE vulnerabilities, and privacy leakage.  |
 | **Agent&nbsp;Scan** | This is an independent, multi-agent automated scanning framework. It is designed to evaluate the security of AI agent workflows. It seamlessly supports agents running across various platforms, including Dify and Coze. |
 | **MCP&nbsp;Server&nbsp;&&nbsp;Agent&nbsp;Skills&nbsp;scan** | It thoroughly detects 14 major categories of security risks. The detection applies to both MCP Servers and Agent Skills. It flexibly supports scanning from both source code and remote URLs. |
 | **AI&nbsp;infra&nbsp;vulnerability&nbsp;scan** | This scanner precisely identifies over 100 AI framework components. It covers more than 1900 known CVE vulnerabilities. Supported frameworks include Ollama, ComfyUI, vLLM, n8n, Triton Inference Server and more. |

--- a/readme/README_DE.md
+++ b/readme/README_DE.md
@@ -73,7 +73,7 @@ Helfen Sie uns, A.I.G zu verbessern! Bitte nehmen Sie sich 3-5 Minuten Zeit, um 
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — Abdeckung auf 68 KI-Komponenten erweitert (junoclaw, lollms, sglang hinzugefügt); 600+ neue CVE-Regeln; WebSocket-Provider-Unterstützung für Agent Scan.
 
 
-👉 [Ältere Versionen](../CHANGELOG.md) · 🩺 [EdgeOne ClawScan ausprobieren](https://matrix.tencent.com/clawscan)
+👉 [Ältere Versionen](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## Inhaltsverzeichnis
@@ -92,7 +92,7 @@ Helfen Sie uns, A.I.G zu verbessern! Bitte nehmen Sie sich 3-5 Minuten Zeit, um 
 - [⚖️ Lizenz & Namensnennung](#️-lizenz--namensnennung)
 <br><br>
 ## 🚀 Schnellstart
-### Bereitstellung mit Docker
+### 🐳 Bereitstellung mit Docker
 
 | Docker | RAM | Speicherplatz |
 |:-------|:----|:----------|
@@ -110,7 +110,7 @@ Sobald der Dienst läuft, können Sie die A.I.G-Weboberfläche unter folgender A
 `http://localhost:8088`
 <br>
 
-### Verwendung über OpenClaw
+#### Verwendung über OpenClaw
 
 Sie können A.I.G auch direkt über den OpenClaw-Chat mithilfe des `aig-scanner`-Skills aufrufen.
 
@@ -148,16 +148,59 @@ Weitere Informationen finden Sie unter: [https://tencent.github.io/AI-Infra-Guar
 
 </details>
 
-### Online-Pro-Version ausprobieren
+### ⚡ aig-skill-scan mit einem Befehl installieren
+
+Agent Skill Sicherheitsaudit-Tool, einfach in CI/CD-Pipelines integrierbar. Schwachstellenklassifizierung entspricht der [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09 Taxonomie. [Mehr erfahren →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# API-Schlüssel über Umgebungsvariable setzen
+export LLM_API_KEY="your-api-key"
+
+# Lokales Skill-Projektverzeichnis scannen
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 Online-Pro-Version ausprobieren
 Erleben Sie die Pro-Version mit erweiterten Funktionen und verbesserter Leistung. Die Pro-Version erfordert einen [Einladungscode](https://wj.qq.com/s2/25099467/25vn/) und wird vorrangig für Mitwirkende vergeben, die Issues, Pull Requests oder Diskussionen eingereicht oder aktiv zur Verbreitung der Community beigetragen haben. Besuchen Sie: [https://aigsec.ai/](https://aigsec.ai/).
 <br>
 <br>
 
 ## ✨ Funktionen
 
+### 🔍 aig-skill-scan Leistung & Abdeckung
+
+Leistung auf [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) mit verschiedenen LLMs:
+
+| # | Modell | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+Deckt 9 Kategorien von Skill-Sicherheitsrisiken ab (SkillTrustBench T01–T09):
+
+| Schicht | Risiken |
+|:------|:--------|
+| A · Anweisung & Speicher | T01 Skill-Anweisungs-Hijacking, T02 Speicher-Poisoning |
+| B · Code-Ausführung | T03 Remote-Payload-Download & Ausführung, T04 Eingebetteter Schadcode |
+| C · Systemberechtigungen | T05 Rechteeskalation & unberechtigter Zugriff, T06 Systempersistenz |
+| D · Toolchain & Abhängigkeiten | T07 Tool-Hijacking & Spoofing, T08 Unsichere Abhängigkeiten |
+| E · Skill-Code-Qualität | T09 Unsichere Programmierpraktiken |
+
+Vollständige Bestenliste und Details unter [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/).
+
+### 🔬 Sicherheits-Scanning & Bewertung
+
 | Funktion | Weitere Informationen |
 |:--------|:------------|
-| **ClawScan (OpenClaw&nbsp;Security&nbsp;Scan)** | Unterstützt die Ein-Klick-Bewertung von OpenClaw-Sicherheitsrisiken. Erkennt unsichere Konfigurationen, Skill-Risiken, CVE-Schwachstellen und Datenschutzverletzungen. |
+| **[ClawScan (OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | Unterstützt die Ein-Klick-Bewertung von OpenClaw-Sicherheitsrisiken. Erkennt unsichere Konfigurationen, Skill-Risiken, CVE-Schwachstellen und Datenschutzverletzungen. |
 | **Agent&nbsp;Scan** | Ein eigenständiges, multi-agenten-basiertes automatisiertes Scan-Framework. Es ist darauf ausgelegt, die Sicherheit von KI-Agent-Workflows zu bewerten. Es unterstützt nahtlos Agents, die auf verschiedenen Plattformen laufen, einschließlich Dify und Coze. |
 | **MCP&nbsp;Server&nbsp;&&&nbsp;Agent&nbsp;Skills&nbsp;Scan** | Erkennt umfassend 14 Hauptkategorien von Sicherheitsrisiken. Die Erkennung gilt sowohl für MCP Server als auch für Agent Skills. Unterstützt flexibel das Scannen aus Quellcode und entfernten URLs. |
 | **AI Infrastructure Vulnerability Scan** | Identifiziert präzise über 100 KI-Framework-Komponenten. Deckt mehr als 1900 bekannte CVE-Schwachstellen ab. Unterstützte Frameworks umfassen Ollama, ComfyUI, vLLM, n8n, Triton Inference Server und weitere. |

--- a/readme/README_ES.md
+++ b/readme/README_ES.md
@@ -73,7 +73,7 @@
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — Cobertura ampliada a 68 componentes de IA (añadidos junoclaw, lollms, sglang); 600+ nuevas reglas CVE; soporte de proveedor WebSocket para Agent Scan.
 
 
-👉 [Versiones anteriores](../CHANGELOG.md) · 🩺 [Probar EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
+👉 [Versiones anteriores](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## Tabla de Contenidos
@@ -92,7 +92,7 @@
 - [⚖️ Licencia y Atribución](#️-licencia-y-atribución)
 <br><br>
 ## 🚀 Inicio Rápido
-### Despliegue con Docker
+### 🐳 Despliegue con Docker
 
 | Docker | RAM | Espacio en Disco |
 |:-------|:----|:----------|
@@ -110,7 +110,7 @@ Una vez que el servicio esté en ejecución, puedes acceder a la interfaz web de
 `http://localhost:8088`
 <br>
 
-### Usar desde OpenClaw
+#### Usar desde OpenClaw
 
 También puedes llamar a A.I.G directamente desde el chat de OpenClaw mediante la skill `aig-scanner`.
 
@@ -148,16 +148,59 @@ Para más información, consulta: [https://tencent.github.io/AI-Infra-Guard/?men
 
 </details>
 
-### Probar la Versión Pro en Línea
+### ⚡ Instalar aig-skill-scan con un solo comando
+
+Herramienta de auditoría de seguridad de Agent Skills, fácilmente integrable en pipelines CI/CD empresariales. La clasificación de vulnerabilidades se alinea con la taxonomía [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09. [Más información →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# Establecer clave API mediante variable de entorno
+export LLM_API_KEY="your-api-key"
+
+# Escanear un directorio de proyecto Skill local
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 Probar la Versión Pro en Línea
 Experimenta la versión Pro con funciones avanzadas y rendimiento mejorado. La versión Pro requiere un [código de invitación](https://wj.qq.com/s2/25099467/25vn/) y se prioriza para los contribuyentes que han enviado issues, pull requests o discusiones, o que ayudan activamente al crecimiento de la comunidad. Visita: [https://aigsec.ai/](https://aigsec.ai/).
 <br>
 <br>
 
 ## ✨ Características
 
+### 🔍 Rendimiento y cobertura de aig-skill-scan
+
+Rendimiento en [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) con diferentes LLMs:
+
+| # | Modelo | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+Cubre 9 categorías de riesgos de seguridad de Skills (SkillTrustBench T01–T09):
+
+| Capa | Riesgos |
+|:------|:--------|
+| A · Instrucciones y memoria | T01 Secuestro de instrucciones de Skill, T02 Envenenamiento de memoria |
+| B · Ejecución de código | T03 Descarga y ejecución de payload remoto, T04 Código malicioso incrustado |
+| C · Privilegios del sistema | T05 Escalada de privilegios y acceso no autorizado, T06 Persistencia del sistema |
+| D · Cadena de herramientas y dependencias | T07 Secuestro y suplantación de herramientas, T08 Dependencias inseguras |
+| E · Calidad del código Skill | T09 Prácticas de codificación inseguras |
+
+Para la tabla de clasificación completa, visite [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/).
+
+### 🔬 Escaneo de seguridad y evaluación
+
 | Característica | Más Información |
 |:--------|:------------|
-| **ClawScan (OpenClaw&nbsp;Security&nbsp;Scan)** | Soporta la evaluación con un clic de los riesgos de seguridad de OpenClaw. Detecta configuraciones inseguras, riesgos de Skills, vulnerabilidades CVE y fugas de privacidad. |
+| **[ClawScan (OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | Soporta la evaluación con un clic de los riesgos de seguridad de OpenClaw. Detecta configuraciones inseguras, riesgos de Skills, vulnerabilidades CVE y fugas de privacidad. |
 | **Agent&nbsp;Scan** | Es un framework independiente de escaneo automatizado multi-agente. Está diseñado para evaluar la seguridad de los flujos de trabajo de Agent de IA. Soporta sin problemas agents que se ejecutan en diversas plataformas, incluidas Dify y Coze. |
 | **MCP&nbsp;Server&nbsp;&&nbsp;Agent&nbsp;Skills&nbsp;scan** | Detecta exhaustivamente 14 categorías principales de riesgos de seguridad. La detección se aplica tanto a MCP Servers como a Agent Skills. Soporta de forma flexible el escaneo tanto desde código fuente como desde URLs remotas. |
 | **Escaneo de vulnerabilidades en infraestructura de IA** | Este scanner identifica con precisión más de 100 componentes de frameworks de IA. Cubre más de 1900 vulnerabilidades CVE conocidas. Los frameworks soportados incluyen Ollama, ComfyUI, vLLM, n8n, Triton Inference Server y más. |

--- a/readme/README_FR.md
+++ b/readme/README_FR.md
@@ -73,7 +73,7 @@ Aidez-nous à améliorer A.I.G ! Veuillez prendre 3 à 5 minutes pour remplir no
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — Couverture étendue à 68 composants IA (ajout de junoclaw, lollms, sglang) ; 600+ nouvelles règles CVE ; prise en charge du provider WebSocket pour Agent Scan.
 
 
-👉 [Versions précédentes](../CHANGELOG.md) · 🩺 [Essayer EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
+👉 [Versions précédentes](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## Table des matières
@@ -92,7 +92,7 @@ Aidez-nous à améliorer A.I.G ! Veuillez prendre 3 à 5 minutes pour remplir no
 - [⚖️ Licence & Attribution](#️-licence--attribution)
 <br><br>
 ## 🚀 Démarrage rapide
-### Déploiement avec Docker
+### 🐳 Déploiement avec Docker
 
 | Docker | RAM | Espace disque |
 |:-------|:----|:----------|
@@ -110,7 +110,7 @@ Une fois le service lancé, vous pouvez accéder à l'interface web d'A.I.G à l
 `http://localhost:8088`
 <br>
 
-### Utilisation depuis OpenClaw
+#### Utilisation depuis OpenClaw
 
 Vous pouvez également appeler A.I.G directement depuis le chat OpenClaw via le skill `aig-scanner`.
 
@@ -148,16 +148,59 @@ Pour plus d'informations, voir : [https://tencent.github.io/AI-Infra-Guard/?menu
 
 </details>
 
-### Essayer la version Pro en ligne
+### ⚡ Installer aig-skill-scan en une seule commande
+
+Outil d'audit de sécurité des Agent Skills, facilement intégrable aux pipelines CI/CD d'entreprise. La classification des vulnérabilités est alignée sur la taxonomie [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09. [En savoir plus →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# Définir la clé API via une variable d'environnement
+export LLM_API_KEY="your-api-key"
+
+# Scanner un répertoire de projet Skill local
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 Essayer la version Pro en ligne
 Découvrez la version Pro avec des fonctionnalités avancées et des performances améliorées. La version Pro nécessite un [code d'invitation](https://wj.qq.com/s2/25099467/25vn/) et est prioritairement réservée aux contributeurs ayant soumis des issues, des pull requests ou des discussions, ou qui aident activement à développer la communauté. Visitez : [https://aigsec.ai/](https://aigsec.ai/).
 <br>
 <br>
 
 ## ✨ Fonctionnalités
 
+### 🔍 Performance & couverture d'aig-skill-scan
+
+Performance sur [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) avec différents LLMs :
+
+| # | Modèle | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+Couvre 9 catégories de risques de sécurité des Skills (SkillTrustBench T01–T09) :
+
+| Couche | Risques |
+|:------|:--------|
+| A · Instructions & mémoire | T01 Détournement d'instructions Skill, T02 Empoisonnement de mémoire |
+| B · Exécution de code | T03 Téléchargement & exécution de charge utile distante, T04 Code malveillant intégré |
+| C · Privilèges système | T05 Escalade de privilèges & accès non autorisé, T06 Persistance système |
+| D · Chaîne d'outils & dépendances | T07 Détournement & usurpation d'outils, T08 Dépendances non sécurisées |
+| E · Qualité du code Skill | T09 Pratiques de codage non sécurisées |
+
+Pour le classement complet, visitez [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/).
+
+### 🔬 Analyse de sécurité & évaluation
+
 | Fonctionnalité | Plus d'informations |
 |:--------|:------------|
-| **ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)** | Prend en charge l'évaluation en un clic des risques de sécurité OpenClaw. Détecte les configurations non sécurisées, les risques liés aux Skills, les vulnérabilités CVE et les fuites de confidentialité. |
+| **[ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | Prend en charge l'évaluation en un clic des risques de sécurité OpenClaw. Détecte les configurations non sécurisées, les risques liés aux Skills, les vulnérabilités CVE et les fuites de confidentialité. |
 | **Agent&nbsp;Scan** | Framework d'analyse automatisée multi-agents indépendant, conçu pour évaluer la sécurité des workflows d'agents IA. Prend en charge de façon transparente les agents fonctionnant sur diverses plateformes, notamment Dify et Coze. |
 | **MCP&nbsp;Server&nbsp;&&nbsp;Agent&nbsp;Skills&nbsp;scan** | Détecte de manière approfondie 14 grandes catégories de risques de sécurité. La détection s'applique aussi bien aux MCP Servers qu'aux Agent Skills. Prend en charge de manière flexible l'analyse à partir du code source et d'URLs distantes. |
 | **AI&nbsp;infra&nbsp;vulnerability&nbsp;scan** | Identifie précisément plus de 100 composants de frameworks IA. Couvre plus de 1 900 vulnérabilités CVE connues. Les frameworks supportés incluent Ollama, ComfyUI, vLLM, n8n, Triton Inference Server et bien d'autres. |

--- a/readme/README_JA.md
+++ b/readme/README_JA.md
@@ -73,7 +73,7 @@ A.I.Gの改善にご協力ください！3〜5分で[ユーザーフィードバ
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — カバレッジが68種AIコンポーネントに拡大（junoclaw、lollms、sglangを追加）；600件以上の新規CVEルール追加；Agent ScanがWebSocketプロバイダーをサポート。
 
 
-👉 [過去のリリース](../CHANGELOG.md) · 🩺 [EdgeOne ClawScanを試す](https://matrix.tencent.com/clawscan)
+👉 [過去のリリース](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## 目次
@@ -93,7 +93,7 @@ A.I.Gの改善にご協力ください！3〜5分で[ユーザーフィードバ
 <br><br>
 
 ## クイックスタート
-### Dockerによるデプロイ
+### 🐳 Dockerによるデプロイ
 
 | Docker | RAM | ディスク容量 |
 |:-------|:----|:----------|
@@ -111,7 +111,7 @@ docker-compose -f docker-compose.images.yml up -d
 `http://localhost:8088`
 <br>
 
-### OpenClawからの使用
+#### OpenClawからの使用
 
 `aig-scanner`スキルを使用して、OpenClawチャットからA.I.Gを直接呼び出すこともできます。
 
@@ -149,16 +149,59 @@ docker-compose up -d
 
 </details>
 
-### オンラインPro版を試す
+### ⚡ aig-skill-scan をワンコマンドでインストール
+
+Agent Skillセキュリティ監査ツール。企業のCI/CDパイプラインに簡単に統合可能。脆弱性分類は[SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09分類法に準拠。[詳細 →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# 環境変数でAPIキーを設定
+export LLM_API_KEY="your-api-key"
+
+# ローカルのSkillプロジェクトディレクトリをスキャン
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 オンラインPro版を試す
 高度な機能と改善されたパフォーマンスを備えたPro版をお試しください。Pro版には[招待コード](https://wj.qq.com/s2/25099467/25vn/)が必要で、Issue、Pull Request、Discussionを提出した方、またはコミュニティの成長に積極的に貢献された方が優先されます。アクセス: [https://aigsec.ai/](https://aigsec.ai/)
 <br>
 <br>
 
 ## 機能一覧
 
+### 🔍 aig-skill-scan パフォーマンスとカバレッジ
+
+[SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) での各LLMの性能：
+
+| # | モデル | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+9カテゴリのSkillセキュリティリスクをカバー（SkillTrustBench T01–T09）：
+
+| レイヤー | リスク |
+|:------|:--------|
+| A · 命令とメモリ | T01 スキル命令ハイジャック、T02 メモリポイズニング |
+| B · コード実行 | T03 リモートペイロードダウンロード＆実行、T04 埋め込み悪意コード |
+| C · システム権限 | T05 権限昇格＆不正アクセス、T06 システム永続化 |
+| D · ツールチェーン＆依存関係 | T07 ツールハイジャック＆なりすまし、T08 安全でない依存関係 |
+| E · Skillコード品質 | T09 安全でないコーディング |
+
+完全なリーダーボードと詳細は [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) をご覧ください。
+
+### 🔬 セキュリティスキャン＆評価
+
 | 機能 | 詳細 |
 |:--------|:------------|
-| **ClawScan（OpenClawセキュリティスキャン）** | OpenClawのセキュリティリスクのワンクリック評価に対応。安全でない設定、スキルリスク、CVE脆弱性、プライバシー漏洩を検出します。 |
+| **[ClawScan（OpenClawセキュリティスキャン）](https://matrix.tencent.com/clawscan)** | OpenClawのセキュリティリスクのワンクリック評価に対応。安全でない設定、スキルリスク、CVE脆弱性、プライバシー漏洩を検出します。 |
 | **Agent Scan** | 独立したマルチエージェント自動スキャンフレームワークです。AIエージェントワークフローのセキュリティを評価するために設計されています。DifyやCozeなど、さまざまなプラットフォームで動作するエージェントをシームレスにサポートします。 |
 | **MCPサーバー＆エージェントスキルスキャン** | 14の主要なセキュリティリスクカテゴリを徹底的に検出します。MCPサーバーとエージェントスキルの両方に適用されます。ソースコードとリモートURLの両方からのスキャンに柔軟に対応します。 |
 | **AIインフラ脆弱性スキャン** | 100以上のAIフレームワークコンポーネントを正確に識別するスキャナーです。1900以上の既知のCVE脆弱性をカバーしています。対応フレームワークにはOllama、ComfyUI、vLLM、n8n、Triton Inference Serverなどが含まれます。 |

--- a/readme/README_KR.md
+++ b/readme/README_KR.md
@@ -73,7 +73,7 @@ A.I.G 개선에 도움을 주세요! 3~5분만 투자하여 [사용자 피드백
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — 68개 AI 컴포넌트로 커버리지 확대(junoclaw, lollms, sglang 추가); 600개 이상의 신규 CVE 규칙 추가; Agent Scan에 WebSocket 프로바이더 지원.
 
 
-👉 [이전 릴리스](../CHANGELOG.md) · 🩺 [EdgeOne ClawScan 체험하기](https://matrix.tencent.com/clawscan)
+👉 [이전 릴리스](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## 목차
@@ -92,7 +92,7 @@ A.I.G 개선에 도움을 주세요! 3~5분만 투자하여 [사용자 피드백
 - [⚖️ 라이선스 및 저작권 표시](#️-라이선스-및-저작권-표시)
 <br><br>
 ## 🚀 빠른 시작
-### Docker를 이용한 배포
+### 🐳 Docker를 이용한 배포
 
 | Docker | RAM | 디스크 공간 |
 |:-------|:----|:----------|
@@ -110,7 +110,7 @@ docker-compose -f docker-compose.images.yml up -d
 `http://localhost:8088`
 <br>
 
-### OpenClaw에서 사용하기
+#### OpenClaw에서 사용하기
 
 OpenClaw 채팅에서 `aig-scanner` skill을 통해 A.I.G를 직접 호출할 수도 있습니다.
 
@@ -148,16 +148,59 @@ docker-compose up -d
 
 </details>
 
-### 온라인 Pro 버전 체험하기
+### ⚡ aig-skill-scan 한 줄 명령어로 설치
+
+Agent Skill 보안 감사 도구로, 기업 CI/CD 파이프라인에 쉽게 통합할 수 있습니다. 취약점 분류는 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09 분류 체계에 맞춰져 있습니다. [자세히 보기 →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# 환경 변수로 API 키 설정
+export LLM_API_KEY="your-api-key"
+
+# 로컬 Skill 프로젝트 디렉토리 scan
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 온라인 Pro 버전 체험하기
 고급 기능과 향상된 성능을 갖춘 Pro 버전을 경험해 보세요. Pro 버전은 [초대 코드](https://wj.qq.com/s2/25099467/25vn/)가 필요하며, 이슈·풀 리퀘스트·토론을 제출했거나 커뮤니티 성장에 적극적으로 기여한 분들을 우선적으로 제공합니다. 방문: [https://aigsec.ai/](https://aigsec.ai/).
 <br>
 <br>
 
 ## ✨ 주요 기능
 
+### 🔍 aig-skill-scan 성능 및 커버리지
+
+[SkillTrustBench](https://matrix.tencent.com/skilltrustbench/)에서의 다양한 LLM 성능:
+
+| # | 모델 | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+9가지 Skill 보안 위험 카테고리 커버 (SkillTrustBench T01–T09):
+
+| 계층 | 위험 |
+|:------|:--------|
+| A · 지시 & 메모리 | T01 Skill 지시 하이재킹, T02 메모리 포이즈닝 |
+| B · 코드 실행 | T03 원격 페이로드 다운로드 & 실행, T04 내장 악성 코드 |
+| C · 시스템 권한 | T05 권한 상승 & 비인가 접근, T06 시스템 지속성 |
+| D · 툴체인 & 의존성 | T07 도구 하이재킹 & 위장, T08 안전하지 않은 의존성 |
+| E · Skill 코드 품질 | T09 안전하지 않은 코딩 관행 |
+
+전체 리더보드 및 상세 정보는 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/)를 방문하세요.
+
+### 🔬 보안 scan 및 평가
+
 | 기능 | 상세 정보 |
 |:--------|:------------|
-| **ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)** | OpenClaw 보안 위험에 대한 원클릭 평가를 지원합니다. 안전하지 않은 설정, Skill 위험, CVE 취약점 및 개인정보 유출을 탐지합니다. |
+| **[ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | OpenClaw 보안 위험에 대한 원클릭 평가를 지원합니다. 안전하지 않은 설정, Skill 위험, CVE 취약점 및 개인정보 유출을 탐지합니다. |
 | **Agent&nbsp;Scan** | AI Agent 워크플로우의 보안을 평가하도록 설계된 독립적인 다중 Agent 자동화 scan 프레임워크입니다. Dify 및 Coze를 포함한 다양한 플랫폼에서 실행되는 Agent를 원활하게 지원합니다. |
 | **MCP&nbsp;Server&nbsp;&&nbsp;Agent&nbsp;Skills&nbsp;scan** | 14가지 주요 보안 위험 카테고리를 철저히 탐지합니다. MCP Server와 Agent Skills 모두에 적용됩니다. 소스 코드와 원격 URL 모두에서 유연하게 scan을 지원합니다. |
 | **AI&nbsp;인프라&nbsp;취약점&nbsp;scan** | 100개 이상의 AI 프레임워크 컴포넌트를 정확하게 식별합니다. 1,900개 이상의 알려진 CVE 취약점을 커버합니다. Ollama, ComfyUI, vLLM, n8n, Triton Inference Server 등의 프레임워크를 지원합니다. |

--- a/readme/README_PT.md
+++ b/readme/README_PT.md
@@ -73,7 +73,7 @@ Ajude-nos a melhorar o A.I.G! Por favor, reserve 3-5 minutos para preencher noss
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — Cobertura expandida para 68 componentes de IA (adicionados junoclaw, lollms, sglang); 600+ novas regras de CVE; suporte a provider WebSocket para Agent Scan.
 
 
-👉 [Versões anteriores](../CHANGELOG.md) · 🩺 [Experimente o EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
+👉 [Versões anteriores](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## Índice
@@ -92,7 +92,7 @@ Ajude-nos a melhorar o A.I.G! Por favor, reserve 3-5 minutos para preencher noss
 - [⚖️ Licença e Atribuição](#️-licença-e-atribuição)
 <br><br>
 ## 🚀 Início Rápido
-### Implantação com Docker
+### 🐳 Implantação com Docker
 
 | Docker | RAM | Espaço em Disco |
 |:-------|:----|:----------------|
@@ -110,7 +110,7 @@ Após o serviço estar em execução, você pode acessar a interface web do A.I.
 `http://localhost:8088`
 <br>
 
-### Usar pelo OpenClaw
+#### Usar pelo OpenClaw
 
 Você também pode chamar o A.I.G diretamente pelo chat do OpenClaw por meio da skill `aig-scanner`.
 
@@ -148,16 +148,59 @@ Para mais informações, acesse: [https://tencent.github.io/AI-Infra-Guard/?menu
 
 </details>
 
-### Experimente a Versão Pro Online
+### ⚡ Instale o aig-skill-scan com um único comando
+
+Ferramenta de auditoria de segurança de Agent Skills, facilmente integrável em pipelines CI/CD corporativos. A classificação de vulnerabilidades segue a taxonomia [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09. [Saiba mais →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# Definir chave de API via variável de ambiente
+export LLM_API_KEY="your-api-key"
+
+# Escanear um diretório de projeto Skill local
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 Experimente a Versão Pro Online
 Experimente a versão Pro com recursos avançados e desempenho aprimorado. A versão Pro requer um [código de convite](https://wj.qq.com/s2/25099467/25vn/) e é priorizada para contribuidores que submeteram issues, pull requests ou discussões, ou que ajudam ativamente a expandir a comunidade. Acesse: [https://aigsec.ai/](https://aigsec.ai/).
 <br>
 <br>
 
 ## ✨ Funcionalidades
 
+### 🔍 Desempenho e cobertura do aig-skill-scan
+
+Desempenho no [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) com diferentes LLMs:
+
+| # | Modelo | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+Cobre 9 categorias de riscos de segurança de Skills (SkillTrustBench T01–T09):
+
+| Camada | Riscos |
+|:------|:--------|
+| A · Instrução & memória | T01 Sequestro de instrução de Skill, T02 Envenenamento de memória |
+| B · Execução de código | T03 Download & execução de payload remoto, T04 Código malicioso embutido |
+| C · Privilégios do sistema | T05 Escalação de privilégios & acesso não autorizado, T06 Persistência do sistema |
+| D · Cadeia de ferramentas & dependências | T07 Sequestro & falsificação de ferramentas, T08 Dependências inseguras |
+| E · Qualidade do código Skill | T09 Práticas de codificação inseguras |
+
+Para o ranking completo, visite [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/).
+
+### 🔬 Scan de segurança & avaliação
+
 | Funcionalidade | Mais Informações |
 |:--------------|:-----------------|
-| **ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)** | Suporta avaliação com um clique de riscos de segurança do OpenClaw. Detecta configurações inseguras, riscos de Skills, vulnerabilidades CVE e vazamento de privacidade. |
+| **[ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | Suporta avaliação com um clique de riscos de segurança do OpenClaw. Detecta configurações inseguras, riscos de Skills, vulnerabilidades CVE e vazamento de privacidade. |
 | **Agent&nbsp;Scan** | É um framework independente e automatizado de scan multi-agent. Foi projetado para avaliar a segurança de fluxos de trabalho de AI agent. Suporta perfeitamente agents em execução em diversas plataformas, incluindo Dify e Coze. |
 | **MCP&nbsp;Server&nbsp;&&nbsp;Agent&nbsp;Skills&nbsp;scan** | Detecta minuciosamente 14 categorias principais de riscos de segurança. A detecção se aplica tanto a MCP Servers quanto a Agent Skills. Suporta flexivelmente o scan a partir de código-fonte e URLs remotas. |
 | **AI&nbsp;infra&nbsp;vulnerability&nbsp;scan** | Este scanner identifica com precisão mais de 100 componentes de frameworks de IA. Cobre mais de 1900 vulnerabilidades CVE conhecidas. Os frameworks suportados incluem Ollama, ComfyUI, vLLM, n8n, Triton Inference Server e muito mais. |

--- a/readme/README_RU.md
+++ b/readme/README_RU.md
@@ -73,7 +73,7 @@
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — Покрытие расширено до 68 AI-компонентов (добавлены junoclaw, lollms, sglang); 600+ новых правил CVE; поддержка WebSocket-провайдера для Agent Scan.
 
 
-👉 [Предыдущие версии](../CHANGELOG.md) · 🩺 [Попробовать EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
+👉 [Предыдущие версии](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan)
 
 
 ## Содержание
@@ -92,7 +92,7 @@
 - [⚖️ Лицензия и атрибуция](#️-лицензия-и-атрибуция)
 <br><br>
 ## 🚀 Быстрый старт
-### Развёртывание с Docker
+### 🐳 Развёртывание с Docker
 
 | Docker | ОЗУ | Дисковое пространство |
 |:-------|:----|:----------|
@@ -110,7 +110,7 @@ docker-compose -f docker-compose.images.yml up -d
 `http://localhost:8088`
 <br>
 
-### Использование из OpenClaw
+#### Использование из OpenClaw
 
 Вы также можете вызвать A.I.G напрямую из чата OpenClaw через skill `aig-scanner`.
 
@@ -148,16 +148,59 @@ docker-compose up -d
 
 </details>
 
-### Попробуйте онлайн Pro-версию
+### ⚡ Установите aig-skill-scan одной командой
+
+Инструмент аудита безопасности Agent Skills, легко интегрируемый в корпоративные CI/CD пайплайны. Классификация уязвимостей соответствует таксономии [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09. [Подробнее →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# Установить API-ключ через переменную окружения
+export LLM_API_KEY="your-api-key"
+
+# Сканировать локальный каталог проекта Skill
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language en \
+           -o result.json
+```
+
+### 🌟 Попробуйте онлайн Pro-версию
 Оцените Pro-версию с расширенными функциями и улучшенной производительностью. Для входа требуется [пригласительный код](https://wj.qq.com/s2/25099467/25vn/); приоритет предоставляется участникам, создавшим issues, pull request'ы или обсуждения, а также активно помогающим развивать сообщество. Перейти: [https://aigsec.ai/](https://aigsec.ai/).
 <br>
 <br>
 
 ## ✨ Возможности
 
+### 🔍 Производительность и покрытие aig-skill-scan
+
+Производительность на [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) с различными LLM:
+
+| # | Модель | F1 | Precision | Recall | FPR |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+Покрывает 9 категорий рисков безопасности Skills (SkillTrustBench T01–T09):
+
+| Уровень | Риски |
+|:------|:--------|
+| A · Инструкции и память | T01 Перехват инструкций Skill, T02 Отравление памяти |
+| B · Выполнение кода | T03 Загрузка и выполнение удалённой полезной нагрузки, T04 Встроенный вредоносный код |
+| C · Системные привилегии | T05 Повышение привилегий и несанкционированный доступ, T06 Системная персистентность |
+| D · Цепочка инструментов и зависимости | T07 Перехват и подмена инструментов, T08 Небезопасные зависимости |
+| E · Качество кода Skill | T09 Небезопасные практики программирования |
+
+Полный рейтинг и подробности на [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/).
+
+### 🔬 Сканирование безопасности и оценка
+
 | Функция | Подробнее |
 |:--------|:------------|
-| **ClawScan (OpenClaw&nbsp;Security&nbsp;Scan)** | Поддерживает оценку рисков безопасности OpenClaw одним кликом. Обнаруживает небезопасные конфигурации, риски Skill, уязвимости CVE и утечки конфиденциальных данных. |
+| **[ClawScan (OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | Поддерживает оценку рисков безопасности OpenClaw одним кликом. Обнаруживает небезопасные конфигурации, риски Skill, уязвимости CVE и утечки конфиденциальных данных. |
 | **Agent&nbsp;Scan** | Независимый многоагентный автоматизированный фреймворк сканирования, предназначенный для оценки безопасности рабочих процессов AI Agent. Поддерживает агентов, работающих на различных платформах, включая Dify и Coze. |
 | **MCP&nbsp;Server&nbsp;&&&nbsp;Agent&nbsp;Skills&nbsp;scan** | Обнаруживает 14 основных категорий рисков безопасности. Применимо как к MCP Server, так и к Agent Skills. Гибко поддерживает сканирование как из исходного кода, так и по удалённым URL. |
 | **Сканирование&nbsp;уязвимостей&nbsp;AI-инфраструктуры** | Точно идентифицирует более 100 компонентов AI-фреймворков. Покрывает более 1900 известных CVE-уязвимостей. Поддерживаемые фреймворки: Ollama, ComfyUI, vLLM, n8n, Triton Inference Server и другие. |

--- a/readme/README_ZH.md
+++ b/readme/README_ZH.md
@@ -71,7 +71,7 @@
 - **2026-05-28** · [v4.1.10](https://github.com/Tencent/AI-Infra-Guard/releases/tag/v4.1.10) — 覆盖扩展至 68 种 AI 组件（新增 junoclaw、lollms、sglang）；新增 600+ CVE 规则；Agent Scan 支持 WebSocket 接入方式。
 
 
-👉 [更早版本](../CHANGELOG.md) · 🩺 [立即体验 EdgeOne ClawScan](https://matrix.tencent.com/clawscan/)
+👉 [更早版本](../CHANGELOG.md) · 🔍 [aig-skill-scan](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan) · 📊 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) · 🩺 [EdgeOne ClawScan](https://matrix.tencent.com/clawscan/)
 
 ## 目录
 - [🚀 快速开始](#-快速开始)
@@ -89,10 +89,10 @@
 - [📄 开源协议](#-开源协议)
 
 ## 🚀 快速开始
-### Docker 一键部署
+### 🐳 使用 Docker 部署 A.I.G
 
 | Docker | 内存 | 磁盘空间 |
-|--------|------|----------|
+|:-------|:----|:----------|
 | 20.10 或更高 | 4GB+ | 10GB+ |
 
 ```bash
@@ -107,7 +107,7 @@ docker-compose -f docker-compose.images.yml up -d
 `http://localhost:8088`
 <br>
 
-### 在 OpenClaw 中使用
+#### 在 OpenClaw 中使用
 
 你也可以通过 OpenClaw 的 `aig-scanner` skill 直接调用 A.I.G 服务。
 
@@ -120,7 +120,7 @@ clawhub install aig-scanner
 更多说明见：[`aig-scanner` 说明](../skills/aig-scanner/README.zh-CN.md)
 
 <details>
-<summary><strong>📦 更多安装方式</strong></summary>
+<summary><strong>更多安装方式</strong></summary>
 
 ### 其他安装方式
 
@@ -145,20 +145,63 @@ docker-compose up -d
 
 </details>
 
-### 体验在线Pro版
+### ⚡ 一键安装 aig-skill-scan
+
+Agent Skill 安全审计工具，可轻松集成到企业 CI/CD 流水线。漏洞分类对齐 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) T01–T09 分类法。[了解更多 →](https://github.com/Tencent/AI-Infra-Guard/tree/main/skill-scan)
+
+```bash
+pip install aig-skill-scan
+
+# 通过环境变量设置 API Key
+export LLM_API_KEY="your-api-key"
+
+# 扫描本地 Skill 项目目录
+aig-skill-scan --repo /path/to/your/skill \
+           -m deepseek-v4-flash \
+           --language zh \
+           -o result.json
+```
+
+### 🌟 体验在线Pro版
 体验具有内测及高级功能的Pro版，需要[邀请码](https://wj.qq.com/s2/25099467/25vn/)，优先提供给提交过 Issues、Pull Requests 或 Discussions，或积极帮助社区发展的贡献者。访问：[https://aigsec.ai/](https://aigsec.ai/)
 <br/>
 <br/>
 
 ## ✨ 功能特性
 
+### 🔍 aig-skill-scan 性能与覆盖范围
+
+使用不同 LLM 在 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/) 上的表现：
+
+| # | 模型 | F1 | Precision (精确率) | Recall (召回率) | FPR (误报率) |
+|:--|:------|:---|:----------|:-------|:----|
+| 1 | Claude Opus 4.6 | **0.9848** | 0.9725 | **0.9974** | 0.0663 |
+| 2 | GLM 5.1 | 0.9836 | 0.9701 | **0.9974** | 0.0723 |
+| 3 | Gemini 3.5 Flash | 0.9792 | **0.9947** | 0.9641 | **0.0120** |
+| 4 | Kimi 2.6 | 0.9780 | 0.9895 | 0.9667 | 0.0241 |
+| 5 | DeepSeek v4 Flash | 0.9740 | 0.9868 | 0.9615 | 0.0301 |
+
+覆盖 9 类 Skill 安全风险（SkillTrustBench T01–T09）：
+
+| 层级 | 攻击类别 |
+|:------|:--------|
+| A — 指令与记忆层 | T01 技能指令劫持、T02 Agent 记忆投毒 |
+| B — 代码执行通道 | T03 远程载荷下载执行、T04 内嵌恶意代码 |
+| C — 系统权限与持久化 | T05 越权访问与提权、T06 系统持久化驻留 |
+| D — 工具链与依赖层 | T07 工具劫持与伪装、T08 不安全依赖 |
+| E — Skill 自身安全质量 | T09 不安全编码 |
+
+完整排行榜与详情请访问 [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/)。
+
+### 🔬 安全扫描与评估
+
 | 功能模块 | 详情说明 |
 |:--------|:------------|
-| **ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)** | 支持一键评估 OpenClaw 的安全风险。可全面检测不安全配置、Skill 风险、CVE 漏洞以及隐私泄露等问题。 |
+| **[ClawScan(OpenClaw&nbsp;Security&nbsp;Scan)](https://matrix.tencent.com/clawscan)** | 支持一键评估 OpenClaw 的安全风险。可全面检测不安全配置、Skill 风险、CVE 漏洞以及隐私泄露等问题。 |
 | **Agent&nbsp;Scan** | 专为评估 AI Agent 工作流的安全性而设计，无缝支持对运行在 Dify、Coze 等各类平台上的 Agent 进行安全检测。 |
 | **MCP&nbsp;Server&nbsp;&&nbsp;Agent&nbsp;Skills&nbsp;scan** | 深度检测 MCP Server 与 Agent Skills 的 14 大类的安全风险。灵活支持上传源代码和远程 URL 两种方式进行检测。 |
 | **AI&nbsp;infra&nbsp;vulnerability&nbsp;scan** | 精准识别 100+ 种 AI 开源 Web 组件。涵盖 1900+ 已知的 CVE 漏洞，支持检测的框架包括 Ollama、ComfyUI、vLLM、n8n、Triton Inference Server 等。 |
-| **Jailbreak&nbsp;Evaluation** | 支持使用精选的数据集与越狱攻击算法快速评估大模型内生安全风险与护栏有效性，同时提供详尽的跨模型横向对比与评估功能。 ||
+| **Jailbreak&nbsp;Evaluation** | 支持使用精选的数据集与越狱攻击算法快速评估大模型内生安全风险与护栏有效性，同时提供详尽的跨模型横向对比与评估功能。 |
 
 <details>
 <summary><strong>其他优势</strong></summary>


### PR DESCRIPTION
- Add aig-skill-scan and SkillTrustBench links in What's New section
- Add aig-skill-scan Quick Start section with pip install command
- Add Performance & Coverage section with SkillTrustBench benchmark scores
- Sync all changes to 8 language versions (ZH/JA/KR/DE/FR/ES/PT/RU)