### PR TITLE
fix: correct agent template config path after modularization

### DIFF
--- a/common/websocket/knowledge2_api.go
+++ b/common/websocket/knowledge2_api.go
@@ -984,8 +984,8 @@ func HandleAgentPromptTest(c *gin.Context) {
 }
 
 func HandleAgentTemplate(c *gin.Context) {
-	enConfig := "agent-scan/config/provider_config_en.json"
-	zhConfig := "agent-scan/config/provider_config_zh.json"
+	enConfig := "agent-scan/agent_scan/config/provider_config_en.json"
+	zhConfig := "agent-scan/agent_scan/config/provider_config_zh.json"
 	language := c.DefaultQuery("language", "zh")
 	var data []byte
 	var err error


### PR DESCRIPTION
## Problem

After PR #482 merged the agent-scan modularization, the `/api/v1/knowledge/agent/template` endpoint returns empty responses, causing Agent management to fail with error: "Agent模版的接口没返回 /api/v1/knowledge/agent/template?language=zh"

## Root Cause

PR #482 moved `provider_config` files from:
- Old: `agent-scan/config/provider_config_{en,zh}.json`
- New: `agent-scan/agent_scan/config/provider_config_{en,zh}.json`

But the Go backend `HandleAgentTemplate` function in `common/websocket/knowledge2_api.go` was not updated to reference the new path. The config files exist at the new location but the Go code reads from the old (non-existent) path, so `os.ReadFile` fails and the endpoint returns empty data.

## Fix

Updated the two path references in `HandleAgentTemplate` to match the modularized directory structure.

## Verification

- Confirmed files exist at `agent-scan/agent_scan/config/` in `main`
- Confirmed files do NOT exist at old `agent-scan/config/` in `main`
- Confirmed Go code still references old path in `main`
- Applied fix, verified correct path is used