### PR TITLE
fix: update agent template config path for modularized agent-scan

### DIFF
--- a/common/websocket/knowledge2_api.go
+++ b/common/websocket/knowledge2_api.go
@@ -984,8 +984,8 @@ func HandleAgentPromptTest(c *gin.Context) {
 }
 
 func HandleAgentTemplate(c *gin.Context) {
-	enConfig := "agent-scan/config/provider_config_en.json"
-	zhConfig := "agent-scan/config/provider_config_zh.json"
+	enConfig := "agent-scan/agent_scan/config/provider_config_en.json"
+	zhConfig := "agent-scan/agent_scan/config/provider_config_zh.json"
 	language := c.DefaultQuery("language", "zh")
 	var data []byte
 	var err error


### PR DESCRIPTION
The HandleAgentTemplate function still referenced the old path 'agent-scan/config/' after modularization moved the config files to 'agent-scan/agent_scan/config/'. This caused the
/api/v1/knowledge/agent/template endpoint to return empty responses, making Agent management non-functional.