### PR TITLE
[AIG-Bot] 新增漏洞规则 2026-07-31（17 条 CVE + 3 条指纹）

### DIFF
--- a/data/fingerprints/flyto2.yaml
+++ b/data/fingerprints/flyto2.yaml
@@ -1,0 +1,28 @@
+info:
+  name: Flyto2 Core
+  author: A.I.G bot
+  severity: info
+  desc: Flyto2 Core is an open-source execution kernel/runtime for AI-agent workflows and automation, exposing an HTTP Execution API (FastAPI on default port 8333) with health, info, module/workflow execution, and MCP endpoints
+  metadata:
+    product: flyto2
+    vendor: flytohub
+http:
+  - method: GET
+    path: /health
+    matchers:
+      - 'body="\"status\": \"ok\"" && body="\"version\":"'
+  - method: GET
+    path: /v1/info
+    matchers:
+      - 'body="\"name\": \"flyto-core\"" && body="\"module_count\":" && body="\"category_count\":"'
+  - method: GET
+    path: /openapi.json
+    matchers:
+      - 'body="\"title\": \"flyto-core Execution API\""'
+version:
+  - method: GET
+    path: /health
+    extractor:
+      part: body
+      group: 1
+      regex: '"version"\s*:\s*"([0-9][0-9.a-zA-Z\-]+)"'

--- a/data/fingerprints/network-ai.yaml
+++ b/data/fingerprints/network-ai.yaml
@@ -1,0 +1,23 @@
+info:
+  name: Network-AI
+  author: A.I.G bot
+  severity: info
+  desc: Network-AI is a TypeScript/Node.js multi-agent orchestrator with built-in MCP SSE server, exposing HTTP/SSE endpoints for AI agent interaction including blackboard tools, budget/token management, and control-plane operations
+  metadata:
+    product: network-ai
+    vendor: jovancoding
+http:
+  - method: GET
+    path: /health
+    matchers:
+      - body="\"status\":\"ok\"" && body="\"bridge\":\"network-ai\""
+version:
+  - method: POST
+    path: /mcp
+    body: '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"aig","version":"0.0.1"}}}'
+    headers:
+      Content-Type: application/json
+    extractor:
+      part: body
+      group: 1
+      regex: '"version"\s*:\s*"([0-9][0-9.a-zA-Z\-]+)"'

--- a/data/fingerprints/suna.yaml
+++ b/data/fingerprints/suna.yaml
@@ -1,0 +1,21 @@
+info:
+  name: Suna
+  author: A.I.G bot
+  severity: info
+  desc: Suna (Kortix) is an open-source AI command center / AI agent platform with task automation, browser usage, crawler, and code execution capabilities.
+  metadata:
+    product: suna
+    vendor: kortix-ai
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="__KORTIX_RUNTIME_CONFIG"
+      - body="AI Command Center"
+version:
+  - method: GET
+    path: '/health'
+    extractor:
+      part: body
+      group: 1
+      regex: '"version":"([0-9]+\.[0-9]+\.[0-9]+)"'

--- a/data/vuln/LiteLLM/CVE-2026-67425.yaml
+++ b/data/vuln/LiteLLM/CVE-2026-67425.yaml
@@ -1,0 +1,18 @@
+info:
+  name: LiteLLM
+  author: A.I.G bot
+  cve: CVE-2026-67425
+  summary: LiteLLM 是一个代理服务器（AI 网关），用于以 OpenAI（或原生）格式调用 LLM API
+  details: "LiteLLM 是一个代理服务器（AI 网关），用于以 OpenAI（或原生）格式调用 LLM API。在 2.26.6
+    版本之前，llm.chat 函数会从环境变量中读取 OPENAI_API_KEY 和 ANTHROPIC_API_KEY 等提供商密钥，
+    并将其通过 Authorization Bearer 请求头发送到调用者可控的 base_url，使得攻击者可以在通过 SSRF
+    防护的公共主机上获取运营者的 API 密钥。该问题已在 2.26.6 版本中修复。"
+  cvss: '8.6'
+  severity: HIGH
+  security_advise: 升级 LiteLLM 至 2.26.6 或更高版本。确保提供商 API 密钥不会泄露到调用者可控的端点，
+    并验证 base_url 以防止基于 SSRF 的密钥窃取。
+rule: version < "2.26.6"
+references:
+- https://github.com/flytohub/flyto-core/commit/d5f89d71303e3c1e6418d347c5c55fcd173cc8cc
+- https://github.com/flytohub/flyto-core/releases/tag/v2.26.6
+- https://github.com/flytohub/flyto-core/security/advisories/GHSA-qq9q-xgm3-xv9g

--- a/data/vuln/LiteLLM/CVE-2026-67428.yaml
+++ b/data/vuln/LiteLLM/CVE-2026-67428.yaml
@@ -1,0 +1,21 @@
+info:
+  name: LiteLLM
+  author: A.I.G bot
+  cve: CVE-2026-67428
+  summary: Flyto2 Core 是自动化和 AI 代理工作流的执行内核
+  details: "Flyto2 Core 是自动化和 AI 代理工作流的执行内核。在 2.26.7 版本之前，HTTP 发射模块包括
+    src/core/modules/third_party/developer/http/requests.py、core.api.http_get、core.api.http_post、
+    graphql.query、graphql.mutation、monitor.http_check、communication.slack_send、
+    notification.discord.send_message、notification.slack.send_message、notification.teams.send_message、
+    ai.vision_analyze、verify.visual_diff、browser.proxy_rotate 以及 agent 和 llm 内联 base_url 分支
+    在获取调用者可控的 URL 时不经过 validate_url_with_env_config 验证，允许 SSRF 攻击内部端点
+    或云元数据端点。该问题已在 2.26.7 版本中修复。"
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: 升级至 2.26.7 或更高版本。修复方案为所有 HTTP 发射模块添加了 validate_url_with_env_config
+    验证，防止 SSRF 攻击内部端点和云元数据服务。
+rule: version < "2.26.7"
+references:
+- https://github.com/flytohub/flyto-core/commit/0a0a528520ec18f5a21f1ddf858a71cc1edfb6e9
+- https://github.com/flytohub/flyto-core/releases/tag/v2.26.7
+- https://github.com/flytohub/flyto-core/security/advisories/GHSA-pgwh-4jj4-qm8v

--- a/data/vuln/astrbot/CVE-2026-17529.yaml
+++ b/data/vuln/astrbot/CVE-2026-17529.yaml
@@ -1,0 +1,51 @@
+info:
+  name: astrbot
+  author: A.I.G bot
+  severity: medium
+  metadata:
+    cve_id: CVE-2026-17529
+    cwe: CWE-285, CWE-863
+    cvss: 6.3
+    cvss_vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  tags: astrbot,授权绕过,工具访问,cwe285,cwe863
+  details: 'AstrBot 4.25.5 及之前版本在 astrbot/core/astr_main_agent.py 文件中存在授权校验不当漏洞。该缺陷允许通过操控
+    req.func_tool 参数绕过基于角色（persona）的工具访问限制。已认证的低权限用户可访问本应被角色配置限制的工具，导致未授权的工具执行。该漏洞已在提交
+    d23011262e8e75e1ec41b0f1f0091493a022327e 中修复。
+
+    '
+  cve: CVE-2026-17529
+rule: version >= "4.25.0" && version <= "4.25.5"
+details: '在 AstrBotDevs AstrBot 4.25.0 至 4.25.5 版本中发现授权校验不当漏洞。该漏洞存在于 astrbot/core/astr_main_agent.py
+  文件中，req.func_tool 参数未根据角色（persona）工具访问控制进行正确校验。
+
+
+  当角色配置了受限工具集（如 persona["tools"] = []）时，_ensure_persona_and_skills 函数会将受限工具集应用到请求中。然而，在该函数返回后，_decorate_llm_request
+  和 build_main_agent 中的后续处理可能会向 req.func_tool 添加额外工具，从而绕过角色限制。这使得低权限已认证用户能够访问本应被角色配置限制的工具。
+
+
+  修复补丁（提交 d23011262e8e75e1ec41b0f1f0091493a022327e）修改了 _ensure_persona_and_skills
+  函数，使其返回允许的工具集合（persona_allowed_tools），同时 build_main_agent 现在会从 req.func_tool 中过滤掉不在允许集合中的工具，确保在所有工具注入点之后仍能强制执行角色限制。
+
+
+  此外，修复还纠正了 astr_agent_tool_exec.py 中 _build_handoff_toolset 的逻辑，确保在构建交接工具集时正确应用权限守卫（_PermissionGuardedTool），防止通过代理交接机制进行未授权的工具访问。
+
+
+  注意：根据 OSV 数据，受影响版本为 4.25.0 至 4.25.5。
+
+  '
+security_advise: '- 升级 AstrBot 至包含修复提交 d23011262e8e75e1ec41b0f1f0091493a022327e 的
+  4.25.5 之后版本
+
+  - 如无法立即升级，请审查并限制角色工具配置，以最小化未授权工具访问的影响
+
+  - 监控日志中与预期角色工具集不匹配的异常工具调用
+
+  - 配置角色工具访问时遵循最小权限原则
+
+  '
+references:
+- https://github.com/AstrBotDevs/AstrBot/
+- https://github.com/AstrBotDevs/AstrBot/commit/d23011262e8e75e1ec41b0f1f0091493a022327e
+- https://github.com/AstrBotDevs/AstrBot/issues/8780
+- https://github.com/AstrBotDevs/AstrBot/pull/8786
+- https://nvd.nist.gov/vuln/detail/CVE-2026-17529

--- a/data/vuln/astrbot/CVE-2026-17530.yaml
+++ b/data/vuln/astrbot/CVE-2026-17530.yaml
@@ -1,0 +1,50 @@
+info:
+  name: astrbot
+  author: A.I.G bot
+  severity: medium
+  metadata:
+    cve_id: CVE-2026-17530
+    cwe: CWE-285, CWE-863
+    cvss: 6.3
+    cvss_vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  tags: astrbot,授权绕过,子代理,交接工具集,cwe285,cwe863
+  details: 'AstrBot 4.25.5 及之前版本在 Subagent 组件中存在授权校验不当漏洞，具体位于 astrbot/core/astr_agent_tool_exec.py
+    文件的 _build_handoff_toolset 函数中。该缺陷允许在构建代理交接工具集时绕过授权校验。已认证的低权限用户可通过代理交接机制访问本应被限制的工具，导致未授权的工具执行。该漏洞已在提交
+    d23011262e8e75e1ec41b0f1f0091493a022327e 中修复。
+
+    '
+  cve: CVE-2026-17530
+rule: version >= "4.25.0" && version <= "4.25.5"
+details: '在 AstrBotDevs AstrBot 4.25.5 及之前版本中发现授权校验不当漏洞。该漏洞存在于 astrbot/core/astr_agent_tool_exec.py
+  的 _build_handoff_toolset 函数中，属于 Subagent 组件。
+
+
+  _build_handoff_toolset 函数负责在代理交接（任务委派）期间构建子代理可用的工具集。然而，该函数未正确地将权限守卫（_PermissionGuardedTool）应用于交接工具集中包含的工具。因此，当父代理将任务委派给子代理时，子代理可能会获得本应被用户角色（persona）配置限制的工具访问权限。
+
+
+  这种授权校验不当使得已认证的低权限用户能够利用子代理交接机制访问和执行本应被角色工具访问策略限制的工具。攻击可远程发起，且该漏洞的利用方式已公开披露。
+
+
+  修复补丁（提交 d23011262e8e75e1ec41b0f1f0091493a022327e）修改了 _build_handoff_toolset 函数，使其正确地使用
+  _PermissionGuardedTool 包装工具，确保即使工具被委派给子代理时，基于角色的访问限制仍能被强制执行。
+
+
+  注意：根据 NVD 和 OSV 数据，受影响版本为 4.25.5 及之前版本。
+
+  '
+security_advise: '- 升级 AstrBot 至包含修复提交 d23011262e8e75e1ec41b0f1f0091493a022327e 的
+  4.25.5 之后版本
+
+  - 如无法立即升级，请审查并限制角色工具配置，以最小化通过子代理交接进行未授权工具访问的影响
+
+  - 监控日志中来自子代理交接的异常工具调用，检查是否与预期角色工具集不匹配
+
+  - 配置角色工具访问时遵循最小权限原则
+
+  '
+references:
+- https://github.com/AstrBotDevs/AstrBot/
+- https://github.com/AstrBotDevs/AstrBot/commit/d23011262e8e75e1ec41b0f1f0091493a022327e
+- https://github.com/AstrBotDevs/AstrBot/issues/8781
+- https://github.com/AstrBotDevs/AstrBot/pull/8786
+- https://nvd.nist.gov/vuln/detail/CVE-2026-17530

--- a/data/vuln/dify/CVE-2026-18266.yaml
+++ b/data/vuln/dify/CVE-2026-18266.yaml
@@ -1,0 +1,26 @@
+info:
+  name: dify
+  author: A.I.G bot
+  cve: CVE-2026-18266
+  summary: Dify 1.16.0 之前版本在 webapp-signin 登录流程中存在开放重定向漏洞，远程攻击者可通过 oauth_redirect_url 参数将用户重定向至攻击者控制的 URL。
+  details: >-
+    Dify AI Workflow 在 AppInitializer 组件的 OAuth 流程处理中存在开放重定向漏洞（CWE-601：URL 重定向到不可信站点）。
+    webapp-signin 登录流程接受用户可控的 redirect_url 参数，在认证完成后将浏览器重定向至该 URL，且未校验目标是否属于可信来源。
+    远程攻击者可构造恶意登录链接，受害者点击并完成认证后会被重定向至攻击者控制的站点，从而实施钓鱼和敏感信息泄露。
+    利用该漏洞需要用户交互（受害者需访问恶意页面或打开恶意链接）。受影响版本为 1.16.0 之前版本。
+    厂商在 PR #38864 中修复此漏洞，引入了基于白名单的重定向目标校验逻辑（resolveWebAppLoginRedirect /
+    replaceLoginRedirect），封装在新增的 login-redirect.ts 模块中，该修复首次包含于 1.16.0 版本。
+  cvss: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
+  severity: MEDIUM
+  security_advise: 升级 Dify 至 1.16.0 或更高版本。该修复在 webapp-signin 的 login-redirect 模块中增加了
+    基于白名单的重定向目标校验（resolveWebAppLoginRedirect），防止重定向至不可信来源。
+    官方修复详见 https://github.com/langgenius/dify/releases/tag/1.16.0。
+  references:
+    - https://www.zerodayinitiative.com/advisories/ZDI-26-452/
+    - https://github.com/langgenius/dify/pull/38864
+    - https://github.com/langgenius/dify/releases/tag/1.16.0
+rule: version < "1.16.0"
+references:
+  - https://www.zerodayinitiative.com/advisories/ZDI-26-452/
+  - https://github.com/langgenius/dify/pull/38864
+  - https://github.com/langgenius/dify/releases/tag/1.16.0

--- a/data/vuln/langflow/CVE-2026-13442.yaml
+++ b/data/vuln/langflow/CVE-2026-13442.yaml
@@ -1,0 +1,12 @@
+info:
+  name: langflow
+  author: A.I.G bot
+  cve: CVE-2026-13442
+  summary: langflow IBM Langflow OSS FAISS 命名空间跨用户信息泄露
+  details: IBM Langflow OSS 1.0.0 至 1.10.1 版本中，攻击者可复用其他用户的 FAISS 命名空间来访问仅限所有者的向量内容，并影响后续查询结果。此漏洞导致跨用户信息泄露，并通过持续污染返回结果造成有限的完整性影响。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: 将 langflow 升级至 1.10.2 或更高版本。
+rule: version >= "1.0.0" && version < "1.10.2"
+references:
+- https://www.ibm.com/support/pages/node/7279988

--- a/data/vuln/network-ai/CVE-2026-46701.yaml
+++ b/data/vuln/network-ai/CVE-2026-46701.yaml
@@ -1,0 +1,22 @@
+info:
+  name: network-ai
+  author: A.I.G bot
+  cve: CVE-2026-46701
+  summary: Network-AI 因默认空密钥导致未认证跨源 MCP 工具调用漏洞
+  details: 'Network-AI 是一个 TypeScript/Node.js 多 Agent 编排框架。在 5.4.5 版本之前，其 MCP SSE
+    服务器默认使用空密钥（`process.env[''NETWORK_AI_MCP_SECRET''] ?? ''''`，位于 `bin/mcp-server.ts:88`），导致
+    `_isAuthorized`（`lib/mcp-transport-sse.ts`）对所有请求 无条件返回 `true`——无需任何 `Authorization`
+    请求头。同时，`_handleRequest` 在每个响应中 设置 `Access-Control-Allow-Origin: *`，因此跨源网页可以无需认证即可向服务器
+    POST 任意 MCP 工具调用（如 blackboard_read、blackboard_write、配置操作等）。这使得未认证的远程 攻击者可以读取和修改实时编排器状态、调用任意
+    MCP 工具，并可能通过 Agent 控制面操作 实现远程代码执行。'
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:H/A:L
+  severity: HIGH
+  security_advise: 建议尽快升级 Network-AI 至 5.4.5 或更高版本。启动 MCP SSE 服务器前，务必将 NETWORK_AI_MCP_SECRET
+    环境变量设置为强非空密钥值。
+rule: version < "5.4.5"
+references:
+- https://github.com/Jovancoding/Network-AI/commit/dc5048112283f3f4eb6c06dd2bf5aa93ef9339be
+- https://github.com/Jovancoding/Network-AI/releases/tag/v5.4.5
+- https://github.com/Jovancoding/Network-AI/security/advisories/GHSA-j3vx-cx2r-pvg8
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/46xxx/CVE-2026-46701.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-46701

--- a/data/vuln/ollama/CVE-2026-65315.yaml
+++ b/data/vuln/ollama/CVE-2026-65315.yaml
@@ -1,0 +1,20 @@
+info:
+  name: ollama
+  author: A.I.G bot
+  cve: CVE-2026-65315
+  summary: Ollama GGUF 元数据解析器不受控内存分配导致远程拒绝服务漏洞
+  details: "Ollama 的 GGUF 元数据解析器存在不受控内存分配漏洞（CWE-789），远程攻击者可通过上传精心构造的\
+    \ GGUF 文件触发服务器崩溃。该文件利用攻击者可控的长度和计数字段（字符串长度、张量维度计数、元数据数组计数）作为分配大小，而未对剩余文件大小进行验证。攻击者可通过\
+    \ blob 上传和模型创建或拉取 API 端点上传不足 1KB 的构造文件，导致服务器不可恢复的崩溃。该漏洞影响所有截至 HEAD commit f0078ae\
+    \ 的 Ollama 版本。修复已通过 PR #17062（\"create: harden GGUF create flows\"）于 2026 年 7 月\
+    \ 6 日合并，并包含在 Ollama v0.31.2 及更高版本中。"
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+  severity: HIGH
+  security_advise: 升级 Ollama 至 v0.31.2 或更高版本，该版本包含 GGUF 元数据解析器不受控内存分配漏洞的修复（PR
+    #17062）。
+rule: version < "0.31.2"
+references:
+- https://github.com/ollama/ollama
+- https://github.com/ollama/ollama/issues/17042
+- https://www.vulncheck.com/advisories/ollama-remote-denial-of-service-via-attacker-controlled-allocation-in-gguf-metadata-parser
+- https://www.ionix.io/threat-center/cve-2026-65315/

--- a/data/vuln/openwebui/CVE-2026-59212.yaml
+++ b/data/vuln/openwebui/CVE-2026-59212.yaml
@@ -1,0 +1,19 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59212
+  summary: Open WebUI 知识文件只读访问可被提升为文件写入/删除权限
+  details: Open WebUI 是一个功能丰富、用户友好的自托管 AI 平台。在 0.9.6 到 0.10.0 之前的版本中，_verify_knowledge_file_access
+    仅检查读取权限，而文件写入和删除路由后续通过可写的 model meta.knowledge 条目信任对象派生的访问权限，导致具有只读知识文件访问权限的用户可以将权限提升至文件写入或删除操作。此问题已在
+    0.10.0 版本中修复。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L
+  severity: MEDIUM
+  security_advise: 建议尽快升级 openwebui 至 0.10.0 或更高版本。
+rule: version >= "0.9.6" && version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/commit/17df0264929514599dbcb21c6578bcdfa204b04d
+- https://github.com/open-webui/open-webui/pull/26032
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-2xwm-4h2q-ggfx
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/59xxx/CVE-2026-59212.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-59212

--- a/data/vuln/openwebui/CVE-2026-59214.yaml
+++ b/data/vuln/openwebui/CVE-2026-59214.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59214
+  summary: Open WebUI 通过 Pyodide 同源 web worker 存储型 XSS 可发起认证请求访问管理员端点
+  details: Open WebUI 是一个功能丰富、用户友好的自托管 AI 平台。在 0.10.0 之前的版本中，Open WebUI 使用
+    Pyodide 在同源 web worker 中运行客户端 Python 代码，允许存储型聊天载荷通过 pyodide.http.pyfetch
+    或 js 模块的 fetch 和 XMLHttpRequest API 发起认证同源请求。当受害者点击"运行"时，这些请求可访问仅管理员可用的端点，
+    并通过已配置的工具执行服务端代码。该问题已在 0.10.0 版本中修复。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: 升级 Open WebUI 至 0.10.0 或更高版本，该版本修复了 Pyodide web worker 同源请求问题。
+rule: version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-4r2p-27mh-5m22
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-59214

--- a/data/vuln/openwebui/CVE-2026-59215.yaml
+++ b/data/vuln/openwebui/CVE-2026-59215.yaml
@@ -1,0 +1,26 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59215
+  summary: Open WebUI 私有频道线程消息跨频道泄露
+  details: >-
+    Open WebUI 是一个可扩展、功能丰富且用户友好的自托管 AI 平台。在 0.10.0 版本之前，
+    频道线程的父消息（parent）与回复（reply）处理逻辑未将 parent_id 与 URL 中的频道
+    进行绑定。该缺陷允许已认证用户在撰写线程回复时引用属于其他私有频道或私信（DM）
+    频道的消息，从而跨频道泄露线程上下文。拥有有效账户的攻击者可通过构造带有猜测或
+    枚举出的 parent_id 的请求，推断私有频道消息内容。该漏洞归类为 CWE-639
+    （通过用户可控键的授权绕过）。该问题已在 0.10.0 版本中修复，修复方式为将 parent_id
+    校验绑定到 URL 中的频道。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: >-
+    将 Open WebUI 升级至 0.10.0 或更高版本，该版本将线程 parent_id 校验绑定到请求 URL
+    中的频道。若无法立即升级，请将私有/私信频道功能访问权限限制为可信用户，并审计
+    可疑的跨频道线程活动。
+rule: version < "0.10.0"
+references:
+  - https://github.com/open-webui/open-webui/security/advisories/GHSA-73x5-h92w-xc2j
+  - https://github.com/open-webui/open-webui/pull/25766
+  - https://github.com/open-webui/open-webui/release/tag/v0.10.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-59215
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/59xxx/CVE-2026-59215.json

--- a/data/vuln/openwebui/CVE-2026-59216.yaml
+++ b/data/vuln/openwebui/CVE-2026-59216.yaml
@@ -1,0 +1,36 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59216
+  summary: "Open WebUI：因 Socket.IO event-caller session_id 未校验导致跨用户代码解释器与工具执行"
+  details: |
+    Open WebUI 是一个可扩展、功能丰富且用户友好的自托管 AI 平台。
+    在 0.10.0 版本之前，get_event_call 处理器在仅校验 session 已连接的情况下，就将 execute:python
+    和 execute:tool 这两类 Socket.IO 事件投递给了客户端提供的 session_id。这使得已认证用户
+    一旦通过 ydoc:document:join 事件获知其他用户的 socket ID，即可在该用户会话中执行
+    代码解释器（Python）或调用工具，从而造成跨用户的代码解释器与工具执行。
+
+    这属于授权校验缺失类漏洞（CWE-639 / CWE-862），会跨会话暴露已授权的代码解释器与工具能力——
+    攻击者无法读取对方聊天内容，但可在对方会话上下文中执行代码或工具。
+
+    严重等级：HIGH（CVSS 7.7，CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N）。
+
+    受影响版本：0.10.0 之前的所有版本（0.10.0 已修复）。
+    OSINT 利用成熟度：LOW——撰写时尚无公开 PoC/exploit；利用需已认证攻击者获取其他在线 socket 会话的 session_id。
+  security_advise: |
+    将 Open WebUI 升级至 0.10.0 或更高版本，该版本在投递 execute:python / execute:tool
+    Socket.IO 事件前会校验 session_id 的归属。
+
+    若无法立即升级，可采取以下缓解措施：
+      - 限制对 Open WebUI 实例的访问（网络 ACL / VPN / 反向代理鉴权）。
+      - 限制可使用代码解释器 / 工具功能的已认证用户范围。
+      - 监控 Socket.IO 事件日志，排查可疑的跨会话 execute:python / execute:tool 调用。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N
+  severity: HIGH
+rule: version < "0.10.0"
+references:
+  - https://github.com/open-webui/open-webui/security/advisories/GHSA-74h3-cxq7-vc5q
+  - https://github.com/open-webui/open-webui/pull/25763
+  - https://github.com/open-webui/open-webui/commit/386ac958144dbbbf0aa6e268070d72b681a318aa
+  - https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-59216

--- a/data/vuln/openwebui/CVE-2026-59217.yaml
+++ b/data/vuln/openwebui/CVE-2026-59217.yaml
@@ -1,0 +1,17 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59217
+  summary: Open WebUI 文件上传的 metadata.knowledge_id 绕过知识库写权限校验，允许只读用户向知识库添加文件
+  details: Open WebUI 是一个功能丰富、用户友好的自托管 AI 平台。在 0.10.0 之前的版本中，文件上传路径接受
+    metadata.knowledge_id 参数，并在未应用 /api/v1/knowledge//file/add 所使用的写权限校验的情况下，将上传的文件自动关联到目标知识库，导致只读知识库用户可以向其仅有读权限的知识库添加任意文件。该问题在 0.10.0 版本中已修复。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
+  severity: MEDIUM
+  security_advise: 升级 Open WebUI 至 0.10.0 或更高版本，该版本确保文件上传路径应用与 /api/v1/knowledge//file/add 相同的写权限校验。
+rule: version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-7r7x-gjvr-448g
+- https://github.com/open-webui/open-webui/pull/26001
+- https://github.com/open-webui/open-webui/commit/b7626f05fb92b24ab923ad81a037071ebd5623d1
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-59217

--- a/data/vuln/openwebui/CVE-2026-59221.yaml
+++ b/data/vuln/openwebui/CVE-2026-59221.yaml
@@ -1,0 +1,16 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59221
+  summary: Open WebUI 终端代理路径遍历防护绕过（九次编码绕过）
+  details: Open WebUI 是一个功能丰富、用户友好的自托管 AI 平台。在 0.9.6 到 0.10.0 之前的版本中，backend/open_webui/routers/terminals.py
+    中的 _sanitize_proxy_path 对代理路径仅解码八次，导致九次百分号编码的 ../ 遍历值能够通过规范化检查，并被上游终端服务器进一步解码为路径遍历序列。已认证的低权限用户可通过路径遍历读取终端服务器上的任意文件，导致敏感信息泄露。该问题在 0.10.0 版本中已修复。
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: 升级 openwebui 至 0.10.0 或更高版本。
+rule: version >= "0.9.6" && version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/commit/05098d25a58d03738e01c4e85e8852c3b4ad849c
+- https://github.com/open-webui/open-webui/pull/26050
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-frvj-c5qp-xj4w

--- a/data/vuln/openwebui/CVE-2026-59224.yaml
+++ b/data/vuln/openwebui/CVE-2026-59224.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59224
+  summary: Open WebUI 终端代理将可伪造且无完整性绑定的用户身份转发至上游
+  details: |
+    Open WebUI 是一个可扩展、功能丰富且用户友好的自托管 AI 平台。在 0.10.0 版本之前，backend/open_webui/routers/terminals.py 模块从未编码的 session_id 构建 ws_terminal 上游 URL，并将 user_id 作为查询参数附加，允许通过查询注入使终端后端解析另一个用户身份。此外，HTTP 代理路径将 X-User-Id 头作为无完整性绑定的身份声明转发。已认证的低权限攻击者可利用这些缺陷在访问终端功能时冒充其他用户的身份，可能获取属于不同用户的资源或操作的未授权访问。此问题在 0.10.0 版本中已修复。
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: |
+    1. 升级到 open-webui >= 0.10.0
+    2. 如果无法立即升级，请仅将终端访问权限限制给可信用户
+    3. 检查访问日志中是否有可疑的终端会话活动，以排查是否曾被利用
+rule: version < "0.10.0"
+references:
+  - https://github.com/open-webui/open-webui/commit/5f3a628a8d291bb5d33e1a0b0c89fb62a2927934
+  - https://github.com/open-webui/open-webui/pull/26042
+  - https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+  - https://github.com/open-webui/open-webui/security/advisories/GHSA-j657-m4c4-24jq
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-59224

--- a/data/vuln/ray/CVE-2026-57516.yaml
+++ b/data/vuln/ray/CVE-2026-57516.yaml
@@ -1,0 +1,28 @@
+info:
+  name: ray
+  author: A.I.G bot
+  cve: CVE-2026-57516
+  summary: Ray WebDataset 读取器不安全反序列化远程代码执行漏洞
+  details: 'Ray 2.56.0 之前版本在 WebDataset 读取器中存在不安全反序列化漏洞，攻击者可通过向 read_webdataset() 函数提供恶意
+    tar 归档文件实现远程代码执行。webdataset_datasource.py 中的 _default_decoder() 函数对 .pkl/.pickle
+    扩展名的 tar 条目无条件调用 pickle.loads()，对 .pt/.pth 扩展名的条目使用 weights_only=False 调用
+    torch.load()，在处理恶意数据集的每个 Ray 远程 Worker 中执行任意代码。
+
+    [利用成熟度：低]
+
+    - 利用成熟度低：暂无已知公开 PoC 或活跃利用
+
+    注意：受影响版本为 Ray < 2.56.0，修复版本为 Ray 2.56.0。ray 指纹有 matchers 但无 version extractor，AIG
+    引擎在扫描时无法评估版本条件。此规则对所有检测到的 Ray 实例发出告警，待补充 version extractor 后回填版本条件。'
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: 升级 Ray 至 2.56.0 或更高版本。修复版本移除了 WebDataset 解码器中无条件调用的 pickle.loads() 和
+    torch.load()，替换为安全的反序列化方法。此外，避免从不可信来源加载 WebDataset 归档文件，并考虑限制 Ray Worker
+    网络访问作为临时缓解措施。
+rule: 'version < "2.56.0"'
+references:
+- https://github.com/ray-project/ray/pull/63469
+- https://github.com/ray-project/ray/pull/63470
+- https://github.com/ray-project/ray/releases/tag/ray-2.56.0
+- https://github.com/ray-project/ray/security/advisories/GHSA-hhrp-gw25-jr43
+- https://www.vulncheck.com/advisories/ray-unsafe-deserialization-rce-via-webdataset-reader

--- a/data/vuln/suna/CVE-2026-66027.yaml
+++ b/data/vuln/suna/CVE-2026-66027.yaml
@@ -1,0 +1,40 @@
+info:
+  name: Suna
+  author: A.I.G bot
+  cve: CVE-2026-66027
+  summary: Suna < 0.9.102 消息队列 API 访问控制失效漏洞
+  details: |
+    Suna（Kortix）0.9.102 之前版本在消息队列 API（/v1/queue/*）中存在访问控制失效漏洞，
+    允许已认证的攻击者利用缺失的所有权和账户隔离检查，访问和操纵属于其他用户的队列资源。
+    队列路由应用了认证（combinedAuth 验证有效的 Supabase JWT 或 Kortix API Key），
+    但路由处理程序从不读取 userId，也不执行所有权检查。
+
+    攻击者可以：
+    - 通过 GET /v1/queue/all 读取所有用户的待处理提示队列
+    - 通过 GET/DELETE /v1/queue/sessions/:sessionId 读取或删除其他用户的会话
+    - 通过 POST /v1/queue/sessions/:sessionId 向其他用户的会话队列注入任意提示，
+      导致后台 drainer 将恶意消息转发给受害者正在运行的 AI Agent，
+      并使用受害者的凭据和权限执行操作。
+
+    底层基于文件系统的存储将会话队列存储为 <DATA_DIR>/queue/<sessionId>.json，
+    不包含账户或用户字段，且在任何读取、写入或删除操作之前都不会对 project_sessions
+    表（记录了 accountId）进行查找验证。
+
+    [利用成熟度：低] - 未发现公开的 PoC 或漏洞利用代码。
+  security_advise: |
+    1. 将 Suna 升级至 0.9.102 或更高版本（commit 7536a7d47fc93abcb66e677fcc993b390c81296a）
+    2. 审查并在所有 /v1/queue/* 端点强制实施所有权/账户隔离检查
+    3. 确保会话队列存储包含账户/用户字段，并针对 project_sessions 表进行访问验证
+    4. 监控应用程序日志中的未授权队列访问尝试
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L
+  severity: HIGH
+rule: version < "0.9.102"
+references:
+  - https://github.com/geo-chen/oss/blob/main/suna.md
+  - https://github.com/kortix-ai/suna/commit/7536a7d47fc93abcb66e677fcc993b390c81296a
+  - https://github.com/kortix-ai/suna/pull/4373
+  - https://github.com/kortix-ai/suna/releases/tag/v0.9.102
+  - https://www.vulncheck.com/advisories/suna-broken-access-control-via-message-queue-api
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/66xxx/CVE-2026-66027.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-66027
+  - https://github.com/kortix-ai/suna

--- a/data/vuln_en/LiteLLM/CVE-2026-67425.yaml
+++ b/data/vuln_en/LiteLLM/CVE-2026-67425.yaml
@@ -1,0 +1,22 @@
+info:
+  name: LiteLLM
+  author: A.I.G bot
+  cve: CVE-2026-67425
+  summary: LiteLLM is a proxy server (AI Gateway) to call LLM APIs in OpenAI (or native)
+    format
+  details: "LiteLLM is a proxy server (AI Gateway) to call LLM APIs in OpenAI (or native)
+    format. Prior to version 2.26.6, the llm.chat function reads provider keys such
+    as OPENAI_API_KEY and ANTHROPIC_API_KEY from the environment and sends them in
+    the Authorization Bearer header to a caller-controlled base_url, allowing an
+    attacker to receive the operator's key on a public host that passes the SSRF
+    guard. This issue is fixed in version 2.26.6."
+  cvss: '8.6'
+  severity: HIGH
+  security_advise: Upgrade LiteLLM to version 2.26.6 or later. Ensure that provider
+    API keys are not leaked to caller-controlled endpoints and validate base_url
+    to prevent SSRF-based key exfiltration.
+rule: version < "2.26.6"
+references:
+- https://github.com/flytohub/flyto-core/commit/d5f89d71303e3c1e6418d347c5c55fcd173cc8cc
+- https://github.com/flytohub/flyto-core/releases/tag/v2.26.6
+- https://github.com/flytohub/flyto-core/security/advisories/GHSA-qq9q-xgm3-xv9g

--- a/data/vuln_en/LiteLLM/CVE-2026-67428.yaml
+++ b/data/vuln_en/LiteLLM/CVE-2026-67428.yaml
@@ -1,0 +1,23 @@
+info:
+  name: LiteLLM
+  author: A.I.G bot
+  cve: CVE-2026-67428
+  summary: Flyto2 Core is an execution kernel for automation and AI-agent workflows
+  details: "Flyto2 Core is an execution kernel for automation and AI-agent workflows.
+    Prior to 2.26.7, HTTP-emitting modules including src/core/modules/third_party/developer/http/requests.py,
+    core.api.http_get, core.api.http_post, graphql.query, graphql.mutation, monitor.http_check,
+    communication.slack_send, notification.discord.send_message, notification.slack.send_message,
+    notification.teams.send_message, ai.vision_analyze, verify.visual_diff, browser.proxy_rotate,
+    and the agent and llm inline base_url branch fetch caller-controlled URLs without
+    validate_url_with_env_config, allowing SSRF to internal or metadata endpoints.
+    This issue is fixed in version 2.26.7."
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: Upgrade to version 2.26.7 or later. The fix adds validate_url_with_env_config
+    validation to all HTTP-emitting modules, preventing SSRF to internal endpoints
+    and cloud metadata services.
+rule: version < "2.26.7"
+references:
+- https://github.com/flytohub/flyto-core/commit/0a0a528520ec18f5a21f1ddf858a71cc1edfb6e9
+- https://github.com/flytohub/flyto-core/releases/tag/v2.26.7
+- https://github.com/flytohub/flyto-core/security/advisories/GHSA-pgwh-4jj4-qm8v

--- a/data/vuln_en/astrbot/CVE-2026-17529.yaml
+++ b/data/vuln_en/astrbot/CVE-2026-17529.yaml
@@ -1,0 +1,66 @@
+info:
+  name: astrbot
+  author: A.I.G bot
+  severity: medium
+  metadata:
+    cve_id: CVE-2026-17529
+    cwe: CWE-285, CWE-863
+    cvss: 6.3
+    cvss_vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  tags: astrbot,authorization-bypass,tool-access,cwe285,cwe863
+  details: 'AstrBot up to version 4.25.5 contains an incorrect authorization vulnerability
+    in the file astrbot/core/astr_main_agent.py. The flaw allows manipulation of the
+    req.func_tool argument to bypass persona-based tool access restrictions. An authenticated
+    low-privileged user can access tools that should be restricted by persona configuration,
+    leading to unauthorized tool execution. The vulnerability was fixed in commit
+    d23011262e8e75e1ec41b0f1f0091493a022327e.
+
+    '
+  cve: CVE-2026-17529
+rule: version >= "4.25.0" && version <= "4.25.5"
+details: 'A vulnerability was identified in AstrBotDevs AstrBot affecting versions
+  4.25.0 through 4.25.5. The vulnerability exists in astrbot/core/astr_main_agent.py
+  where the req.func_tool argument is not properly validated against persona-based
+  tool access controls.
+
+
+  When a persona is configured with a restricted set of tools (e.g., persona["tools"]
+  = []), the _ensure_persona_and_skills function applies the restricted toolset to
+  the request. However, after this function returns, additional tools may be added
+  to req.func_tool by subsequent processing in _decorate_llm_request and build_main_agent,
+  bypassing the persona restrictions. This allows a low-privileged authenticated user
+  to access tools that should be restricted by their persona configuration.
+
+
+  The fix (commit d23011262e8e75e1ec41b0f1f0091493a022327e) modifies _ensure_persona_and_skills
+  to return the set of allowed tools (persona_allowed_tools), and build_main_agent
+  now filters out any tools from req.func_tool that are not in the allowed set, ensuring
+  persona restrictions are enforced after all tool injection points.
+
+
+  Additionally, the fix corrects _build_handoff_toolset in astr_agent_tool_exec.py
+  to properly apply permission guards (_PermissionGuardedTool) to tools when building
+  handoff toolsets, preventing unauthorized tool access through agent handoff mechanisms.
+
+
+  Note: Affected versions are 4.25.0 through 4.25.5 based on OSV data.
+
+  '
+security_advise: '- Upgrade AstrBot to a version newer than 4.25.5 that includes the
+  fix from commit d23011262e8e75e1ec41b0f1f0091493a022327e
+
+  - If upgrading is not immediately possible, review and restrict persona tool configurations
+  to minimize the impact of unauthorized tool access
+
+  - Monitor logs for unusual tool invocations that do not match the expected persona
+  toolset
+
+  - Apply the principle of least privilege when configuring persona tool access
+
+  '
+references:
+- https://github.com/AstrBotDevs/AstrBot/
+- https://github.com/AstrBotDevs/AstrBot/commit/d23011262e8e75e1ec41b0f1f0091493a022327e
+- https://github.com/AstrBotDevs/AstrBot/issues/8780
+- https://github.com/AstrBotDevs/AstrBot/pull/8786
+- https://nvd.nist.gov/vuln/detail/CVE-2026-17529

--- a/data/vuln_en/astrbot/CVE-2026-17530.yaml
+++ b/data/vuln_en/astrbot/CVE-2026-17530.yaml
@@ -1,0 +1,66 @@
+info:
+  name: astrbot
+  author: A.I.G bot
+  severity: medium
+  metadata:
+    cve_id: CVE-2026-17530
+    cwe: CWE-285, CWE-863
+    cvss: 6.3
+    cvss_vector: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+  tags: astrbot,authorization-bypass,subagent,handoff-toolset,cwe285,cwe863
+  details: 'AstrBot up to version 4.25.5 contains an incorrect authorization vulnerability
+    in the Subagent component, specifically in the _build_handoff_toolset function
+    of the file astrbot/core/astr_agent_tool_exec.py. The flaw allows manipulation
+    to bypass authorization checks when building handoff toolsets for subagent delegation.
+    An authenticated low-privileged user can access tools that should be restricted,
+    leading to unauthorized tool execution through the agent handoff mechanism. The
+    vulnerability was fixed in commit d23011262e8e75e1ec41b0f1f0091493a022327e.
+
+    '
+  cve: CVE-2026-17530
+rule: version >= "4.25.0" && version <= "4.25.5"
+details: 'A vulnerability was identified in AstrBotDevs AstrBot affecting versions
+  up to 4.25.5. The vulnerability exists in the _build_handoff_toolset function of
+  astrbot/core/astr_agent_tool_exec.py, which is part of the Subagent component.
+
+
+  The _build_handoff_toolset function is responsible for constructing the set of tools
+  available to a subagent during agent handoff (delegation). However, this function
+  does not properly apply permission guards (_PermissionGuardedTool) to the tools
+  it includes in the handoff toolset. As a result, when a parent agent delegates tasks
+  to a subagent, the subagent may receive access to tools that should be restricted
+  by the user''s persona configuration.
+
+
+  This incorrect authorization allows an authenticated low-privileged user to leverage
+  the subagent handoff mechanism to access and execute tools that are otherwise restricted
+  by their persona''s tool access policy. The attack can be launched remotely, and
+  the exploit has been publicly disclosed.
+
+
+  The fix (commit d23011262e8e75e1ec41b0f1f0091493a022327e) modifies _build_handoff_toolset
+  to properly wrap tools with _PermissionGuardedTool, ensuring that persona-based
+  access restrictions are enforced even when tools are delegated to subagents.
+
+
+  Note: Affected versions are up to 4.25.5 based on NVD and OSV data.
+
+  '
+security_advise: '- Upgrade AstrBot to a version newer than 4.25.5 that includes the
+  fix from commit d23011262e8e75e1ec41b0f1f0091493a022327e
+
+  - If upgrading is not immediately possible, review and restrict persona tool configurations
+  to minimize the impact of unauthorized tool access through subagent handoff
+
+  - Monitor logs for unusual tool invocations originating from subagent handoff that
+  do not match the expected persona toolset
+
+  - Apply the principle of least privilege when configuring persona tool access
+
+  '
+references:
+- https://github.com/AstrBotDevs/AstrBot/
+- https://github.com/AstrBotDevs/AstrBot/commit/d23011262e8e75e1ec41b0f1f0091493a022327e
+- https://github.com/AstrBotDevs/AstrBot/issues/8781
+- https://github.com/AstrBotDevs/AstrBot/pull/8786
+- https://nvd.nist.gov/vuln/detail/CVE-2026-17530

--- a/data/vuln_en/dify/CVE-2026-18266.yaml
+++ b/data/vuln_en/dify/CVE-2026-18266.yaml
@@ -1,0 +1,30 @@
+info:
+  name: dify
+  author: A.I.G bot
+  cve: CVE-2026-18266
+  summary: Dify before 1.16.0 allows remote attackers to redirect users to attacker-controlled URLs via the oauth_redirect_url parameter in the webapp-signin login flow.
+  details: >-
+    Dify AI Workflow contains an open redirect vulnerability (CWE-601: URL Redirection to Untrusted Site)
+    in the OAuth flow handling within the AppInitializer component. The webapp-signin login flow
+    accepts a user-controllable redirect_url parameter and redirects the browser to that URL after
+    authentication without validating that the target belongs to a trusted origin. A remote attacker
+    can craft a malicious sign-in link that, once a victim clicks and authenticates, redirects them
+    to an attacker-controlled site, enabling phishing and sensitive-information disclosure.
+    User interaction is required (the victim must visit a malicious page or open a malicious link).
+    The flaw exists in versions prior to 1.16.0. The vendor fixed it in PR #38864 by introducing a
+    resolveWebAppLoginRedirect / replaceLoginRedirect allowlist-based validation in the new
+    login-redirect.ts module, first shipped in release 1.16.0.
+  cvss: CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N
+  severity: MEDIUM
+  security_advise: Upgrade Dify to version 1.16.0 or later. The fix adds allowlist-based redirect
+    target validation (resolveWebAppLoginRedirect) in the webapp-signin login-redirect module,
+    preventing redirects to untrusted origins. See https://github.com/langgenius/dify/releases/tag/1.16.0.
+  references:
+    - https://www.zerodayinitiative.com/advisories/ZDI-26-452/
+    - https://github.com/langgenius/dify/pull/38864
+    - https://github.com/langgenius/dify/releases/tag/1.16.0
+rule: version < "1.16.0"
+references:
+  - https://www.zerodayinitiative.com/advisories/ZDI-26-452/
+  - https://github.com/langgenius/dify/pull/38864
+  - https://github.com/langgenius/dify/releases/tag/1.16.0

--- a/data/vuln_en/langflow/CVE-2026-13442.yaml
+++ b/data/vuln_en/langflow/CVE-2026-13442.yaml
@@ -1,0 +1,15 @@
+info:
+  name: langflow
+  author: A.I.G bot
+  cve: CVE-2026-13442
+  summary: langflow IBM Langflow OSS FAISS namespace cross-user information disclosure
+  details: IBM Langflow OSS 1.0.0 through 1.10.1 can allow an attacker to reuse another
+    user's FAISS namespace to access owner-only vector content and influence later
+    query results. This causes cross-user information disclosure and limited integrity
+    impact through persistent poisoning of returned results.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
+  severity: HIGH
+  security_advise: Upgrade langflow to version 1.10.2 or later.
+rule: version >= "1.0.0" && version < "1.10.2"
+references:
+- https://www.ibm.com/support/pages/node/7279988

--- a/data/vuln_en/network-ai/CVE-2026-46701.yaml
+++ b/data/vuln_en/network-ai/CVE-2026-46701.yaml
@@ -1,0 +1,28 @@
+info:
+  name: network-ai
+  author: A.I.G bot
+  cve: CVE-2026-46701
+  severity: HIGH
+  details: 'Network-AI is a TypeScript/Node.js multi-agent orchestrator. Prior to
+    version 5.4.5, the MCP SSE server defaults to an empty secret (`process.env[''NETWORK_AI_MCP_SECRET'']
+    ?? ''''` at `bin/mcp-server.ts:88`), which causes `_isAuthorized` (`lib/mcp-transport-sse.ts`)
+    to return `true` unconditionally for every request — no `Authorization` header
+    is required. Simultaneously, `_handleRequest` sets `Access-Control-Allow-Origin:
+    *` on every response, so a cross-origin web page can POST arbitrary MCP tool invocations
+    (e.g. blackboard_read, blackboard_write, config operations) to the server without
+    any authentication. This allows unauthenticated remote attackers to read and mutate
+    live orchestrator state, invoke arbitrary MCP tools, and potentially achieve remote
+    code execution via agent control-plane operations.'
+  security_advise: Upgrade to version 5.4.5 or later. Ensure the NETWORK_AI_MCP_SECRET
+    environment variable is set to a strong non-empty value before starting the MCP
+    SSE server.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:H/A:L
+  summary: Network-AI unauthenticated cross-origin MCP tool invocation via empty default
+    secret
+rule: version < "5.4.5"
+references:
+- https://github.com/Jovancoding/Network-AI/commit/dc5048112283f3f4eb6c06dd2bf5aa93ef9339be
+- https://github.com/Jovancoding/Network-AI/releases/tag/v5.4.5
+- https://github.com/Jovancoding/Network-AI/security/advisories/GHSA-j3vx-cx2r-pvg8
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/46xxx/CVE-2026-46701.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-46701

--- a/data/vuln_en/ollama/CVE-2026-65315.yaml
+++ b/data/vuln_en/ollama/CVE-2026-65315.yaml
@@ -1,0 +1,26 @@
+info:
+  name: ollama
+  author: A.I.G bot
+  cve: CVE-2026-65315
+  summary: ollama GGUF metadata parser uncontrolled memory allocation leads to remote
+    denial of service
+  details: "Ollama contains an uncontrolled memory allocation vulnerability (CWE-789)\
+    \ in the GGUF metadata parser that allows remote attackers to crash the server\
+    \ by supplying a crafted GGUF file with attacker-controlled length and count fields\
+    \ in string lengths, tensor dimension counts, and metadata array counts that are\
+    \ used as allocation sizes without validation against remaining file size. Attackers\
+    \ can upload a sub-1KB crafted GGUF file via the blob upload and model create\
+    \ or pull API endpoints to trigger the crash, resulting in an unrecoverable server\
+    \ crash. The vulnerability affects all Ollama versions through HEAD commit f0078ae.\
+    \ A fix was merged via PR #17062 (\"create: harden GGUF create flows\") on July\
+    \ 6, 2026 and is included in Ollama v0.31.2 and later."
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+  severity: HIGH
+  security_advise: Upgrade Ollama to v0.31.2 or later which includes the fix for
+    uncontrolled memory allocation in the GGUF metadata parser (PR #17062).
+rule: version < "0.31.2"
+references:
+- https://github.com/ollama/ollama
+- https://github.com/ollama/ollama/issues/17042
+- https://www.vulncheck.com/advisories/ollama-remote-denial-of-service-via-attacker-controlled-allocation-in-gguf-metadata-parser
+- https://www.ionix.io/threat-center/cve-2026-65315/

--- a/data/vuln_en/openwebui/CVE-2026-59212.yaml
+++ b/data/vuln_en/openwebui/CVE-2026-59212.yaml
@@ -1,0 +1,22 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59212
+  severity: MEDIUM
+  details: Open WebUI is an extensible, feature-rich, and user-friendly self-hosted
+    AI platform. From 0.9.6 before 0.10.0, _verify_knowledge_file_access only checked
+    read access while file write and delete routes later trusted object-derived access
+    through writable model meta.knowledge entries, allowing a user with read-only
+    knowledge file access to upgrade to file write or delete operations. This issue
+    is fixed in version 0.10.0.
+  security_advise: Upgrade to version 0.10.0 or later.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:L
+  summary: Open WebUI knowledge file read-only access can be upgraded to file write/delete
+rule: version >= "0.9.6" && version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/commit/17df0264929514599dbcb21c6578bcdfa204b04d
+- https://github.com/open-webui/open-webui/pull/26032
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-2xwm-4h2q-ggfx
+- https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/59xxx/CVE-2026-59212.json
+- https://nvd.nist.gov/vuln/detail/CVE-2026-59212

--- a/data/vuln_en/openwebui/CVE-2026-59214.yaml
+++ b/data/vuln_en/openwebui/CVE-2026-59214.yaml
@@ -1,0 +1,21 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59214
+  summary: Open WebUI stored XSS via Pyodide same-origin web worker allows authenticated
+    requests to admin-only endpoints
+  details: Open WebUI is an extensible, feature-rich, and user-friendly self-hosted
+    AI platform. Prior to 0.10.0, Open WebUI runs client-side Python with Pyodide in
+    a same-origin web worker, allowing stored chat payloads that use pyodide.http.pyfetch
+    or the js module fetch and XMLHttpRequest APIs to issue authenticated same-origin
+    requests when a victim clicks Run, which can reach admin-only endpoints and execute
+    server-side code through configured tools. This issue is fixed in version 0.10.0.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:N
+  severity: HIGH
+  security_advise: Upgrade to Open WebUI version 0.10.0 or later which addresses the
+    Pyodide web worker same-origin request issue.
+rule: version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-4r2p-27mh-5m22
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-59214

--- a/data/vuln_en/openwebui/CVE-2026-59215.yaml
+++ b/data/vuln_en/openwebui/CVE-2026-59215.yaml
@@ -1,0 +1,30 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59215
+  summary: Open WebUI Private Channel Thread Cross-Channel Message Disclosure
+  details: >-
+    Open WebUI is an extensible, feature-rich, and user-friendly self-hosted AI
+    platform. Prior to version 0.10.0, the channel thread parent and reply handling
+    did not bind the parent_id to the channel specified in the URL. This flaw allows
+    an authenticated user to reference a message belonging to another private or
+    direct-message (DM) channel when composing a thread reply, thereby disclosing
+    thread context across channels. An attacker with a valid account can infer the
+    content of private channel messages by crafting requests with guessed or
+    enumerated parent_id values. The vulnerability is categorized as CWE-639
+    (Authorization Bypass Through User-Controlled Key). The issue is fixed in
+    version 0.10.0, which binds parent_id validation to the channel in the URL.
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:N/A:N
+  severity: LOW
+  security_advise: >-
+    Upgrade Open WebUI to version 0.10.0 or later, which binds thread parent_id
+    validation to the channel in the request URL. If immediate upgrade is not
+    possible, restrict access to private/DM channel features to trusted users and
+    audit for suspicious cross-channel thread activity.
+rule: version < "0.10.0"
+references:
+  - https://github.com/open-webui/open-webui/security/advisories/GHSA-73x5-h92w-xc2j
+  - https://github.com/open-webui/open-webui/pull/25766
+  - https://github.com/open-webui/open-webui/release/tag/v0.10.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-59215
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/59xxx/CVE-2026-59215.json

--- a/data/vuln_en/openwebui/CVE-2026-59216.yaml
+++ b/data/vuln_en/openwebui/CVE-2026-59216.yaml
@@ -1,0 +1,39 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59216
+  summary: "Open WebUI: Cross-user code-interpreter and tool execution via unvalidated Socket.IO event-caller session_id"
+  details: |
+    Open WebUI is an extensible, feature-rich, and user-friendly self-hosted AI platform.
+    Prior to version 0.10.0, the get_event_call handler delivered execute:python and
+    execute:tool Socket.IO events to a client-supplied session_id after checking only that
+    the session was connected. This allowed authenticated users who learned another socket ID
+    through the ydoc:document:join event to run the code interpreter (Python) or invoke tools
+    in that other user's session, resulting in cross-user code-interpreter and tool execution.
+
+    This is an authorization failure (CWE-639 / CWE-862) exposing authorized code
+    interpreter and tool capabilities across sessions — an attacker cannot read another
+    user's chat, but could execute code / tools under that user's session context.
+
+    Severity: HIGH (CVSS 7.7, CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N).
+
+    Affected versions: all versions prior to 0.10.0 (fixed in 0.10.0).
+    OSINT exploitation maturity: LOW — no public PoC/exploit observed at time of writing;
+    exploitation requires an authenticated attacker to obtain another live socket session_id.
+  security_advise: |
+    Upgrade Open WebUI to version 0.10.0 or later, which validates the session_id ownership
+    before delivering execute:python / execute:tool Socket.IO events.
+
+    Mitigations if immediate upgrade is not possible:
+      - Restrict access to the Open WebUI instance (network ACL / VPN / reverse proxy auth).
+      - Limit which authenticated users can reach the code-interpreter / tools feature.
+      - Monitor Socket.IO event logs for suspicious cross-session execute:python / execute:tool calls.
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:N
+  severity: HIGH
+rule: version < "0.10.0"
+references:
+  - https://github.com/open-webui/open-webui/security/advisories/GHSA-74h3-cxq7-vc5q
+  - https://github.com/open-webui/open-webui/pull/25763
+  - https://github.com/open-webui/open-webui/commit/386ac958144dbbbf0aa6e268070d72b681a318aa
+  - https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-59216

--- a/data/vuln_en/openwebui/CVE-2026-59217.yaml
+++ b/data/vuln_en/openwebui/CVE-2026-59217.yaml
@@ -1,0 +1,23 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59217
+  summary: Open WebUI file upload metadata.knowledge_id bypasses knowledge-base write-access
+    check allowing read-only users to add files to a knowledge base
+  details: Open WebUI is an extensible, feature-rich, and user-friendly self-hosted
+    AI platform. Prior to 0.10.0, the file upload path accepted metadata.knowledge_id
+    and auto-linked uploaded files to a target knowledge base without applying the
+    write-access check used by /api/v1/knowledge//file/add, allowing read-only knowledge-base
+    users to add arbitrary files to a knowledge base they should only be able to read.
+    This issue is fixed in version 0.10.0.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N
+  severity: MEDIUM
+  security_advise: Upgrade to Open WebUI version 0.10.0 or later which ensures the
+    file upload path applies the same write-access check as /api/v1/knowledge//file/add.
+rule: version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-7r7x-gjvr-448g
+- https://github.com/open-webui/open-webui/pull/26001
+- https://github.com/open-webui/open-webui/commit/b7626f05fb92b24ab923ad81a037071ebd5623d1
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://nvd.nist.gov/vuln/detail/CVE-2026-59217

--- a/data/vuln_en/openwebui/CVE-2026-59221.yaml
+++ b/data/vuln_en/openwebui/CVE-2026-59221.yaml
@@ -1,0 +1,24 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59221
+  summary: Open WebUI terminal proxy path traversal guard bypass via nine-times percent-encoded
+    traversal
+  details: Open WebUI is an extensible, feature-rich, and user-friendly self-hosted
+    AI platform. From 0.9.6 before 0.10.0, _sanitize_proxy_path in backend/open_webui/routers/terminals.py
+    decoded proxy paths only eight times, allowing a nine-times percent-encoded ../
+    traversal value to pass normalization checks and be decoded by the upstream terminal
+    server. This allows an authenticated low-privileged user to read arbitrary files
+    on the terminal server via path traversal, leading to information disclosure.
+    The issue is fixed in version 0.10.0.
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N
+  severity: HIGH
+  security_advise: Upgrade to Open WebUI version 0.10.0 or later which increases
+    the decoding loop in _sanitize_proxy_path to fully normalize nested percent-encoded
+    traversal sequences.
+rule: version >= "0.9.6" && version < "0.10.0"
+references:
+- https://github.com/open-webui/open-webui/commit/05098d25a58d03738e01c4e85e8852c3b4ad849c
+- https://github.com/open-webui/open-webui/pull/26050
+- https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+- https://github.com/open-webui/open-webui/security/advisories/GHSA-frvj-c5qp-xj4w

--- a/data/vuln_en/openwebui/CVE-2026-59224.yaml
+++ b/data/vuln_en/openwebui/CVE-2026-59224.yaml
@@ -1,0 +1,20 @@
+info:
+  name: openwebui
+  author: A.I.G bot
+  cve: CVE-2026-59224
+  summary: Open WebUI terminal proxy forwards spoofable integrity-unbound user identity to upstream
+  details: |
+    Open WebUI is an extensible, feature-rich, and user-friendly self-hosted AI platform. Prior to version 0.10.0, the backend/open_webui/routers/terminals.py module built the ws_terminal upstream URL from an unencoded session_id and appended user_id as a query parameter, allowing query injection to make the terminal backend resolve another user identity. Additionally, the HTTP proxy path forwarded the X-User-Id header as an integrity-unbound identity claim. An authenticated low-privileged attacker could exploit these flaws to impersonate another user's identity when accessing terminal functionality, potentially gaining unauthorized access to resources or actions belonging to a different user. This issue is fixed in version 0.10.0.
+  cvss: CVSS:3.1/AV:N/AC:H/PR:L/UI:R/S:C/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: |
+    1. Upgrade to open-webui >= 0.10.0
+    2. If upgrading is not immediately possible, restrict terminal access to trusted users only
+    3. Review access logs for any suspicious terminal session activity that may indicate prior exploitation
+rule: version < "0.10.0"
+references:
+  - https://github.com/open-webui/open-webui/commit/5f3a628a8d291bb5d33e1a0b0c89fb62a2927934
+  - https://github.com/open-webui/open-webui/pull/26042
+  - https://github.com/open-webui/open-webui/releases/tag/v0.10.0
+  - https://github.com/open-webui/open-webui/security/advisories/GHSA-j657-m4c4-24jq
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-59224

--- a/data/vuln_en/ray/CVE-2026-57516.yaml
+++ b/data/vuln_en/ray/CVE-2026-57516.yaml
@@ -1,0 +1,35 @@
+info:
+  name: ray
+  author: A.I.G bot
+  cve: CVE-2026-57516
+  summary: Ray Unsafe Deserialization RCE via WebDataset Reader
+  details: 'Ray prior to 2.56.0 contains an unsafe deserialization vulnerability in
+    the WebDataset reader that allows attackers to achieve remote code execution by
+    supplying a malicious tar archive to the read_webdataset() function. The _default_decoder()
+    function in webdataset_datasource.py unconditionally calls pickle.loads() on tar
+    entries with .pkl/.pickle extensions and torch.load() with weights_only=False
+    on .pt/.pth entries, executing arbitrary code inside Ray remote workers on every
+    worker that processes the malicious dataset.
+
+    [Exploit Maturity: LOW]
+
+    - Low exploit maturity: no known public PoC or active exploitation
+
+    Note: Affected versions are Ray < 2.56.0. Fixed in Ray 2.56.0. The ray fingerprint
+    has matchers but no version extractor; the version condition cannot be evaluated
+    by the AIG engine at scan time. This rule alerts on all detected Ray instances
+    pending version extractor supplementation.'
+  cvss: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H
+  severity: HIGH
+  security_advise: Upgrade Ray to version 2.56.0 or later. The fix removes unconditional
+    pickle.loads() and torch.load() calls in the WebDataset decoder, replacing them
+    with safe deserialization methods. Additionally, avoid loading WebDataset archives
+    from untrusted sources and consider restricting Ray worker network access as a
+    temporary mitigation.
+rule: 'version < "2.56.0"'
+references:
+- https://github.com/ray-project/ray/pull/63469
+- https://github.com/ray-project/ray/pull/63470
+- https://github.com/ray-project/ray/releases/tag/ray-2.56.0
+- https://github.com/ray-project/ray/security/advisories/GHSA-hhrp-gw25-jr43
+- https://www.vulncheck.com/advisories/ray-unsafe-deserialization-rce-via-webdataset-reader

--- a/data/vuln_en/suna/CVE-2026-66027.yaml
+++ b/data/vuln_en/suna/CVE-2026-66027.yaml
@@ -1,0 +1,44 @@
+info:
+  name: Suna
+  author: A.I.G bot
+  cve: CVE-2026-66027
+  summary: Suna < 0.9.102 Broken Access Control via Message Queue API
+  details: |
+    Suna (Kortix) before 0.9.102 contains a broken access control vulnerability in
+    the message queue API (/v1/queue/*) that allows authenticated attackers to
+    access and manipulate queue resources belonging to other users by exploiting
+    missing ownership and account isolation checks. The queue routes apply
+    authentication (combinedAuth verifies a valid Supabase JWT or Kortix API key)
+    but the route handlers never read userId and perform no ownership check.
+
+    Attackers can:
+    - Read pending prompt queues of all users via GET /v1/queue/all
+    - Read or delete individual sessions via GET/DELETE /v1/queue/sessions/:sessionId
+    - Inject arbitrary prompts into another user's session queue via POST
+      /v1/queue/sessions/:sessionId, causing the background drainer to forward
+      malicious messages to the victim's running AI agent with the victim's
+      credentials and permissions.
+
+    The underlying filesystem-backed storage stores session queues as
+    <DATA_DIR>/queue/<sessionId>.json with no account or user field, and no
+    lookup against the project_sessions table (which records accountId) is
+    performed before any read, write, or delete.
+
+    [Exploit Maturity: LOW] - No public PoC or exploit code identified.
+  security_advise: |
+    1. Upgrade Suna to version 0.9.102 or later (commit 7536a7d47fc93abcb66e677fcc993b390c81296a)
+    2. Review and enforce ownership/account isolation checks on all /v1/queue/* endpoints
+    3. Ensure session queue storage includes account/user fields and validates access against project_sessions table
+    4. Monitor for unauthorized queue access attempts in application logs
+  cvss: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L
+  severity: HIGH
+rule: version < "0.9.102"
+references:
+  - https://github.com/geo-chen/oss/blob/main/suna.md
+  - https://github.com/kortix-ai/suna/commit/7536a7d47fc93abcb66e677fcc993b390c81296a
+  - https://github.com/kortix-ai/suna/pull/4373
+  - https://github.com/kortix-ai/suna/releases/tag/v0.9.102
+  - https://www.vulncheck.com/advisories/suna-broken-access-control-via-message-queue-api
+  - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/66xxx/CVE-2026-66027.json
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-66027
+  - https://github.com/kortix-ai/suna


### PR DESCRIPTION
## 🤖 自动生成的 AIG 规则 [2026-07-31]

本 PR 由 AIG-Bot 自动创建，包含最新漏洞检测规则（CVE + OpenClaw 安全公告）。

### 📊 统计

| 类型 | 数量 |
|------|------|
| CVE 漏洞规则 (EN + CN) | 17 条 |
| OpenClaw 安全公告 (EN) | 0 条 |
| OpenClaw 安全公告 (ZH) | 0 条 |
| 指纹规则 | 3 条 |

### 📋 新增 CVE 漏洞规则

- `CVE-2026-13442` (langflow)
- `CVE-2026-17529` (astrbot)
- `CVE-2026-17530` (astrbot)
- `CVE-2026-18266` (dify)
- `CVE-2026-46701` (network-ai)
- `CVE-2026-57516` (ray)
- `CVE-2026-59212` (openwebui)
- `CVE-2026-59214` (openwebui)
- `CVE-2026-59215` (openwebui)
- `CVE-2026-59216` (openwebui)
- `CVE-2026-59217` (openwebui)
- `CVE-2026-59221` (openwebui)
- `CVE-2026-59224` (openwebui)
- `CVE-2026-65315` (ollama)
- `CVE-2026-66027` (suna)
- `CVE-2026-67425` (LiteLLM)
- `CVE-2026-67428` (LiteLLM)

### 📢 新增 OpenClaw 安全公告

（无）

### 🔍 新增指纹规则

- `flyto2.yaml`
- `network-ai.yaml`
- `suna.yaml`

---
*由 AIG-Bot 自动生成，请人工审核后合并。*
