### PR TITLE
feat: add GET-only fingerprints for Qdrant, Chroma, and Weaviate

### DIFF
--- a/data/fingerprints/chroma.yaml
+++ b/data/fingerprints/chroma.yaml
@@ -1,0 +1,30 @@
+info:
+  name: chroma
+  author: unauth.dev
+  severity: info
+  desc: Chroma is an open-source embedding database for building AI applications with retrieval.
+  metadata:
+    product: chroma
+    vendor: chromadb
+http:
+  - method: GET
+    path: '/api/v2/heartbeat'
+    matchers:
+      - body="nanosecond heartbeat"
+  - method: GET
+    path: '/api/v1/heartbeat'
+    matchers:
+      - body="nanosecond heartbeat"
+version:
+  - method: GET
+    path: '/api/v2/version'
+    extractor:
+      part: body
+      group: 1
+      regex: '"(\d+\.\d+\.?\d+?)"'
+  - method: GET
+    path: '/api/v1/version'
+    extractor:
+      part: body
+      group: 1
+      regex: '"(\d+\.\d+\.?\d+?)"'

--- a/data/fingerprints/qdrant.yaml
+++ b/data/fingerprints/qdrant.yaml
@@ -1,0 +1,24 @@
+info:
+  name: qdrant
+  author: unauth.dev
+  severity: info
+  desc: Qdrant is an open-source vector database and similarity search engine for embedding-based AI applications.
+  metadata:
+    product: qdrant
+    vendor: qdrant
+http:
+  - method: GET
+    path: '/'
+    matchers:
+      - body="qdrant - vector search engine"
+  - method: GET
+    path: '/collections'
+    matchers:
+      - body="\"result\"" && body="\"collections\"" && body="\"status\":\"ok\""
+version:
+  - method: GET
+    path: '/'
+    extractor:
+      part: body
+      group: 1
+      regex: '"version":"(\d+\.\d+\.?\d+?)"'

--- a/data/fingerprints/weaviate.yaml
+++ b/data/fingerprints/weaviate.yaml
@@ -1,0 +1,20 @@
+info:
+  name: weaviate
+  author: unauth.dev
+  severity: info
+  desc: Weaviate is an open-source vector database with semantic search and generative AI modules.
+  metadata:
+    product: weaviate
+    vendor: weaviate
+http:
+  - method: GET
+    path: '/v1/meta'
+    matchers:
+      - body="\"hostname\"" && body="\"version\"" && body="\"modules\""
+version:
+  - method: GET
+    path: '/v1/meta'
+    extractor:
+      part: body
+      group: 1
+      regex: '"version":"(\d+\.\d+\.?\d+?)"'


### PR DESCRIPTION
### What

Three new fingerprints in `data/fingerprints/`, one YAML each, in the existing schema. All detection is a single read-only GET per block — no writes, no auth attempts, no exploit strings.

- `qdrant.yaml` — matches the service banner at `GET /` (`qdrant - vector search engine`) and the open data plane at `GET /collections` (`result`/`collections`/`status:"ok"` envelope). Version extracted from the banner.
- `chroma.yaml` — matches the heartbeat at `GET /api/v2/heartbeat` (and `/api/v1/heartbeat` for older releases): `{"nanosecond heartbeat": ...}`. Version extracted from `GET /api/v2/version` (falls back to `/api/v1/version`), which returns a bare JSON string on the current release.
- `weaviate.yaml` — matches `GET /v1/meta` on its `hostname` + `version` + `modules` keys. Version extracted from the same payload.

### Why

These three vector databases are among the most-common exposed AI-infrastructure services, and `data/fingerprints/` has no coverage for any of them (checked against `main`, 2026-08-01). They ship without authentication by default, and open instances are easy to find in the wild: the Ollama-scale problem is 175,108 reachable hosts (SentinelLABS × Censys, Jan 2026), and open Qdrant instances answering `GET /collections` with 200 — no API key — are a routine finding in exposure scans. The fingerprint for each service is the same GET an unauthenticated attacker would use to confirm the data plane is open.

### Validation

Validated against live local instances, default ports, no authentication (the exposure state being fingerprinted). Each fingerprint fired on its own service and did **not** fire on the other two, on a bare `nginx:alpine`, or on `ollama/ollama` (an existing fingerprinted service). All requests/responses below are verbatim (bodies trimmed where long).

| Fingerprint | Image (tag @ digest) | Request | Response (trimmed) | Matcher that fired | Extracted version |
|---|---|---|---|---|---|
| qdrant | `qdrant/qdrant:latest` @ `sha256:0bd98fa7…` (1.18.3) | `GET /` | `200 {"title":"qdrant - vector search engine","version":"1.18.3","commit":"db8fa43f…"}` | `body="qdrant - vector search engine"` | `1.18.3` |
| qdrant | same | `GET /collections` | `200 {"result":{"collections":[]},"status":"ok","time":2.291e-6}` | `body="\"result\"" && body="\"collections\"" && body="\"status\":\"ok\""` | — |
| chroma | `chromadb/chroma:latest` @ `sha256:1e0b73a1…` (1.0.0) | `GET /api/v2/heartbeat` | `200 {"nanosecond heartbeat":1785595580662704954}` | `body="nanosecond heartbeat"` | — |
| chroma | same | `GET /api/v2/version` | `200 "1.0.0"` | (version block) | `1.0.0` |
| weaviate | `semitechnologies/weaviate:latest` @ `sha256:84e00a8e…` (1.38.8) | `GET /v1/meta` | `200 {"grpcMaxMessageSize":104858000,"hostname":"http://[::]:8080","modules":{…42 modules…},"version":"1.38.8"}` | `body="\"hostname\"" && body="\"version\"" && body="\"modules\""` | `1.38.8` |

Negatives (each fingerprint vs. the other two fixtures, `nginx:alpine`, `ollama/ollama:latest`): 12/12 no match. Notes from the fixtures:

- Chroma 1.0.0 answers `/api/v1/heartbeat` with `410 Gone`; the v1 blocks are retained for older releases still common in the wild and never fire on the current release.
- Weaviate's `hostname` value is deployment-dependent (`http://[::]:8080` in the container) — the matcher keys on JSON structure, not the hostname value.

### Methodology note

These fingerprints come out of unauth.dev's exposure-tracking work on self-hosted AI infrastructure. Coverage gaps in shared fingerprint data hurt everyone grading this space, so they're contributed back here.

### License

This contribution is Apache-2.0, matching the project license.
