### PR TITLE
fix(data): correct CVE-2026-61428 version rule to version < "4.6.78"

### DIFF
--- a/data/vuln/ai-agent-config/CVE-2026-61428.yaml
+++ b/data/vuln/ai-agent-config/CVE-2026-61428.yaml
@@ -15,5 +15,5 @@ info:
   - https://www.vulncheck.com/advisories/praisonai-agentmail-before-message-injection-via-webhook
   - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/61xxx/CVE-2026-61428.json
   - https://nvd.nist.gov/vuln/detail/CVE-2026-61428
-rule: version >= "0"
+rule: version < "4.6.78"
 references: null

--- a/data/vuln_en/ai-agent-config/CVE-2026-61428.yaml
+++ b/data/vuln_en/ai-agent-config/CVE-2026-61428.yaml
@@ -16,5 +16,5 @@ info:
   - https://www.vulncheck.com/advisories/praisonai-agentmail-before-message-injection-via-webhook
   - https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/61xxx/CVE-2026-61428.json
   - https://nvd.nist.gov/vuln/detail/CVE-2026-61428
-rule: version >= "0"
+rule: version < "4.6.78"
 references: null


### PR DESCRIPTION
## Summary

Fixes #519 — the rule for CVE-2026-61428 (`data/vuln/ai-agent-config/CVE-2026-61428.yaml`) previously used `rule: version >= "0"`, which matches **every** detected version and therefore flags all PraisonAI AgentMail instances as vulnerable regardless of version.

Correct semantics per the advisory (affected: versions before 4.6.78): `rule: version < "4.6.78"`.

## Changes
- `data/vuln/ai-agent-config/CVE-2026-61428.yaml`: rule corrected
- `data/vuln_en/ai-agent-config/CVE-2026-61428.yaml`: rule corrected (EN mirror)

Closes #519