### PR TITLE
fix: correct streamable_http_client import name in mcp_tools.py

### DIFF
--- a/agent-scan/agent_scan/utils/mcp_tools.py
+++ b/agent-scan/agent_scan/utils/mcp_tools.py
@@ -24,7 +24,7 @@ from contextlib import asynccontextmanager
 
 from mcp import ClientSession
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 class MCPTools:
@@ -54,7 +54,7 @@ class MCPTools:
         if self.transport == "sse":
             ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
         elif self.transport == "streamable-http":
-            ctx = streamablehttp_client(url=self.url, headers=self.headers)  # type: ignore
+            ctx = streamable_http_client(url=self.url, headers=self.headers)  # type: ignore
         else:
             raise ValueError(f"Unsupported transport protocol: {self.transport}")
 

--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -25,7 +25,7 @@ from typing import Any, Literal
 
 from mcp import ClientSession
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 
 class MCPTools:
@@ -59,7 +59,7 @@ class MCPTools:
         if self.transport == "sse":
             ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
         elif self.transport == "streamable-http":
-            ctx = streamablehttp_client(url=self.url, headers=self.headers)  # type: ignore
+            ctx = streamable_http_client(url=self.url, headers=self.headers)  # type: ignore
         else:
             raise ValueError(f"Unsupported transport protocol: {self.transport}")
 


### PR DESCRIPTION
## Fix #522

## Problem

MCP scan fails with `ImportError: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'`:

The `mcp` library exports the function as `streamable_http_client` (with underscore), not `streamablehttp_client`.

## Fix

Corrected the import name in both modules:
- `mcp-scan/mcp_scan/utils/mcp_tools.py`
- `agent-scan/agent_scan/utils/mcp_tools.py`

Changed `streamablehttp_client` → `streamable_http_client` in both the import statement and the function call site.

## Testing

Verified