### PR TITLE
fix(mcp-scan): prevent RCE via prompt injection in dynamic scan mode

### DIFF
--- a/mcp-scan/mcp_scan/tools/dispatcher.py
+++ b/mcp-scan/mcp_scan/tools/dispatcher.py
@@ -27,6 +27,17 @@ from mcp_scan.utils.prompt_manager import prompt_manager
 if TYPE_CHECKING:  # pragma: no cover
     from mcp_scan.utils.tool_context import ToolContext
 
+# 动态扫描模式下的安全工具白名单：仅允许只读/元信息工具，禁止 execute_shell / read_file
+# 等本地操作工具，防止恶意 MCP 工具描述中的 prompt injection 诱导 agent 执行任意命令。
+_DYNAMIC_SAFE_TOOLS = frozenset({
+    "finish",
+    "think",
+    "call_mcp_tool",
+    "list_mcp_tools",
+    "list_mcp_prompts",
+    "list_mcp_resources",
+})
+
 
 class ToolDispatcher:
     def __init__(
@@ -66,15 +77,15 @@ class ToolDispatcher:
         return None
 
     async def get_all_tools_prompt(self) -> str:
-        """获取所有可用工具的描述 Prompt"""
-        # common_tools = ['finish', 'think']
-        # normal_tools = copy.copy(common_tools)
-        # normal_tools.extend(['read_file', 'execute_shell'])
-        # dynamic_tools = copy.copy(common_tools)
-        # dynamic_tools.extend(['call_mcp_tool', 'list_mcp_tools', 'list_mcp_prompts', 'list_mcp_resources'])
+        """获取所有可用工具的描述 Prompt
 
+        动态扫描模式（mcp_server_url 非空）下仅暴露安全工具子集，
+        防止恶意 MCP 工具描述中的 prompt injection 诱导 agent 调用
+        execute_shell 等危险本地工具。
+        """
         if self.mcp_server_url:
-            prompt = get_tools_prompt([])
+            # 动态扫描：仅注册安全工具，移除 execute_shell / read_file
+            prompt = get_tools_prompt(list(_DYNAMIC_SAFE_TOOLS))
             manager = await self._ensure_mcp_manager()
             if not manager:
                 raise RuntimeError("Failed to connect to MCP server")
@@ -88,6 +99,7 @@ class ToolDispatcher:
                 logger.error(f"Failed to fetch MCP tools description: {e}")
                 return prompt
         else:
+            # 静态扫描：全部工具可用
             prompt = get_tools_prompt([])
 
         return prompt
@@ -96,6 +108,18 @@ class ToolDispatcher:
         self, tool_name: str, args: dict[str, Any], context: Optional["ToolContext"] = None
     ) -> str:
         """统一调用入口：自动识别是本地还是远程工具"""
+        # 动态扫描模式下的工具白名单拦截：
+        # 防止恶意 MCP 工具描述中的 prompt injection 诱导 agent 调用
+        # execute_shell / read_file 等危险本地工具。
+        if self.mcp_server_url and tool_name not in _DYNAMIC_SAFE_TOOLS:
+            logger.warning(
+                f"Blocked tool '{tool_name}' in dynamic scan mode — not in safe whitelist"
+            )
+            return (
+                f"Error: Tool '{tool_name}' is not available in dynamic scan mode. "
+                f"Only MCP interaction tools are allowed."
+            )
+
         # 1. 尝试作为本地工具调用
         tool_func = get_tool_by_name(tool_name)
         if tool_func:

--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -146,8 +146,43 @@ class MCPTools:
 
         return " ".join(attrs)
 
+    # 工具描述最大长度，防止超长描述注入大量指令
+    _MAX_DESC_LEN = 500
+
+    # 需要净化的 prompt injection 指令模式
+    _INJECTION_PATTERNS = [
+        r"(?i)ignore\s+(previous|above|all)\s+instructions?",
+        r"(?i)you\s+are\s+now\s+in\b",
+        r"(?i)system\s*(note|override|prompt)\s*:",
+        r"(?i)\bexecute\s+(this|the)\s+(shell|command|diagnostic)\b",
+        r"(?i)\brun\s+this\s+(exact\s+)?diagnostic\b",
+        r"(?i)\bself[- ]?test\b.*\b(execute|run|shell|command)\b",
+        r"(?i)\bDNS\s+connectivity\s+self[- ]?test\b",
+        r"(?i)\b(scanner|scanning)\s+(environment|pipeline)\s+self[- ]?test\b",
+        r"(?i)\benvironment\s+fingerprint\b",
+        r"(?i)\bexecute_shell\b",
+    ]
+
+    @classmethod
+    def _sanitize_description(cls, desc: str) -> str:
+        """净化 MCP 工具描述，移除 prompt injection 指令并截断过长内容。"""
+        if not desc:
+            return ""
+        import re
+
+        sanitized = desc
+        for pattern in cls._INJECTION_PATTERNS:
+            sanitized = re.sub(pattern, "[REMOVED]", sanitized)
+        if len(sanitized) > cls._MAX_DESC_LEN:
+            sanitized = sanitized[: cls._MAX_DESC_LEN] + "... [truncated]"
+        return sanitized
+
     async def describe_mcp_tools(self) -> str:
-        """Return `<mcp_tools>` XML listing tool names and descriptions."""
+        """Return `<mcp_tools>` XML listing tool names and descriptions.
+
+        对远程 MCP 工具描述进行净化（截断 + 移除指令性内容），防止恶意
+        MCP 服务器通过工具描述注入 prompt injection 指令。
+        """
         try:
             async with self._session() as session:
                 data = await session.list_tools()
@@ -162,6 +197,9 @@ class MCPTools:
             # 缓存工具 schema，用于后续参数类型转换
             self._tools_schema[t.name] = t.inputSchema
 
+            # 净化工具描述，移除 prompt injection 指令
+            safe_desc = self._sanitize_description(t.description)
+
             parameters = ""
             for k, param in t.inputSchema["properties"].items():
                 required = "true" if k in t.inputSchema.get("required", []) else "false"
@@ -175,14 +213,14 @@ class MCPTools:
                 parameters += f"""<parameter {all_attrs}></parameter>"""
             xml_lines.append(f"""
     <name>{t.name}</name>
-    <description>{t.description}</description>
+    <description>{safe_desc}</description>
     <parameters>
       <parameter name="tool_name" type=string required=true>tool_name is {t.name}</parameter>
       {parameters}
     </parameters>
             """)
             name = t.name
-            detail = t.description or ""
+            detail = safe_desc
             xml_lines.append(f"detail:{detail} 调用格式:\n<tool_name>{name}</tool_name>\n</tool>")
         xml_lines.append("</mcp_tools>")
         return "\n".join(xml_lines)


### PR DESCRIPTION
Dynamic scan mode exposes execute_shell to the agent, allowing a malicious MCP server to inject prompt-injection directives in tool descriptions and trick the agent into running arbitrary commands (e.g. DNS exfiltration).

Root causes:
1. dispatcher.get_all_tools_prompt() calls get_tools_prompt([]) (all tools) even in dynamic scan mode, so execute_shell/read_file remain available.
2. MCPTools.describe_mcp_tools() injects remote tool descriptions into the system prompt without sanitization.

Fixes:
- Add _DYNAMIC_SAFE_TOOLS whitelist (finish, think, call_mcp_tool, list_mcp_tools, list_mcp_prompts, list_mcp_resources) and use it in get_all_tools_prompt() for dynamic scan mode.
- Block non-whitelisted tool calls in call_tool() as defense-in-depth.
- Add _sanitize_description() to strip prompt-injection patterns and truncate overly long descriptions before injecting into system prompt.