### PR TITLE
fix(docker): use uv sync to install agent-scan Python deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,10 @@ COPY --from=builder /app/CHANGELOG.md .
 # 复制数据文件到容器中
 COPY --from=builder /app/data ./data
 
-# 复制agent-scan目录并安装Python依赖
+# 复制agent-scan目录并使用uv安装Python依赖
 COPY ./agent-scan /app/agent-scan
-RUN pip install --no-cache-dir -r /app/agent-scan/requirements.txt
+RUN cd /app/agent-scan \
+    && /usr/local/bin/uv sync --no-dev
 
 # 复制启动脚本到镜像中
 COPY start.sh /app/start.sh


### PR DESCRIPTION
## 背景 / Background

容器内 `agent-scan` 的 Python 依赖安装方式与运行时调用方式不一致，导致运行时 `uv` 仍会尝试重新解析并拉取依赖，在无外网访问的容器环境下失败。

## 问题 / Root Cause

原 Dockerfile 通过 `pip install --no-cache-dir -r requirements.txt` 安装 `agent-scan` 依赖，但 Go 运行时实际通过 `/usr/local/bin/uv run test_client_connect.py` 调用该脚本（见 `common/websocket/knowledge2_api.go`）。

`uv run` 依赖 uv 自管理的项目环境（由 `pyproject.toml` + `uv.lock` 解析得到）。`pip install` 安装到的是解释器 site-packages，并不在 uv 的项目环境内，因此运行时 `uv` 视依赖为未安装，再次尝试解析并向网络拉取，在隔离容器中失败或产生非预期行为。

## 修改 / Changes

将构建期依赖安装由 `pip install -r requirements.txt` 改为：

```dockerfile
RUN cd /app/agent-scan \
    && /usr/local/bin/uv sync --no-dev
```

- 使用 `uv sync --no-dev` 将依赖解析进 uv 管理的虚拟环境，与运行时 `uv run` 复用同一套环境，避免运行时重新拉取依赖。
- `--no-dev` 排除 `pytest`/`ruff` 等开发依赖，保持运行时镜像精简。

## 影响 / Impact

- 修复容器内 `test_client_connect.py` 调用链路在无外网环境下因依赖未被 `uv` 识别而失败的问题。
- 不改变运行时对外行为，不影响扫描规则、API 结构与数据文件。
