### PR TITLE
fix: use commonpath for path containment in file tools

### DIFF
--- a/mcp-scan/mcp_scan/tools/file/write_file.py
+++ b/mcp-scan/mcp_scan/tools/file/write_file.py
@@ -36,8 +36,9 @@ def write_file(file_path: str, content: str, context: ToolContext = None) -> dic
     """
     try:
         # 创建目录（如果不存在）
-        directory = os.path.dirname(file_path)
-        if not directory.startswith(context.folder):
+        directory = os.path.realpath(os.path.dirname(file_path))
+        folder = os.path.realpath(context.folder)
+        if os.path.commonpath([directory, folder]) != folder:
             return {"success": False, "message": f"Path is not allowed: {file_path}"}
         if directory and not os.path.exists(directory):
             os.makedirs(directory, exist_ok=True)

--- a/skill-scan/skill_scan/tools/dir/dir_actions.py
+++ b/skill-scan/skill_scan/tools/dir/dir_actions.py
@@ -55,7 +55,7 @@ def dir_tree(path: str, max_depth: int = 4, context: ToolContext = None) -> dict
         abs_path = os.path.realpath(path)
         if context and context.folder:
             folder = os.path.realpath(context.folder)
-            if not abs_path.startswith(folder):
+            if os.path.commonpath([abs_path, folder]) != folder:
                 return {
                     'success': False,
                     'message': f'Path is not allowed: {path}',

--- a/skill-scan/skill_scan/tools/file/write_file.py
+++ b/skill-scan/skill_scan/tools/file/write_file.py
@@ -19,8 +19,9 @@ def write_file(file_path: str, content: str, context: ToolContext = None) -> dic
     """
     try:
         # Create the directory if it does not exist
-        directory = os.path.dirname(file_path)
-        if not directory.startswith(context.folder):
+        directory = os.path.realpath(os.path.dirname(file_path))
+        folder = os.path.realpath(context.folder)
+        if os.path.commonpath([directory, folder]) != folder:
             return {
                 "success": False,
                 "message": f"Path is not allowed: {file_path}"

--- a/skill-scan/skill_scan/tools/grep/grep_actions.py
+++ b/skill-scan/skill_scan/tools/grep/grep_actions.py
@@ -35,7 +35,7 @@ def grep(
         abs_path = os.path.realpath(path)
         if context and context.folder:
             folder = os.path.realpath(context.folder)
-            if not abs_path.startswith(folder):
+            if os.path.commonpath([abs_path, folder]) != folder:
                 return {
                     'success': False,
                     'message': f'Path is not allowed: {path}',


### PR DESCRIPTION
## Summary

Fixes #538: the LLM agent's file tools verified path containment with `str.startswith(base_dir)`, which accepts sibling-directory prefixes. With a skill directory of `/tmp/scan/skill`, the path `/tmp/scan/skill-evil/secrets.txt` passed the check, letting a prompt-injected SKILL.md read or write files outside the intended sandbox.

## Changes

Replaced the prefix check with the `os.path.commonpath([realpath(path), realpath(folder)]) == folder` comparison already used by `read_file.py` and `ls_actions.py`:

- `skill-scan/skill_scan/tools/dir/dir_actions.py` (dir_tree)
- `skill-scan/skill_scan/tools/grep/grep_actions.py` (grep)
- `skill-scan/skill_scan/tools/file/write_file.py` (write_file, now also realpaths the target directory before both the check and the write)
- `mcp-scan/mcp_scan/tools/file/write_file.py` (same broken pattern as skill-scan's write_file)

## Verification

Smoke-tested against a sibling-prefix directory with a fake ToolContext: sibling writes/listing/grep are all rejected with "Path is not allowed", while paths inside the skill folder succeed.

```
write sibling-evil -> False   (Path is not allowed)
write inside       -> True
dir_tree sibling-evil -> False
grep sibling-evil -> False
```

All four changed files compile cleanly.
