### PR TITLE
fix(mcp-scan): surface the underlying error when MCP connection fails

### DIFF
--- a/mcp-scan/mcp_scan/tools/dispatcher.py
+++ b/mcp-scan/mcp_scan/tools/dispatcher.py
@@ -50,6 +50,7 @@ class ToolDispatcher:
         self.mcp_tools_manager: MCPTools | None = None
         self.mcp_transport = None
         self.mcp_headers = mcp_headers
+        self.last_connect_error: Exception | None = None
 
     async def _ensure_mcp_manager(self) -> MCPTools | None:
         if not self.mcp_server_url:
@@ -57,6 +58,7 @@ class ToolDispatcher:
         if self.mcp_tools_manager:
             return self.mcp_tools_manager
 
+        self.last_connect_error = None
         transports = [self.mcp_transport] if self.mcp_transport else ["streamable-http", "sse"]
         for transport in transports:
             if not transport:
@@ -71,12 +73,16 @@ class ToolDispatcher:
                 )
                 return self.mcp_tools_manager
             except Exception as e:
+                self.last_connect_error = e
                 logger.warning(
                     f"ToolDispatcher: transport '{transport}' failed for {self.mcp_server_url}: {type(e).__name__}: {e}"
                 )
                 continue
 
-        logger.error(f"ToolDispatcher: Failed to connect to MCP server: {self.mcp_server_url}")
+        logger.error(
+            f"ToolDispatcher: Failed to connect to MCP server: {self.mcp_server_url} "
+            f"(tried transports: {transports}); last error: {self.last_connect_error}"
+        )
         return None
 
     async def get_all_tools_prompt(self) -> str:
@@ -91,7 +97,8 @@ class ToolDispatcher:
             prompt = get_tools_prompt(list(_DYNAMIC_SAFE_TOOLS))
             manager = await self._ensure_mcp_manager()
             if not manager:
-                raise RuntimeError("Failed to connect to MCP server")
+                detail = f": {self.last_connect_error}" if self.last_connect_error else ""
+                raise RuntimeError(f"Failed to connect to MCP server{detail}")
             try:
                 mcp_prompt = await manager.describe_mcp_tools()
                 mcp_remote_prompt = prompt_manager.format_prompt(

--- a/mcp-scan/pytests/test_dispatcher.py
+++ b/mcp-scan/pytests/test_dispatcher.py
@@ -1,0 +1,44 @@
+import pytest
+
+from mcp_scan.tools.dispatcher import ToolDispatcher
+
+
+@pytest.mark.asyncio
+async def test_ensure_mcp_manager_records_underlying_connection_error(monkeypatch):
+    """When every transport attempt fails, retain the underlying error."""
+
+    async def fake_describe_mcp_tools(self):
+        raise RuntimeError(
+            "Failed to fetch MCP tools: ConnectionRefusedError: "
+            "[Errno 111] Connection refused"
+        )
+
+    monkeypatch.setattr(
+        "mcp_scan.tools.dispatcher.MCPTools.describe_mcp_tools", fake_describe_mcp_tools
+    )
+
+    dispatcher = ToolDispatcher(mcp_server_url="http://example.invalid/mcp")
+    manager = await dispatcher._ensure_mcp_manager()
+
+    assert manager is None
+    assert dispatcher.last_connect_error is not None
+    assert "ConnectionRefusedError" in str(dispatcher.last_connect_error)
+
+
+@pytest.mark.asyncio
+async def test_get_all_tools_prompt_raises_with_underlying_error_detail(monkeypatch):
+    """Expose the underlying connection failure detail to callers."""
+
+    async def fake_describe_mcp_tools(self):
+        raise RuntimeError(
+            "Failed to fetch MCP tools: ConnectionRefusedError: "
+            "[Errno 111] Connection refused"
+        )
+
+    monkeypatch.setattr(
+        "mcp_scan.tools.dispatcher.MCPTools.describe_mcp_tools", fake_describe_mcp_tools
+    )
+
+    dispatcher = ToolDispatcher(mcp_server_url="http://example.invalid/mcp")
+    with pytest.raises(RuntimeError, match="ConnectionRefusedError"):
+        await dispatcher.get_all_tools_prompt()


### PR DESCRIPTION
## Summary of Changes

`ToolDispatcher._ensure_mcp_manager()` (`mcp-scan/mcp_scan/tools/dispatcher.py`) now records the last exception seen across its per-transport connection attempts (`self.last_connect_error`) instead of discarding it, and includes that detail both in the error log and in the `RuntimeError` raised by `get_all_tools_prompt()` when every transport fails. No public method signatures change.

## Root Cause Analysis

`_ensure_mcp_manager()` tries `"streamable-http"` then `"sse"` and wraps each attempt in `try/except Exception: continue`, discarding the exception entirely. If both fail, it only logs a generic `"Failed to connect to MCP server: <url>"` with no indication of *why*.

This is misleading because `MCPTools.describe_mcp_tools()` (`mcp-scan/mcp_scan/utils/mcp_tools.py`) already does the work of building a detailed root-cause message — it unwraps `BaseExceptionGroup`/`TaskGroup` errors via `_extract_root_cause()` and raises a `RuntimeError` like `Failed to fetch MCP tools: ConnectionRefusedError: ...`. That detail is computed and then thrown away one layer up, in the dispatcher's `except Exception: continue`.

This matches #534: the reporter's MCP server was reachable (`curl` returned 200 from inside the container) but the scan still failed with a bare "Failed to connect to MCP server", giving no way to tell whether the failure was a protocol/transport mismatch, an auth issue, a timeout, or something else in the handshake.

## Test Coverage & Verification

Added `mcp-scan/pytests/test_dispatcher.py`:
- `test_ensure_mcp_manager_records_underlying_connection_error`: monkeypatches `MCPTools.describe_mcp_tools` to fail with a distinguishable error and asserts `dispatcher.last_connect_error` captures it. Fails on the pre-fix code (`AttributeError: no attribute 'last_connect_error'`), passes after.
- `test_get_all_tools_prompt_raises_with_underlying_error_detail`: asserts the `RuntimeError` raised by `get_all_tools_prompt()` includes the underlying error text. Fails on the pre-fix code (message is just `"Failed to connect to MCP server"`), passes after.

Ran:
- `python -m pytest pytests/test_dispatcher.py -v` — 2 passed
- `python -m pytest pytests/ -v` — 9 passed (full `mcp-scan` suite, no regressions)
- `python -m ruff check mcp_scan/tools/dispatcher.py pytests/test_dispatcher.py` — all checks passed

Note: `ruff format --check` wants to reformat the entire `dispatcher.py` file, but this is pre-existing on `main` (confirmed via `git stash` before making any changes) and unrelated to this diff, so I left it as-is to keep the change isolated to the reported issue.

Closes #534