### PR TITLE
refactor(docker): embed API Checker in Agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,17 @@ trpc.log
 .DS_Store
 Thumbs.db
 
+# Python runtime artifacts
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/.venv/
+services/api_checker/log/
+services/api_checker/result/
+services/api_checker/runtime/
+services/api_checker/pamela/results/
+services/api_checker/tests/
+
 # 运行时数据目录（通过卷挂载）
 uploads/
 db/
@@ -42,6 +53,9 @@ img/
 License.txt
 !README.md
 !CHANGELOG.md
+!services/api_checker/requirements.txt
+!services/api_checker/THIRD_PARTY_NOTICES.md
+!services/api_checker/pamela/reference/README.md
 
 # GitHub Actions配置
 .github/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -149,6 +149,7 @@ jobs:
           echo "  Ref: ${{ github.ref }}"
 
       - name: 🐳 Build and push Server image
+        id: build-server
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -161,6 +162,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: 🤖 Build and push Agent image
+        id: build-agent
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ ENV UPLOAD_DIR=/app/uploads
 ENV DB_PATH=/app/db/tasks.db
 ENV TZ=Asia/Shanghai
 ENV PYTHONUNBUFFERED=1
+ENV AIG_API_CHECKER_URL=http://agent:8000
 
 # 暴露端口
 EXPOSE 8088
@@ -100,4 +101,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD pgrep ai-infra-guard || exit 1
 
 # 启动命令
-CMD ["/app/start.sh"] 
+CMD ["/app/start.sh"]

--- a/Dockerfile_Agent
+++ b/Dockerfile_Agent
@@ -38,6 +38,7 @@ RUN set -eux; \
         fonts-wqy-microhei \
         fonts-wqy-zenhei \
         fontconfig \
+        gosu \
         tzdata \
         build-essential \
         vim \
@@ -64,6 +65,11 @@ COPY ./skill-scan /app/skill-scan/
 WORKDIR /app/skill-scan
 RUN uv sync
 
+COPY ./services/api_checker/requirements.txt /tmp/api-checker-requirements.txt
+RUN python -m venv /app/api-checker-venv && \
+    /app/api-checker-venv/bin/pip install --no-cache-dir \
+        -r /tmp/api-checker-requirements.txt && \
+    rm /tmp/api-checker-requirements.txt
 
 RUN set -eux; \
     apt-get purge -y --auto-remove \
@@ -72,17 +78,34 @@ RUN set -eux; \
 
 COPY --from=builder /app/agent /app/agent
 COPY --from=builder /app/data /app/data
+COPY ./services/__init__.py /app/services/__init__.py
+COPY ./services/api_checker /app/services/api_checker
+COPY ./scripts/start_agent_container.sh /app/start_agent_container.sh
 
 # Create a non-root user
 RUN useradd -m -u 1000 agent && \
-    chown -R agent:agent /app
+    mkdir -p /api-checker-data && \
+    chown -R agent:agent /app /api-checker-data && \
+    chmod 755 /app/start_agent_container.sh
 
 RUN chmod 4755 /usr/lib/chromium/chrome-sandbox || \
     chmod 4755 /usr/lib/chromium/chromium-sandbox || \
     chmod 4755 /usr/lib/chromium-browser/chrome-sandbox || \
     true
 
-# Switch to non-root user
-USER agent
+# The entrypoint fixes permissions on upgraded checker volumes, then drops to
+# the non-root agent user before starting either application process.
+WORKDIR /app
 
-ENTRYPOINT ["/app/agent"]
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    AIG_API_CHECKER_ROOT_PATH=/api-checker \
+    AIG_API_CHECKER_DATA_DIR=/api-checker-data \
+    AIG_API_CHECKER_LOG_LEVEL=INFO
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["gosu", "agent:agent", "/app/api-checker-venv/bin/python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()"]
+
+ENTRYPOINT ["/app/start_agent_container.sh"]

--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -1,6 +1,3 @@
-version: '3.8'
-
-
 services:
   webserver:
     image: zhuquelab/aig-server:latest
@@ -12,6 +9,7 @@ services:
       - UPLOAD_DIR=/app/uploads
       - DB_PATH=/app/db/tasks.db
       - TZ=Asia/Shanghai
+      - AIG_API_CHECKER_URL=http://agent:8000
     volumes:
       - ./data:/app/data
       - ./db:/app/db
@@ -19,31 +17,55 @@ services:
       - ./uploads:/app/uploads
     networks:
       - ai-infra-guard-network
+    depends_on:
+      agent:
+        condition: service_healthy
     restart: always
     healthcheck:
-      test: [ "CMD", "curl",  "http://localhost:8088/" ]
+      test: [ "CMD", "curl", "http://localhost:8088/" ]
       interval: 30s
       timeout: 3s
       retries: 3
   agent:
     image: zhuquelab/aig-agent:latest
     container_name: ai-infra-guard-agent
+    expose:
+      - "8000"
     environment:
       - TZ=Asia/Shanghai
       - AIG_SERVER=webserver:8088
+      - AIG_API_CHECKER_ROOT_PATH=/api-checker
+      - AIG_API_CHECKER_DATA_DIR=/api-checker-data
+      - AIG_API_CHECKER_MAX_JOBS=${AIG_API_CHECKER_MAX_JOBS:-20}
+      - AIG_API_CHECKER_ALLOW_HTTP=${AIG_API_CHECKER_ALLOW_HTTP:-0}
+      - AIG_API_CHECKER_ALLOW_PRIVATE_TARGETS=${AIG_API_CHECKER_ALLOW_PRIVATE_TARGETS:-0}
+      - AIG_API_CHECKER_CORS_ORIGINS=${AIG_API_CHECKER_CORS_ORIGINS:-}
     cap_add:
       - SYS_ADMIN
     security_opt:
       - seccomp:unconfined
     shm_size: '2gb'
+    volumes:
+      - api-checker-data:/api-checker-data
     networks:
       - ai-infra-guard-network
     restart: always
-    depends_on:
-      webserver:
-        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - gosu
+        - agent:agent
+        - /app/api-checker-venv/bin/python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()"
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 
 networks:
   ai-infra-guard-network:
     driver: bridge
     name: ai-infra-guard-network
+volumes:
+  api-checker-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: '3.8'
-
-
 services:
   webserver:
     build:
@@ -14,6 +11,7 @@ services:
       - UPLOAD_DIR=/app/uploads
       - DB_PATH=/app/db/tasks.db
       - TZ=Asia/Shanghai
+      - AIG_API_CHECKER_URL=http://agent:8000
     volumes:
       - ./data:/app/data
       - ./db:/app/db
@@ -21,9 +19,12 @@ services:
       - ./uploads:/app/uploads
     networks:
       - ai-infra-guard-network
+    depends_on:
+      agent:
+        condition: service_healthy
     restart: always
     healthcheck:
-      test: [ "CMD", "curl",  "http://localhost:8088/" ]
+      test: [ "CMD", "curl", "http://localhost:8088/" ]
       interval: 30s
       timeout: 3s
       start_period: 5s
@@ -33,21 +34,42 @@ services:
       context: .
       dockerfile: Dockerfile_Agent
     container_name: ai-infra-guard-agent
+    expose:
+      - "8000"
     environment:
       - TZ=Asia/Shanghai
       - AIG_SERVER=webserver:8088
+      - AIG_API_CHECKER_ROOT_PATH=/api-checker
+      - AIG_API_CHECKER_DATA_DIR=/api-checker-data
+      - AIG_API_CHECKER_MAX_JOBS=${AIG_API_CHECKER_MAX_JOBS:-20}
+      - AIG_API_CHECKER_ALLOW_HTTP=${AIG_API_CHECKER_ALLOW_HTTP:-0}
+      - AIG_API_CHECKER_ALLOW_PRIVATE_TARGETS=${AIG_API_CHECKER_ALLOW_PRIVATE_TARGETS:-0}
+      - AIG_API_CHECKER_CORS_ORIGINS=${AIG_API_CHECKER_CORS_ORIGINS:-}
     cap_add:
       - SYS_ADMIN
     security_opt:
       - seccomp:unconfined
     shm_size: '2gb'
+    volumes:
+      - api-checker-data:/api-checker-data
     networks:
       - ai-infra-guard-network
     restart: always
-    depends_on:
-      webserver:
-        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - gosu
+        - agent:agent
+        - /app/api-checker-venv/bin/python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()"
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 networks:
   ai-infra-guard-network:
     driver: bridge
     name: ai-infra-guard-network
+volumes:
+  api-checker-data:

--- a/scripts/start_agent_container.sh
+++ b/scripts/start_agent_container.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+set -u
+
+checker_pid=""
+agent_pid=""
+stopping=0
+
+stop_children() {
+    stopping=1
+    if [ -n "$agent_pid" ]; then
+        kill -TERM "$agent_pid" 2>/dev/null || true
+    fi
+    if [ -n "$checker_pid" ]; then
+        kill -TERM "$checker_pid" 2>/dev/null || true
+    fi
+}
+
+trap stop_children INT TERM
+
+checker_data_dir="${AIG_API_CHECKER_DATA_DIR:-/api-checker-data}"
+case "$checker_data_dir" in
+    /api-checker-data|/api-checker-data/*) ;;
+    *)
+        echo "[agent-container] AIG_API_CHECKER_DATA_DIR must be /api-checker-data or a child path" >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p "$checker_data_dir"
+chown -R agent:agent /api-checker-data
+
+echo "[agent-container] starting API Checker"
+gosu agent:agent /app/api-checker-venv/bin/python \
+    -m uvicorn services.api_checker.server:app \
+    --host 0.0.0.0 --port 8000 --no-access-log &
+checker_pid=$!
+
+while [ "$stopping" -eq 0 ] && kill -0 "$checker_pid" 2>/dev/null; do
+    if [ -z "$agent_pid" ] || ! kill -0 "$agent_pid" 2>/dev/null; then
+        if [ -n "$agent_pid" ]; then
+            wait "$agent_pid"
+            agent_status=$?
+            echo "[agent-container] Agent exited with status $agent_status; retrying" >&2
+            agent_pid=""
+            sleep 2 &
+            wait $! 2>/dev/null || true
+        fi
+        if [ "$stopping" -eq 0 ]; then
+            echo "[agent-container] starting Agent"
+            gosu agent:agent /app/agent &
+            agent_pid=$!
+        fi
+    fi
+    sleep 1 &
+    wait $! 2>/dev/null || true
+done
+
+requested_stop=$stopping
+checker_status=0
+if [ -n "$checker_pid" ]; then
+    if [ "$stopping" -eq 0 ]; then
+        wait "$checker_pid"
+        checker_status=$?
+        echo "[agent-container] API Checker exited with status $checker_status" >&2
+    else
+        wait "$checker_pid" 2>/dev/null || true
+    fi
+    checker_pid=""
+fi
+
+stop_children
+if [ -n "$agent_pid" ]; then
+    wait "$agent_pid" 2>/dev/null || true
+fi
+
+if [ "$requested_stop" -eq 1 ]; then
+    exit 0
+fi
+if [ "$checker_status" -eq 0 ]; then
+    checker_status=1
+fi
+exit "$checker_status"

--- a/services/api_checker/Dockerfile
+++ b/services/api_checker/Dockerfile
@@ -1,0 +1,33 @@
+# Development-only standalone image for debugging the Python service.
+# Production Compose and release builds embed API Checker in Dockerfile_Agent.
+FROM docker.io/library/python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    AIG_API_CHECKER_ROOT_PATH=/api-checker \
+    AIG_API_CHECKER_DATA_DIR=/data \
+    AIG_API_CHECKER_LOG_LEVEL=INFO
+
+WORKDIR /app
+
+COPY services/api_checker/requirements.txt /tmp/api-checker-requirements.txt
+RUN pip install --no-cache-dir -r /tmp/api-checker-requirements.txt \
+    && rm /tmp/api-checker-requirements.txt
+
+COPY services/__init__.py /app/services/__init__.py
+COPY services/api_checker /app/services/api_checker
+
+RUN mkdir -p /data \
+    && addgroup --system aig \
+    && adduser --system --ingroup aig --home /nonexistent --no-create-home aig \
+    && chown -R aig:aig /app /data
+
+USER aig
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()"]
+
+CMD ["python", "-m", "uvicorn", "services.api_checker.server:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]


### PR DESCRIPTION
## Scope

- embeds the API Checker runtime and source in `aig-agent`
- runs the Go Agent and Python Checker under one container entrypoint
- updates Compose so WebServer proxies to `http://agent:8000`
- persists checker data in the Agent volume and uses the Agent health check
- keeps release CI limited to the existing Server and Agent images; no separate Checker image is built or published

## Container model clarification

Production runs API Checker as part of the Agent image/container. `services/api_checker/Dockerfile` is explicitly development-only for debugging the Python service in isolation; it is not referenced by Compose or release CI.

## Split series / dependencies

Part 5 of the API Checker split. This deployment PR depends on:

- #511 for the WebServer proxy
- #554 for the Python service
- #553 for the bundled PAMELA assets

## Validation

- both Compose files pass `docker compose config --quiet`
- `scripts/start_agent_container.sh` passes `sh -n`
- workflow YAML parses successfully
- combined Agent image built successfully (40/40 steps)
- combined test container became healthy and `/healthz` returned Checker 1.7.0
- logs confirmed both Checker and Agent startup