### PR TITLE
fix(docker): restore published image compose compatibility

### DIFF
--- a/docker-compose.images.yml
+++ b/docker-compose.images.yml
@@ -1,3 +1,6 @@
+version: '3.8'
+
+
 services:
   webserver:
     image: zhuquelab/aig-server:latest
@@ -9,7 +12,6 @@ services:
       - UPLOAD_DIR=/app/uploads
       - DB_PATH=/app/db/tasks.db
       - TZ=Asia/Shanghai
-      - AIG_API_CHECKER_URL=http://agent:8000
     volumes:
       - ./data:/app/data
       - ./db:/app/db
@@ -17,55 +19,31 @@ services:
       - ./uploads:/app/uploads
     networks:
       - ai-infra-guard-network
-    depends_on:
-      agent:
-        condition: service_healthy
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:8088/" ]
+      test: [ "CMD", "curl",  "http://localhost:8088/" ]
       interval: 30s
       timeout: 3s
       retries: 3
   agent:
     image: zhuquelab/aig-agent:latest
     container_name: ai-infra-guard-agent
-    expose:
-      - "8000"
     environment:
       - TZ=Asia/Shanghai
       - AIG_SERVER=webserver:8088
-      - AIG_API_CHECKER_ROOT_PATH=/api-checker
-      - AIG_API_CHECKER_DATA_DIR=/api-checker-data
-      - AIG_API_CHECKER_MAX_JOBS=${AIG_API_CHECKER_MAX_JOBS:-20}
-      - AIG_API_CHECKER_ALLOW_HTTP=${AIG_API_CHECKER_ALLOW_HTTP:-0}
-      - AIG_API_CHECKER_ALLOW_PRIVATE_TARGETS=${AIG_API_CHECKER_ALLOW_PRIVATE_TARGETS:-0}
-      - AIG_API_CHECKER_CORS_ORIGINS=${AIG_API_CHECKER_CORS_ORIGINS:-}
     cap_add:
       - SYS_ADMIN
     security_opt:
       - seccomp:unconfined
     shm_size: '2gb'
-    volumes:
-      - api-checker-data:/api-checker-data
     networks:
       - ai-infra-guard-network
     restart: always
-    healthcheck:
-      test:
-        - CMD
-        - gosu
-        - agent:agent
-        - /app/api-checker-venv/bin/python
-        - -c
-        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3).read()"
-      interval: 30s
-      timeout: 5s
-      start_period: 10s
-      retries: 3
+    depends_on:
+      webserver:
+        condition: service_healthy
 
 networks:
   ai-infra-guard-network:
     driver: bridge
     name: ai-infra-guard-network
-volumes:
-  api-checker-data:


### PR DESCRIPTION
## 问题

#511 更新了 `docker-compose.images.yml`，为 Agent 注入了依赖 `gosu` 和 `/app/api-checker-venv/bin/python` 的 Healthcheck，并让 Webserver 等待 Agent 健康。

当前 Docker Hub `zhuquelab/aig-agent:latest` 仍是 #511 合并前发布的镜像，不包含这些文件，因此 Healthcheck 以 exit 127 失败，导致预构建镜像模式无法正常启动。

## 修改

仅将 `docker-compose.images.yml` 恢复为 #511 前的内容：

- 移除 Agent 的 Checker Healthcheck；
- 恢复原有 Webserver → Agent 启动依赖方向；
- 移除只适用于尚未发布新镜像的 Checker 配置。

不修改源码构建使用的 `docker-compose.yml`、`Dockerfile_Agent`、启动脚本或 API Checker 实现。旧发布镜像恢复正常使用；后续新镜像中的 Checker 仍由 Agent 镜像自身启动。

## 验证

- `docker compose -f docker-compose.images.yml config --quiet`
- `git diff --check`
- 实际检查 Docker Hub `aig-agent:latest`：缺少 `gosu` 和 `/app/api-checker-venv/bin/python`，原新版 Healthcheck 可复现 exit 127