### PR TITLE
fix(mcp-scan): fix streamable_http_client headers param incompatibility with MCP SDK 1.28+

### DIFF
--- a/agent-scan/agent_scan/utils/mcp_tools.py
+++ b/agent-scan/agent_scan/utils/mcp_tools.py
@@ -18,10 +18,12 @@
 
 import asyncio
 import json
+import os
 from datetime import timedelta
 from typing import Any, AsyncIterator, Dict, Literal, Optional
 from contextlib import asynccontextmanager
 
+import httpx
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
@@ -36,7 +38,7 @@ class MCPTools:
             headers = {}
         self.url = url
         self.transport = transport
-        self.timeout_seconds = 10
+        self.timeout_seconds = int(os.environ.get("MCP_TIMEOUT_SECONDS", "30"))
         self.headers = headers
         # 缓存工具 schema，用于参数类型转换
         self._tools_schema: Dict[str, Dict[str, Any]] = {}
@@ -54,7 +56,12 @@ class MCPTools:
         if self.transport == "sse":
             ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
         elif self.transport == "streamable-http":
-            ctx = streamable_http_client(url=self.url, headers=self.headers)  # type: ignore
+            # MCP SDK 1.28+ 的 streamable_http_client 不接受 headers 参数，
+            # 需要通过 http_client 参数传入带 headers 的自定义 httpx 客户端
+            http_client = httpx.AsyncClient(headers=self.headers) if self.headers else None
+            ctx = streamable_http_client(
+                url=self.url, http_client=http_client
+            )  # type: ignore
         else:
             raise ValueError(f"Unsupported transport protocol: {self.transport}")
 

--- a/mcp-scan/mcp_scan/tools/dispatcher.py
+++ b/mcp-scan/mcp_scan/tools/dispatcher.py
@@ -70,7 +70,10 @@ class ToolDispatcher:
                     f"ToolDispatcher: MCP tools manager initialized with transport: {transport}"
                 )
                 return self.mcp_tools_manager
-            except Exception:
+            except Exception as e:
+                logger.warning(
+                    f"ToolDispatcher: transport '{transport}' failed for {self.mcp_server_url}: {type(e).__name__}: {e}"
+                )
                 continue
 
         logger.error(f"ToolDispatcher: Failed to connect to MCP server: {self.mcp_server_url}")

--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -18,11 +18,13 @@
 
 import asyncio
 import json
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Any, Literal
 
+import httpx
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
@@ -41,7 +43,7 @@ class MCPTools:
             headers = {}
         self.url = url
         self.transport = transport
-        self.timeout_seconds = 10
+        self.timeout_seconds = int(os.environ.get("MCP_TIMEOUT_SECONDS", "30"))
         self.headers = headers
         # 缓存工具 schema，用于参数类型转换
         self._tools_schema: dict[str, dict[str, Any]] = {}
@@ -59,7 +61,12 @@ class MCPTools:
         if self.transport == "sse":
             ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
         elif self.transport == "streamable-http":
-            ctx = streamable_http_client(url=self.url, headers=self.headers)  # type: ignore
+            # MCP SDK 1.28+ 的 streamable_http_client 不接受 headers 参数，
+            # 需要通过 http_client 参数传入带 headers 的自定义 httpx 客户端
+            http_client = httpx.AsyncClient(headers=self.headers) if self.headers else None
+            ctx = streamable_http_client(
+                url=self.url, http_client=http_client
+            )  # type: ignore
         else:
             raise ValueError(f"Unsupported transport protocol: {self.transport}")
 


### PR DESCRIPTION
## Problem

When scanning a remote MCP server via the AIG web UI, the task fails with a generic error:

```
RuntimeError: Failed to connect to MCP server
```

This affects any MCP server using the **streamable-http** transport protocol (e.g. `https://mcp.api-inference.modelscope.net/.../mcp`).

## Root Cause

**`streamable_http_client()` does not accept a `headers` keyword argument in MCP SDK 1.28+.**

The scanner tries two transports in sequence: `streamable-http` first, then `sse` as fallback. Both fail:

1. **streamable-http transport**: `TypeError: streamable_http_client() got an unexpected keyword argument 'headers'` — the SDK signature is `(url, *, http_client, terminate_on_close)`, so passing `headers=self.headers` raises `TypeError`.
2. **sse transport**: The server returns `Content-Type: application/json` (streamable-http protocol), not `text/event-stream`, so SSE client raises an error — this is expected behavior, not a bug.

Since both transports fail, `_ensure_mcp_manager()` returns `None`, and `get_all_tools_prompt()` raises the generic `RuntimeError("Failed to connect to MCP server")`.

Worse, `dispatcher.py` swallowed the real errors with a bare `except Exception: continue`, making debugging impossible.

## Fix

| File | Change |
|------|--------|
| `mcp-scan/mcp_scan/utils/mcp_tools.py` | Inject headers via `http_client=httpx.AsyncClient(headers=...)` instead of passing `headers=` directly to `streamable_http_client()`. Also made timeout configurable via `MCP_TIMEOUT_SECONDS` env var (default 30s, was hardcoded 10s). |
| `agent-scan/agent_scan/utils/mcp_tools.py` | Same fix applied to keep the two modules in sync. |
| `mcp-scan/mcp_scan/tools/dispatcher.py` | Log per-transport failure reason (exception type + message) instead of silently swallowing errors with bare `except Exception: continue`. |

## Testing

- Verified locally: after rebuilding both `ai-infra-guard` (webserver) and `agent` binaries, MCP scan against `https://mcp.api-inference.modelscope.net/.../mcp` connects successfully.
- Docker users need to rebuild the image for the fix to take effect.