### PR TITLE
fix(agent): extract pure URL from user input for MCP remote scan

### DIFF
--- a/common/agent/mcp_task.go
+++ b/common/agent/mcp_task.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -128,7 +129,13 @@ func (m *McpTask) Execute(ctx context.Context, request TaskRequest, callbacks Ta
 			return fmt.Errorf("folder does not exist or is not a directory: %s", folder)
 		}
 	} else if transport == "url" {
-		serverUrl = params.Content
+		// Extract pure URL from user input (user may type "帮我扫描 https://..." with a prefix)
+		urlRe := regexp.MustCompile(`https?://[^\s]+`)
+		if match := urlRe.FindString(params.Content); match != "" {
+			serverUrl = match
+		} else {
+			serverUrl = params.Content
+		}
 	}
 
 	var argv []string = make([]string, 0)


### PR DESCRIPTION
## Problem

When users submit MCP remote scan tasks with natural language prefix (e.g. `帮我扫描 https://mcp.api-inference.modelscope.net/.../mcp`), the entire text including the Chinese prefix was passed directly as `--server_url` to the Python subprocess in `common/agent/mcp_task.go`:

```go
} else if transport == "url" {
    serverUrl = params.Content  // "帮我扫描 https://..." — prefix included!
}
```

This caused `httpx` to reject the connection with `UnsupportedProtocol` because the string did not start with `http://` or `https://`, resulting in `Failed to connect to MCP server`.

## Root Cause

`params.Content` contains the **full user input text**, not just the URL. When the web frontend sends a message like "帮我扫描 https://...", the agent code used it verbatim as the server URL without any extraction.

## Fix

Use a regex (`https?://[^\s]+`) to extract the pure URL from user input before passing it to `--server_url`. If no URL pattern is found, fall back to the original behavior (pass `params.Content` as-is).

```go
} else if transport == "url" {
    urlRe := regexp.MustCompile(`https?://[^\s]+`)
    if match := urlRe.FindString(params.Content); match != "" {
        serverUrl = match
    } else {
        serverUrl = params.Content
    }
}
```

## Scope

This is a **standalone robustness fix**, independent of PR #564 (`fix(mcp-scan): fix streamable_http_client headers param incompatibility`), which addresses the `Failed to connect to MCP server` root cause for properly-formatted URLs.

Both fixes are complementary:
- **PR #564** fixes the case where a correct URL is passed but the MCP SDK rejects the `headers` parameter
- **This PR** fixes the case where the URL itself is malformed due to natural language prefix

## Testing

- Verified locally: with input `帮我扫描 https://...`, the agent now correctly extracts the pure URL and passes it to the Python subprocess
- `go build ./common/agent/` passes without errors