### PR TITLE
fix(api-checker): preserve weighted audit deductions

### DIFF
--- a/services/api_checker/server.py
+++ b/services/api_checker/server.py
@@ -1136,8 +1136,12 @@ def _audit_score(audit: dict) -> float:
         0.0,
         min(100.0, 100.0 - float(risk_score)),
     )
-    # 防御内部状态不一致：只要审计结论已是风险，组件分就不能仍为满分。
-    return round(min(score, 50.0) if _audit_has_risk(audit) else score, 1)
+    # _risk_score 已包含各审计项的加权扣分。仅在上游状态不一致（已经
+    # 判定有风险但没有给出任何扣分）时使用防御性兜底，避免一个 LOW
+    # 风险项也被无条件压到 50 分。
+    if _audit_has_risk(audit) and score == 100.0:
+        score = 50.0
+    return round(score, 1)
 
 
 def _signature_score(signature: dict) -> float:

--- a/services/api_checker/tests/test_server.py
+++ b/services/api_checker/tests/test_server.py
@@ -684,6 +684,37 @@ class ServerContractTests(unittest.TestCase):
             100.0,
         )
 
+        weighted_identity_risk = {
+            "verdict": "LOW",
+            "_risk_score": 15,
+            "findings": [{
+                "probe": "identity",
+                "severity": "LOW",
+                "title": "Model identity family mismatch",
+            }],
+            "probe_results": [{
+                "name": "identity",
+                "ok": True,
+                "data": {
+                    "status": 200,
+                    "identity_text": "I am GPT-5.",
+                    "requested_families": ["anthropic"],
+                    "identity_families": ["openai"],
+                },
+            }],
+        }
+        self.assertEqual(85.0, server._audit_score(weighted_identity_risk))
+        self.assertEqual(
+            85.0,
+            server._result_score("quick", {"audit": weighted_identity_risk}),
+        )
+        self.assertEqual(
+            "risk",
+            server._overall_verdict(
+                "quick", {"audit": weighted_identity_risk}, {},
+            ),
+        )
+
         inconsistent_audit = {
             "verdict": "HIGH",
             "_risk_score": 0,


### PR DESCRIPTION
## 问题

API Checker 的黑盒审计已经为每个风险项定义了权重，但 `_audit_score` 对任何风险 finding 都额外执行 `min(score, 50)`。

因此仅有模型身份系列不匹配时：

- identity 风险权重：15
- 原始安全分：85
- 额外封顶后：50

这使 LOW 弱信号与高风险故障得到近似分数，破坏了风险权重的含义。

## 修改

- 正常情况下直接采用 `100 - _risk_score`；
- 仅当上游已经判定有风险、但 `_risk_score` 仍为 0 时，保留 50 分防御性兜底；
- 增加 identity 不匹配回归测试，确认审计分和综合分均为 85，且 overall verdict 仍为 risk。

修改后示例：

| 风险 | 扣分 | 安全分 |
|---|---:|---:|
| identity family mismatch | 15 | 85 |
| relay liveness failed | 50 | 50 |
| 风险状态与零扣分不一致 | fallback | 50 |

## 验证

- Server contract tests：48 passed
- API Checker 全量测试：102 passed
- `git diff --check`：passed