### PR TITLE
fix(promptsecurity): add missing httpx dependency causing Redteam task crash

### DIFF
--- a/AIG-PromptSecurity/pyproject.toml
+++ b/AIG-PromptSecurity/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "deepeval>=2.9.7,<3.7.6",
     "ecoji>=0.1.1",
     "grpcio>=1.67.1",
+    "httpx>=0.27.0",
     "jieba>=0.42.1",
     "loguru>=0.7.3",
     "openai>=1.76.2",

--- a/AIG-PromptSecurity/requirements.txt
+++ b/AIG-PromptSecurity/requirements.txt
@@ -2,6 +2,7 @@ aiohttp>=3.11.18
 deepeval>=2.9.7
 ecoji>=0.1.1
 grpcio>=1.67.1
+httpx>=0.27.0
 loguru>=0.7.3
 openai>=1.76.2
 pandas>=2.3.0


### PR DESCRIPTION
## Problem

All `Model-Redteam-Report` (大模型红队/越狱评测) tasks crash within 2-4 seconds with `exit status 1` before reaching any business logic.

## Root Cause

The `deepteam.metrics.is_jailbreak` module directly imports `httpx` for synchronous and async HTTP calls (`httpx.Client()`, `httpx.AsyncClient()`), but `httpx` was **not declared** in either `pyproject.toml` or `requirements.txt`.

This causes a `ModuleNotFoundError: No module named 'httpx'` during Python module import, which happens before `cli_run.py`'s main try/except block — so the exception is never caught and the process exits with code 1.

### Error trace (from Agent container)

```
File "/app/AIG-PromptSecurity/deepteam/metrics/is_jailbreak/is_jailbreak.py", line 21, in <module>
    import httpx
ModuleNotFoundError: No module named 'httpx'
```

### Why the error was hard to diagnose

The Go agent (`RunCmdWithContext`) only captures the child process exit code (`exit status 1`), not the Python traceback on stderr. So the frontend only shows `exit status 1` without the actual `ModuleNotFoundError`.

## Fix

Add `httpx>=0.27.0` to both dependency manifests:

- `AIG-PromptSecurity/pyproject.toml` (used by `uv sync` in Docker)
- `AIG-PromptSecurity/requirements.txt` (used by `pip install -r`)

## Verification

After adding `httpx` to `pyproject.toml` and running `uv sync`, the `Model-Redteam-Report` task should pass the import stage and proceed to actual evaluation logic.

## Files Changed

- `AIG-PromptSecurity/pyproject.toml`: +1 line (`httpx>=0.27.0`)
- `AIG-PromptSecurity/requirements.txt`: +1 line (`httpx>=0.27.0`)