### PR TITLE
fix(mcp): 正式适配并固定 MCP SDK 2.0

### DIFF
--- a/agent-scan/agent_scan/utils/mcp_tools.py
+++ b/agent-scan/agent_scan/utils/mcp_tools.py
@@ -25,6 +25,8 @@ from typing import Any, AsyncIterator, Dict, Literal, Optional
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+# MCP 2.0 exposes its recommended HTTP client factory from this private module.
+# requirements.txt pins 2.0.0; revisit this import when upgrading the SDK.
 from mcp.shared._httpx_utils import create_mcp_http_client
 
 

--- a/agent-scan/agent_scan/utils/mcp_tools.py
+++ b/agent-scan/agent_scan/utils/mcp_tools.py
@@ -18,13 +18,13 @@
 
 import asyncio
 import json
-from datetime import timedelta
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any, AsyncIterator, Dict, Literal, Optional
-from contextlib import asynccontextmanager
 
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 
 class MCPTools:
@@ -51,34 +51,41 @@ class MCPTools:
         if not self.url:
             raise ValueError("MCP server url is required")
 
-        if self.transport == "sse":
-            ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
-        elif self.transport == "streamable-http":
-            ctx = streamable_http_client(url=self.url, headers=self.headers)  # type: ignore
-        else:
-            raise ValueError(f"Unsupported transport protocol: {self.transport}")
+        async with AsyncExitStack() as stack:
+            if self.transport == "sse":
+                transport_ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
+            elif self.transport == "streamable-http":
+                http_client = create_mcp_http_client(headers=self.headers)
+                await stack.enter_async_context(http_client)
+                transport_ctx = streamable_http_client(
+                    url=self.url,
+                    http_client=http_client,
+                )
+            else:
+                raise ValueError(f"Unsupported transport protocol: {self.transport}")
 
-        async with ctx as session_params:  # type: ignore
+            session_params = await stack.enter_async_context(transport_ctx)
             read, write = session_params[0:2]
-            async with ClientSession(
-                    read,
-                    write,
-                    read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
-            ) as session:  # type: ignore
-                await session.initialize()
-                yield session
+            session = ClientSession(
+                read,
+                write,
+                read_timeout_seconds=float(self.timeout_seconds),
+            )
+            await stack.enter_async_context(session)
+            await session.initialize()
+            yield session
 
     def _build_parameter_attributes(self, param: Dict[str, Any]) -> str:
         """构建参数的 XML 属性字符串，包含所有 schema 信息"""
         attrs = []
-        
+
         # 基础属性：type 和 required 在调用处处理
-        
+
         # description: 描述
         if 'description' in param and param['description']:
             desc = str(param['description']).replace('"', '&quot;')
             attrs.append(f'description="{desc}"')
-        
+
         # enum: 枚举值列表
         if 'enum' in param and param['enum']:
             enum_values = param['enum']
@@ -86,7 +93,7 @@ class MCPTools:
                 enum_str = ','.join(str(v) for v in enum_values)
                 enum_str = enum_str.replace('"', '&quot;')
                 attrs.append(f'enum="{enum_str}"')
-        
+
         # default: 默认值
         if 'default' in param:
             default_val = param['default']
@@ -96,28 +103,28 @@ class MCPTools:
                 default_str = str(default_val)
             default_str = default_str.replace('"', '&quot;')
             attrs.append(f'default="{default_str}"')
-        
+
         # minimum/maximum: 数值范围
         if 'minimum' in param:
             attrs.append(f'minimum="{param["minimum"]}"')
         if 'maximum' in param:
             attrs.append(f'maximum="{param["maximum"]}"')
-        
+
         # minLength/maxLength: 字符串长度限制
         if 'minLength' in param:
             attrs.append(f'minLength="{param["minLength"]}"')
         if 'maxLength' in param:
             attrs.append(f'maxLength="{param["maxLength"]}"')
-        
+
         # pattern: 正则表达式模式
         if 'pattern' in param and param['pattern']:
             pattern_str = str(param['pattern']).replace('"', '&quot;')
             attrs.append(f'pattern="{pattern_str}"')
-        
+
         # format: 格式（如 date-time, email, uri 等）
         if 'format' in param and param['format']:
             attrs.append(f'format="{param["format"]}"')
-        
+
         # examples: 示例值
         if 'examples' in param and param['examples']:
             examples = param['examples']
@@ -125,7 +132,7 @@ class MCPTools:
                 examples_str = ','.join(str(v) for v in examples)
                 examples_str = examples_str.replace('"', '&quot;')
                 attrs.append(f'examples="{examples_str}"')
-        
+
         # items: 数组元素类型（对于 array 类型）
         if 'items' in param:
             items = param['items']
@@ -138,7 +145,7 @@ class MCPTools:
                         items_enum_str = ','.join(str(v) for v in items_enum)
                         items_enum_str = items_enum_str.replace('"', '&quot;')
                         attrs.append(f'itemsEnum="{items_enum_str}"')
-        
+
         return ' '.join(attrs)
 
     async def describe_mcp_tools(self) -> str:

--- a/agent-scan/pyproject.toml
+++ b/agent-scan/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 ]
 dependencies = [
   "loguru==0.7.3",
-  "mcp>=1.23.0",
+  "mcp>=2.0.0,<3.0.0",
   "openai==2.8.1",
   "pydantic==2.12.4",
   "python-dotenv==1.0.0",

--- a/agent-scan/pytests/test_mcp_sdk_v2.py
+++ b/agent-scan/pytests/test_mcp_sdk_v2.py
@@ -1,0 +1,80 @@
+import unittest
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+from agent_scan.utils.mcp_tools import MCPTools
+
+
+class _Context:
+    def __init__(self, value=None):
+        self.value = value
+        self.exited = False
+
+    async def __aenter__(self):
+        return self.value if self.value is not None else self
+
+    async def __aexit__(self, *_args):
+        self.exited = True
+
+
+class _Session(_Context):
+    instances = []
+
+    def __init__(self, read, write, read_timeout_seconds=None):
+        super().__init__()
+        self.read = read
+        self.write = write
+        self.read_timeout_seconds = read_timeout_seconds
+        self.initialized = False
+        self.__class__.instances.append(self)
+
+    async def initialize(self):
+        self.initialized = True
+
+
+class MCP20TransportTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        _Session.instances.clear()
+
+    async def test_streamable_http_uses_managed_mcp_client_and_float_timeout(self):
+        captured = {}
+        http_client = _Context()
+
+        def fake_create_mcp_http_client(headers=None):
+            captured["headers"] = headers
+            return http_client
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(url, *, http_client=None, terminate_on_close=True):
+            captured.update(url=url, http_client=http_client)
+            yield ("read", "write")
+
+        with (
+            patch(
+                "agent_scan.utils.mcp_tools.create_mcp_http_client",
+                fake_create_mcp_http_client,
+            ),
+            patch(
+                "agent_scan.utils.mcp_tools.streamable_http_client",
+                fake_streamable_http_client,
+            ),
+            patch("agent_scan.utils.mcp_tools.ClientSession", _Session),
+        ):
+            manager = MCPTools(
+                "https://example.test/mcp",
+                "streamable-http",
+                headers={"Authorization": "Bearer test"},
+            )
+            manager.timeout_seconds = 7
+            async with manager._session():
+                pass
+
+        self.assertEqual(captured["headers"], {"Authorization": "Bearer test"})
+        self.assertIs(captured["http_client"], http_client)
+        self.assertTrue(http_client.exited)
+        self.assertEqual(_Session.instances[0].read_timeout_seconds, 7.0)
+        self.assertTrue(_Session.instances[0].initialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent-scan/requirements.txt
+++ b/agent-scan/requirements.txt
@@ -1,5 +1,5 @@
 loguru==0.7.3
-mcp>=1.23.0
+mcp==2.0.0
 openai==2.8.1
 pydantic==2.12.4
 python-dotenv==1.0.0

--- a/mcp-scan/README.md
+++ b/mcp-scan/README.md
@@ -254,7 +254,7 @@ mcp-scan/
 │   ├── main.py            # Package entry (CLI)
 │   └── __main__.py        # python -m mcp_scan entry
 ├── main.py                 # Thin shell for AIG Go backend compatibility (uv run main.py)
-├── pyproject.toml          # Project config (version 0.2.0, Python >=3.9)
+├── pyproject.toml          # Project config (version 0.2.0, Python >=3.10)
 ├── py.typed                # PEP 561 type marker
 ├── requirements.txt        # Dependencies
 ├── env.example            # Environment variable template
@@ -315,7 +315,7 @@ If a `SKILL.md` file exists in the project root, the tool automatically triggers
 
 ## 🤝 Development
 
-It is recommended to use `uv` for local development environment management (supports Python >=3.9).
+It is recommended to use `uv` for local development environment management (supports Python >=3.10).
 To initialize the dev environment:
 
 ```bash

--- a/mcp-scan/README_zh.md
+++ b/mcp-scan/README_zh.md
@@ -254,7 +254,7 @@ mcp-scan/
 │   ├── main.py            # 包入口（CLI）
 │   └── __main__.py        # python -m mcp_scan 入口
 ├── main.py                 # AIG Go 后端兼容用的薄层入口 (uv run main.py)
-├── pyproject.toml          # 项目配置（版本 0.2.0，Python >=3.9）
+├── pyproject.toml          # 项目配置（版本 0.2.0，Python >=3.10）
 ├── py.typed                # PEP 561 类型标记
 ├── requirements.txt        # 依赖列表
 ├── env.example            # 环境变量模板
@@ -315,7 +315,7 @@ mcp-scan 支持两种扫描模式，通过 `--aig-mode` 参数切换：
 
 ## 🤝 开发指南
 
-建议使用 `uv` 管理本地开发环境（支持 Python >=3.9）。
+建议使用 `uv` 管理本地开发环境（支持 Python >=3.10）。
 初始化开发环境时，可执行：
 
 ```bash

--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -26,6 +26,8 @@ from typing import Any, Literal
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+# MCP 2.0 exposes its recommended HTTP client factory from this private module.
+# requirements.txt pins 2.0.0; revisit this import when upgrading the SDK.
 from mcp.shared._httpx_utils import create_mcp_http_client
 
 

--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -19,13 +19,13 @@
 import asyncio
 import json
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
-from datetime import timedelta
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any, Literal
 
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 
 class MCPTools:
@@ -56,22 +56,29 @@ class MCPTools:
         if not self.url:
             raise ValueError("MCP server url is required")
 
-        if self.transport == "sse":
-            ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
-        elif self.transport == "streamable-http":
-            ctx = streamable_http_client(url=self.url, headers=self.headers)  # type: ignore
-        else:
-            raise ValueError(f"Unsupported transport protocol: {self.transport}")
+        async with AsyncExitStack() as stack:
+            if self.transport == "sse":
+                transport_ctx = sse_client(url=self.url, headers=self.headers)  # type: ignore
+            elif self.transport == "streamable-http":
+                http_client = create_mcp_http_client(headers=self.headers)
+                await stack.enter_async_context(http_client)
+                transport_ctx = streamable_http_client(
+                    url=self.url,
+                    http_client=http_client,
+                )
+            else:
+                raise ValueError(f"Unsupported transport protocol: {self.transport}")
 
-        async with ctx as session_params:  # type: ignore
+            session_params = await stack.enter_async_context(transport_ctx)
             read, write = session_params[0:2]
-            async with ClientSession(
+            session = ClientSession(
                 read,
                 write,
-                read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
-            ) as session:  # type: ignore
-                await session.initialize()
-                yield session
+                read_timeout_seconds=float(self.timeout_seconds),
+            )
+            await stack.enter_async_context(session)
+            await session.initialize()
+            yield session
 
     def _build_parameter_attributes(self, param: dict[str, Any]) -> str:
         """构建参数的 XML 属性字符串，包含所有 schema 信息"""

--- a/mcp-scan/pyproject.toml
+++ b/mcp-scan/pyproject.toml
@@ -7,7 +7,7 @@ name = "aig-mcp-scan"
 version = "0.2.0"
 description = "MCP Server Security Scanning Tool - an LLM-driven autonomous agent for code audit and vulnerability detection"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [
   { name = "Tencent Zhuque Lab", email = "zhuque@tencent.com" },
@@ -33,7 +33,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -45,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "loguru==0.7.3",
-  "mcp>=1.23.0",
+  "mcp>=2.0.0,<3.0.0",
   "openai==2.8.1",
   "pydantic==2.12.4",
   "python-dotenv==1.0.0",

--- a/mcp-scan/pytests/test_mcp_sdk_v2.py
+++ b/mcp-scan/pytests/test_mcp_sdk_v2.py
@@ -1,0 +1,98 @@
+import unittest
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+from mcp_scan.utils.mcp_tools import MCPTools
+
+
+class _Context:
+    def __init__(self, value=None):
+        self.value = value
+        self.exited = False
+
+    async def __aenter__(self):
+        return self.value if self.value is not None else self
+
+    async def __aexit__(self, *_args):
+        self.exited = True
+
+
+class _Session(_Context):
+    instances = []
+
+    def __init__(self, read, write, read_timeout_seconds=None):
+        super().__init__()
+        self.read = read
+        self.write = write
+        self.read_timeout_seconds = read_timeout_seconds
+        self.initialized = False
+        self.__class__.instances.append(self)
+
+    async def initialize(self):
+        self.initialized = True
+
+
+class MCP20TransportTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        _Session.instances.clear()
+
+    async def test_streamable_http_uses_managed_mcp_client_and_float_timeout(self):
+        captured = {}
+        http_client = _Context()
+
+        def fake_create_mcp_http_client(headers=None):
+            captured["headers"] = headers
+            return http_client
+
+        @asynccontextmanager
+        async def fake_streamable_http_client(url, *, http_client=None, terminate_on_close=True):
+            captured.update(url=url, http_client=http_client)
+            yield ("read", "write")
+
+        with (
+            patch(
+                "mcp_scan.utils.mcp_tools.create_mcp_http_client",
+                fake_create_mcp_http_client,
+            ),
+            patch(
+                "mcp_scan.utils.mcp_tools.streamable_http_client",
+                fake_streamable_http_client,
+            ),
+            patch("mcp_scan.utils.mcp_tools.ClientSession", _Session),
+        ):
+            manager = MCPTools(
+                "https://example.test/mcp",
+                "streamable-http",
+                headers={"Authorization": "Bearer test"},
+            )
+            manager.timeout_seconds = 7
+            async with manager._session():
+                pass
+
+        self.assertEqual(captured["headers"], {"Authorization": "Bearer test"})
+        self.assertIs(captured["http_client"], http_client)
+        self.assertTrue(http_client.exited)
+        self.assertEqual(_Session.instances[0].read_timeout_seconds, 7.0)
+        self.assertTrue(_Session.instances[0].initialized)
+
+    async def test_sse_still_receives_headers(self):
+        captured = {}
+
+        @asynccontextmanager
+        async def fake_sse_client(url, headers=None):
+            captured.update(url=url, headers=headers)
+            yield ("read", "write")
+
+        with (
+            patch("mcp_scan.utils.mcp_tools.sse_client", fake_sse_client),
+            patch("mcp_scan.utils.mcp_tools.ClientSession", _Session),
+        ):
+            manager = MCPTools("https://example.test/sse", "sse", headers={"X-Key": "test"})
+            async with manager._session():
+                pass
+
+        self.assertEqual(captured["headers"], {"X-Key": "test"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp-scan/requirements.txt
+++ b/mcp-scan/requirements.txt
@@ -1,4 +1,4 @@
-mcp>=1.23.0
+mcp==2.0.0
 openai==2.8.1
 pydantic==2.12.4
 python-dotenv==1.0.0


### PR DESCRIPTION
## 背景

当前 `mcp-scan` 和 `agent-scan` 使用以下依赖声明：

```text
mcp>=1.23.0
```

该声明没有限制主版本。在 Python 3.12 环境中进行全新构建时，依赖解析器目前会安装 MCP SDK 2.0.0，但项目中的客户端实现仍使用 MCP 1.x 接口，包括：

- 向 `streamable_http_client()` 直接传递 `headers=`
- 向 `ClientSession` 传递 `timedelta` 类型的 `read_timeout_seconds`
- 创建自定义 HTTP Client 后未明确管理其生命周期

因此，同一份代码可能因镜像构建时间、Python 包源和 Docker 缓存状态不同而安装不同版本的 MCP SDK，产生不一致的运行结果。

## 修改内容

本 PR 将现有 MCP 客户端正式迁移至 MCP SDK 2.0：

- 在运行时 requirements 中固定 `mcp==2.0.0`
- 在 Python 包元数据中声明 `mcp>=2.0.0,<3.0.0`
- 将 `mcp-scan` 最低 Python 版本调整为 3.10
- 使用 MCP 2.0 提供的 `create_mcp_http_client(headers=...)` 创建 HTTP Client
- 通过 `streamable_http_client(http_client=...)` 注入自定义 Client
- 使用 `AsyncExitStack` 管理 HTTP Client、Transport 和 MCP Session 的生命周期
- 将 `read_timeout_seconds` 改为 MCP 2.0 要求的浮点秒数
- 同步修改 `mcp-scan` 和 `agent-scan` 中的重复客户端实现
- 增加针对 Header、SSE、timeout 类型、Session 初始化和 Client 关闭的回归测试

## 与 #564 的关系

#564 已经定位并修复 MCP SDK 1.28+ 中 `streamable_http_client()` 不再接受 `headers=` 的直接问题。

本 PR 在该问题基础上进一步处理当前依赖解析可能直接安装 MCP 2.0.0 的情况，并使用 MCP 2.0 提供的 HTTP Client 工厂、timeout 类型和生命周期管理方式完成正式迁移。

## 影响范围

本 PR 只升级现有 MCP 客户端实现，不改变：

- Go 任务接口
- Web 前端行为
- LLM 扫描流程
- MCP 工具调用逻辑
- inventory/active 测量语义
- 扫描结果数据结构

## 验证结果

- 在全新 Python 3.12 环境中安装两套 requirements，确认解析结果为 `mcp==2.0.0`
- `uv pip check`：所有已安装依赖兼容
- `mcp-scan` 测试：9 项通过
- `agent-scan` 测试：2 项通过
- 两套 Python 包编译检查通过
- 相关文件 Ruff import 和未定义名称检查通过
- `git diff --check` 通过

## 关联问题

- #534
- #564
