### PR TITLE
fix(skill-scan): strip lone surrogates to prevent JSON serialization crash

### DIFF
--- a/skill-scan/skill_scan/tools/dispatcher.py
+++ b/skill-scan/skill_scan/tools/dispatcher.py
@@ -73,8 +73,22 @@ class ToolDispatcher:
                     ret += f"<{k}>\n{items}\n</{k}>\n"
                 else:
                     ret += f"<{k}>{v}</{k}>\n"
-            return ret
-        return str(result)
+            return self._strip_surrogates(ret)
+        return self._strip_surrogates(str(result))
+
+    @staticmethod
+    def _strip_surrogates(s: str) -> str:
+        """Remove lone surrogate characters that arise from non-UTF-8 filenames.
+
+        Python's os.walk()/os.listdir() decodes filenames using 'surrogateescape'
+        error handler, producing lone surrogates (\\udc00-\\udfff) for bytes that
+        are not valid UTF-8. These would crash JSON serialization downstream and
+        pollute the LLM context, so we replace them with '?' here.
+        """
+        try:
+            return s.encode('utf-8', 'replace').decode('utf-8')
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            return s.encode('utf-8', 'ignore').decode('utf-8')
 
     async def close(self):
         pass

--- a/skill-scan/skill_scan/utils/aig_logger.py
+++ b/skill-scan/skill_scan/utils/aig_logger.py
@@ -87,7 +87,23 @@ class McpLogger:
         if isinstance(content, BaseModel):
             content.timestamp = str(time.time())
             content = content.model_dump()
+        # Strip lone surrogate characters (\udc00-\udfff) that can appear when
+        # reading filenames with non-UTF-8 bytes from the OS (surrogateescape).
+        # Without this, pydantic's model_dump_json() raises UnicodeEncodeError
+        # because UTF-8 does not allow surrogates.
+        content = self._strip_surrogates(content)
         self.logger.info(AgentMsg(type=type, content=content).model_dump_json())
+
+    @staticmethod
+    def _strip_surrogates(obj):
+        """Recursively remove lone surrogate characters from strings in obj."""
+        if isinstance(obj, str):
+            return obj.encode('utf-8', 'replace').decode('utf-8')
+        if isinstance(obj, dict):
+            return {k: McpLogger._strip_surrogates(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [McpLogger._strip_surrogates(i) for i in obj]
+        return obj
 
     def new_plan_step(self, stepId: str, stepName: str):
         self._log("newPlanStep", newPlanStep(stepId=stepId, title=stepName))


### PR DESCRIPTION
## Problem

Scanning a repo with non-UTF-8 filenames causes the entire scan to crash with:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udcbc' in position 165: surrogates not allowed
```

**Call stack:**
```
base_agent.py:265  mcpLogger.action_log(tool_id, tool_name, self.step_id, f"```\n{result_message}\n```")
aig_logger.py:90   self.logger.info(AgentMsg(...).model_dump_json())
pydantic           → UnicodeEncodeError
```

## Root Cause

Python 3 decodes filenames from the OS using the `surrogateescape` error handler. When a repo contains files whose names have non-UTF-8 bytes (e.g. GBK/Latin-1 encoded names, or corrupted bytes), those bytes become lone surrogate characters (`\udc00`–`\udfff`).

These surrogates flow through:
1. `os.walk()`/`os.listdir()` → filenames with `\udcXX`
2. `grep`/`ls`/`dir_tree` tool results include those filenames
3. `dispatcher._format_result()` → `result_message` string
4. `base_agent.process_tool_call()` → `mcpLogger.action_log(log=result_message)`
5. `aig_logger._log()` → `AgentMsg.model_dump_json()` → **crash**

Pydantic's JSON serializer uses UTF-8 under the hood, and the UTF-8 standard does not allow lone surrogate code points, so it raises `UnicodeEncodeError`.

Note: `read_file` doesn't trigger this because it opens with `encoding='utf-8'` (no `errors` param), which raises `UnicodeDecodeError` on bad bytes and is caught. The issue is specifically with filenames from OS-level directory traversal.

## Fix

Two-layer defense:

### Layer 1: `dispatcher.py` — `_format_result()`
Strip surrogates from tool results **before** they enter the LLM conversation history. This prevents:
- Surrogates polluting the LLM context (could cause issues on the LLM side too)
- Surrogates propagating through the entire agent loop

### Layer 2: `aig_logger.py` — `_log()`
Strip surrogates from log content right before pydantic serialization. This is the last-resort safety net that covers **all** structured log types (`actionLog`, `statusUpdate`, `toolUsed`, `errorLog`, etc.), not just tool results.

Both layers use `encode('utf-8', 'replace').decode('utf-8')` to replace surrogates with `?`, preserving log readability while guaranteeing serialization never crashes.

## Testing

Verified with a standalone test simulating the exact error scenario:
- `\udcbc` and `\udc80` surrogates → correctly replaced with `?`
- JSON serialization succeeds (previously crashed)
- Recursive cleaning works on nested dict/list structures
- Surrogate at position 165 (matching the original error) → handled correctly

## Files Changed

- `skill-scan/skill_scan/utils/aig_logger.py`: Add `_strip_surrogates()` static method, call it in `_log()` before `model_dump_json()`
- `skill-scan/skill_scan/tools/dispatcher.py`: Add `_strip_surrogates()` static method, call it in `_format_result()` on all return paths