### PR TITLE
fix(agent-scan): quote YAML frontmatter description to prevent parse error

### DIFF
--- a/agent-scan/agent_scan/prompt/skills/agentic-supply-chain-detection/SKILL.md
+++ b/agent-scan/agent_scan/prompt/skills/agentic-supply-chain-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-supply-chain-detection
-description: Detect agentic supply-chain risks: compromised dependencies, malicious plugins/tools/models, and untrusted update sources.
+description: "Detect agentic supply-chain risks: compromised dependencies, malicious plugins/tools/models, and untrusted update sources."
 allowed-tools: dialogue
 ---
 


### PR DESCRIPTION
## Problem

Running Agent Scan with the `agentic-supply-chain-detection` skill produces a YAML frontmatter parse error:

```
Error in user YAML: (<unknown>): mapping values are not allowed in this context at line 2 column 47
```

As a result, the skill file fails to load and the agent cannot obtain the skill content, falling back to a degraded mode.

## Root Cause

The `description` field in `agent-scan/agent_scan/prompt/skills/agentic-supply-chain-detection/SKILL.md` contains a bare colon:

```yaml
description: Detect agentic supply-chain risks: compromised dependencies, malicious plugins/tools/models, and untrusted update sources.
```

YAML parsers interpret the second colon (`risks:`) as a nested mapping indicator, triggering the "mapping values are not allowed in this context" error.

## Fix

Wrap the `description` value in double quotes so the colon is treated as part of the string:

```yaml
description: "Detect agentic supply-chain risks: compromised dependencies, malicious plugins/tools/models, and untrusted update sources."
```

## Verification

Validated all 15 SKILL.md files under `agent-scan/agent_scan/prompt/skills/` with `yaml.safe_load` — all pass after the fix.

## Scope

Single-line change, one file only.