### PR TITLE
Fix formatting of description in SKILL.md

### DIFF
--- a/agent-scan/agent_scan/prompt/skills/agentic-supply-chain-detection/SKILL.md
+++ b/agent-scan/agent_scan/prompt/skills/agentic-supply-chain-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-supply-chain-detection
-description: Detect agentic supply-chain risks: compromised dependencies, malicious plugins/tools/models, and untrusted update sources.
+description: "Detect agentic supply-chain risks: compromised dependencies, malicious plugins/tools/models, and untrusted update sources."
 allowed-tools: dialogue
 ---
 


### PR DESCRIPTION
## Summary

Fixes the invalid YAML frontmatter in
`agent_scan/prompt/skills/agentic-supply-chain-detection/SKILL.md`.

The `description` field contained an unquoted colon, causing YAML
parsing to fail.

## Changes

- Quote the `description` value in the YAML frontmatter.
- No other behavior or skill content was changed.

## Related Issue

Closes #577