### PR TITLE
fix(parser): keep pre-release versions below their release in versionCheck

### DIFF
--- a/common/fingerprints/parser/synax.go
+++ b/common/fingerprints/parser/synax.go
@@ -282,6 +282,9 @@ func (r *Rule) Eval(config *Config) bool {
 	return evalExpr(r.root, config)
 }
 
+// preReleaseSuffixRe 匹配夹在两个数字之间的字母段，例如 "3.11.0rc2" 中的 "rc"。
+var preReleaseSuffixRe = regexp.MustCompile(`([0-9])[A-Za-z]+([0-9])`)
+
 // versionCheck 版本号格式标准化处理
 // 输入版本号字符串，返回处理后的版本号字符串
 // 去除版本号中的字母并进行格式统一化
@@ -293,7 +296,10 @@ func versionCheck(version string) string {
 	// 正则替换所有单词
 	compile := regexp.MustCompile(`[A-Za-z]+`)
 	if compile.MatchString(version) {
-		newVersion := regexp.MustCompile(`\.[A-Za-z]+`).ReplaceAllString(version, ".0")
+		// 字母位于两个数字之间时（如 PEP 440 的 "3.11.0rc2"）先改写为预发布号，
+		// 否则直接删除字母会把两侧数字粘连成 "3.11.02"，即 3.11.2。
+		newVersion := preReleaseSuffixRe.ReplaceAllString(version, "$1-$2")
+		newVersion = regexp.MustCompile(`\.[A-Za-z]+`).ReplaceAllString(newVersion, ".0")
 		newVersion = compile.ReplaceAllString(newVersion, "")
 		//gologger.Debugf("version:%s=>%s", version, newVersion)
 		version = newVersion

--- a/common/fingerprints/parser/synax_test.go
+++ b/common/fingerprints/parser/synax_test.go
@@ -150,3 +150,61 @@ func TestEval(t *testing.T) {
 		}
 	}
 }
+
+// TestVersionCheckPreRelease 覆盖 PEP 440 风格的预发布版本号，
+// 例如 "3.11.0rc2"：直接删除字母会把两侧数字粘连成 "3.11.02"（即 3.11.2）。
+func TestVersionCheckPreRelease(t *testing.T) {
+	for _, c := range []struct {
+		version string
+		want    string
+	}{
+		{"3.11.0rc2", "3.11.0-2"},
+		{"0.6.0rc1", "0.6.0-1"},
+		{"1.2.3b1", "1.2.3-1"},
+		// 未被字母分隔的数字保持原样
+		{"1.2.3", "1.2.3"},
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3b", "1.2.3"},
+		{"1.2.3-rc1", "1.2.3-1"},
+		{"1.2.3.RELEASE", "1.2.3.0"},
+		{"latest", "999"},
+		{"", "0"},
+	} {
+		if got := versionCheck(c.version); got != c.want {
+			t.Fatalf("versionCheck(%q) = %q, want %q", c.version, got, c.want)
+		}
+	}
+}
+
+// TestAdvisoryEvalPreRelease 预发布版本必须落在其正式版本之前，
+// 否则受影响的目标会被漏报。
+func TestAdvisoryEvalPreRelease(t *testing.T) {
+	for _, c := range []struct {
+		rule    string
+		version string
+		want    bool
+	}{
+		{`version < "3.11.0"`, "3.11.0rc2", true},
+		{`version <= "3.11.1"`, "3.11.0rc2", true},
+		{`version == "3.11.2"`, "3.11.0rc2", false},
+		{`version < "0.6.0"`, "0.6.0rc1", true},
+		// 正式版本不受影响
+		{`version < "3.11.0"`, "3.10.9", true},
+		{`version < "3.11.0"`, "3.11.0", false},
+	} {
+		tokens, err := ParseAdvisorTokens(c.rule)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := CheckBalance(tokens); err != nil {
+			t.Fatal(err)
+		}
+		rule, err := TransFormExp(tokens)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := rule.AdvisoryEval(&AdvisoryConfig{Version: c.version}); got != c.want {
+			t.Fatalf("rule %s with version %q = %v, want %v", c.rule, c.version, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

`versionCheck` (`common/fingerprints/parser/synax.go`) strips every letter run from a version string. When the letters sit **between two digits**, the digits on either side merge:

```
"3.11.0rc2"  ->  "3.11.02"   // = 3.11.2
"0.6.0rc1"   ->  "0.6.01"    // = 0.6.1
```

So a pre-release normalizes to a version *higher* than the release it precedes. Every advisory rule that compares versions is evaluated against that value, which inverts the result for targets running a pre-release build. Measured through `AdvisoryEval` before the fix:

| rule | scanned version | result | |
|---|---|---|---|
| `version < "3.11.0"` | `3.11.0rc2` | `false` | advisory missed |
| `version <= "3.11.1"` | `3.11.0rc2` | `false` | advisory missed |
| `version == "3.11.2"` | `3.11.0rc2` | `true` | advisory reported for a version the target isn't running |

## Why

`X.Y.ZrcN` / `X.Y.ZbN` / `X.Y.ZaN` is the standard PEP 440 pre-release form, and the AI infrastructure this scanner targets is largely Python (vLLM, Ray, Gradio, …), where release candidates are commonly deployed. 1920 rule files under `data/vuln` and `data/vuln_en` reference version comparisons, so the miss applies across the whole advisory set rather than to one rule.

## How

Rewrite a letter run between two digits as a pre-release separator before the letters are stripped, so `3.11.0rc2` becomes `3.11.0-2` — which `hashicorp/go-version` orders below `3.11.0`, as it should be.

Versions whose digits are not separated by letters are untouched; the added table pins the existing shapes (`1.2.3`, `v1.2.3`, `1.2.3b`, `1.2.3-rc1`, `1.2.3.RELEASE`, `latest`, `""`) so the normalization stays put.

Both new tests fail on `main`:

```
versionCheck("3.11.0rc2") = "3.11.02", want "3.11.0-2"
rule version < "3.11.0" with version "3.11.0rc2" = false, want true
```

`go test ./common/fingerprints/parser/` passes with the change; `gofmt` and `go vet` are clean.

Out of scope, mentioned for the record: the dotted Java form `1.0.0.RC1` still normalizes to `1.0.0.01` through the separate `\.[A-Za-z]+` → `.0` rule. Fixing that means changing how `.RELEASE`-style suffixes are handled, which is a wider behaviour change — happy to follow up if you want it.

Note on the test run: `internal/mcp/utils`, `common/websocket`, `common/fingerprints/preload` and `common/utils` already fail on a clean checkout in a local environment (they need `/mcp-server` paths, a listener on `127.0.0.1:8265`, cwd-relative `data/` files, and Chinese-locale API strings). I verified those failures are present without this change.

---

*Disclosure: written with AI assistance; the analysis, fix and tests were verified locally.*
