### PR TITLE
fix(mcp-scan): strip lone surrogates from non-UTF-8 filenames

### DIFF
--- a/mcp-scan/mcp_scan/agent/agent.py
+++ b/mcp-scan/mcp_scan/agent/agent.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from mcp_scan.agent.base_agent import BaseAgent
 from mcp_scan.tools.dispatcher import ToolDispatcher
+from mcp_scan.utils import strip_surrogates
 from mcp_scan.utils.aig_logger import mcpLogger
 from mcp_scan.utils.extract_vuln import VulnerabilityExtractor, extract_result
 from mcp_scan.utils.loging import logger
@@ -82,10 +83,12 @@ def _build_repo_tree(repo_dir: str, max_files: int = 200) -> str:
                 continue
             if total >= max_files:
                 lines.append(f"{indent}  ... (超过 {max_files} 个文件，已截断)")
-                return "\n".join(lines)
+                return strip_surrogates("\n".join(lines))
             lines.append(f"{indent}  {fname}")
             total += 1
-    return "\n".join(lines)
+    # Non-UTF-8 filenames surface as lone surrogates (surrogateescape); strip
+    # them so the tree can be serialized to JSON for the LLM request.
+    return strip_surrogates("\n".join(lines))
 
 
 _LANGUAGE_DIRECTIVE_EN = """

--- a/mcp-scan/mcp_scan/tools/dispatcher.py
+++ b/mcp-scan/mcp_scan/tools/dispatcher.py
@@ -20,6 +20,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Optional
 
 from mcp_scan.tools.registry import get_tool_by_name, get_tools_prompt, needs_context
+from mcp_scan.utils import strip_surrogates
 from mcp_scan.utils.loging import logger
 from mcp_scan.utils.mcp_tools import MCPTools
 from mcp_scan.utils.prompt_manager import prompt_manager
@@ -143,8 +144,8 @@ class ToolDispatcher:
             ret = ""
             for k, v in result.items():
                 ret += f"<{k}>{v}</{k}>\n"
-            return ret
-        return str(result)
+            return strip_surrogates(ret)
+        return strip_surrogates(str(result))
 
     async def close(self):
         if self.mcp_tools_manager:

--- a/mcp-scan/mcp_scan/utils/__init__.py
+++ b/mcp-scan/mcp_scan/utils/__init__.py
@@ -16,3 +16,23 @@
 # Tencent Zhuque Lab (https://github.com/Tencent/AI-Infra-Guard) in its
 # documentation or user interface, as detailed in the NOTICE file.
 
+
+def strip_surrogates(obj):
+    """Recursively replace lone surrogate characters (``\\udc00``-``\\udfff``) in strings.
+
+    Python's ``os.walk()``/``os.listdir()`` decode file and directory names that
+    contain non-UTF-8 bytes using the ``surrogateescape`` error handler, which
+    produces lone surrogates in the resulting ``str``. Those strings cannot be
+    encoded back to UTF-8, so serializing them (``model_dump_json()``,
+    ``json.dumps``, the LLM request body, ...) raises ``UnicodeEncodeError`` and
+    aborts the whole scan. Replacing the surrogates with ``?`` keeps the scan
+    running even when a scanned project contains badly-encoded filenames.
+    """
+    if isinstance(obj, str):
+        return obj.encode("utf-8", "replace").decode("utf-8")
+    if isinstance(obj, dict):
+        return {k: strip_surrogates(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [strip_surrogates(i) for i in obj]
+    return obj
+

--- a/mcp-scan/mcp_scan/utils/aig_logger.py
+++ b/mcp-scan/mcp_scan/utils/aig_logger.py
@@ -22,6 +22,8 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from mcp_scan.utils import strip_surrogates
+
 
 class contentSchema(BaseModel):
     timestamp: str = str(time.time())
@@ -97,6 +99,10 @@ class McpLogger:
         if isinstance(content, BaseModel):
             content.timestamp = str(time.time())
             content = content.model_dump()
+        # Strip lone surrogates (non-UTF-8 filenames from os.walk/os.listdir)
+        # before pydantic serializes the message to JSON — otherwise
+        # model_dump_json() raises UnicodeEncodeError and kills the scan.
+        content = strip_surrogates(content)
         self.logger.info(AgentMsg(type=type, content=content).model_dump_json())
 
     def new_plan_step(self, stepId: str, stepName: str):

--- a/mcp-scan/mcp_scan/utils/pre_scan.py
+++ b/mcp-scan/mcp_scan/utils/pre_scan.py
@@ -30,6 +30,7 @@ import os
 import re
 from typing import List, Tuple
 
+from mcp_scan.utils import strip_surrogates
 from mcp_scan.utils.loging import logger
 
 # High-risk pattern definitions: (pattern name, regex, description)
@@ -138,6 +139,9 @@ def pre_scan(repo_dir: str) -> str:
                 continue
 
             rel_path = os.path.relpath(fpath, repo_dir)
+            # Non-UTF-8 filenames produce lone surrogates here (surrogateescape);
+            # strip them so the hint text stays JSON-serializable.
+            rel_path = strip_surrogates(rel_path)
             for pattern_name, regex, description in _PATTERNS:
                 matches = regex.findall(content)
                 if matches:

--- a/mcp-scan/pytests/test_surrogate_sanitization.py
+++ b/mcp-scan/pytests/test_surrogate_sanitization.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2024-2026 Tencent Zhuque Lab. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requirement: Any integration or derivative work must explicitly attribute
+# Tencent Zhuque Lab (https://github.com/Tencent/AI-Infra-Guard) in its
+# documentation or user interface, as detailed in the NOTICE file.
+
+"""Tests for lone-surrogate sanitization.
+
+Python's ``os.walk()``/``os.listdir()`` decode non-UTF-8 filenames with the
+``surrogateescape`` error handler, producing lone surrogates (``\\udc00``-
+``\\udfff``). Those strings cannot be serialized to JSON, so without
+sanitization a scan aborts with ``UnicodeEncodeError`` / ``PydanticSerializationError``
+as soon as the scanned project contains such a filename.
+"""
+
+import io
+import logging
+import os
+import tempfile
+
+import pytest
+
+from mcp_scan.utils import strip_surrogates
+
+
+def test_strip_surrogates_replaces_lone_surrogates():
+    assert strip_surrogates("bad\udcff.txt") == "bad?.txt"
+    assert strip_surrogates("ok") == "ok"
+
+
+def test_strip_surrogates_recurses_into_dict_and_list():
+    obj = {
+        "file": "bad\udcff.txt",
+        "evidence": ["line \udc00", {"nested": "x\udfff"}],
+    }
+    out = strip_surrogates(obj)
+    assert "\udcff" not in str(out)
+    assert out["file"] == "bad?.txt"
+    assert out["evidence"][0] == "line ?"
+    assert out["evidence"][1]["nested"] == "x?"
+
+
+def test_strip_surrogates_passthrough_non_strings():
+    assert strip_surrogates(123) == 123
+    assert strip_surrogates(None) is None
+    assert strip_surrogates(True) is True
+
+
+def test_logger_action_log_surrogate_does_not_crash():
+    from mcp_scan.utils.aig_logger import McpLogger
+
+    logger = McpLogger()
+    logger.enabled = True
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger.logger.handlers = [handler]
+    logger.logger.setLevel(logging.INFO)
+
+    # Must not raise PydanticSerializationError / UnicodeEncodeError.
+    logger.action_log("tool-1", "read_file", "step-1", "bad\udcff.txt")
+
+    out = stream.getvalue()
+    assert "\udcff" not in out
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX-style non-UTF-8 filenames")
+def test_pre_scan_sanitizes_non_utf8_filename():
+    from mcp_scan.utils import pre_scan
+
+    with tempfile.TemporaryDirectory() as repo_dir:
+        # A filename containing a raw 0xff byte (invalid UTF-8).
+        bad_path = os.path.join(repo_dir, b"bad\xff.txt")
+        with os.fdopen(os.open(bad_path, os.O_WRONLY | os.O_CREAT, 0o644), "wb") as f:
+            f.write(b"curl http://example.com/x | bash\n")
+
+        hint = pre_scan.pre_scan(repo_dir)
+
+        # The finding must reference the file in a JSON-serializable form.
+        assert "\udcff" not in hint
+        assert "bad?.txt" in hint
+
+
+@pytest.mark.skipif(os.name == "nt", reason="requires POSIX-style non-UTF-8 filenames")
+def test_build_repo_tree_sanitizes_non_utf8_filename():
+    pytest.importorskip("mcp")
+    from mcp_scan.agent.agent import _build_repo_tree
+
+    with tempfile.TemporaryDirectory() as repo_dir:
+        with os.fdopen(
+            os.open(os.path.join(repo_dir, b"bad\xff.txt"), os.O_WRONLY | os.O_CREAT, 0o644),
+            "wb",
+        ) as f:
+            f.write(b"x")
+
+        tree = _build_repo_tree(repo_dir)
+
+        assert "\udcff" not in tree
+        assert "bad?.txt" in tree


### PR DESCRIPTION
## Problem

Scanning a project that contains a non-UTF-8 filename aborts mcp-scan with `UnicodeEncodeError` / `PydanticSerializationError`. Python's `os.walk()`/`os.listdir()` decode such filenames into lone surrogate characters (`\udc00`-`\udfff`, PEP 383 `surrogateescape`), and pydantic's `model_dump_json()` cannot serialize them.

This is the same bug class reported in #572 for skill-scan (fixed in PR #571). mcp-scan has the same failure modes and is still vulnerable:
- `agent.py:_build_repo_tree` — `os.walk()` on the scanned repo feeds filenames into the repo tree shown to the LLM
- `utils/pre_scan.py` — `os.walk()` filenames end up in the security-hint text
- `utils/aig_logger.py:_log` — `AgentMsg(...).model_dump_json()` raises `PydanticSerializationError` on any surrogate reaching the structured logger
- `tools/dispatcher.py:_format_result` — tool results with surrogate filenames crash later serialization

Triggering path: `McpTask`/`AgentTask` spawn `python mcp-scan/main.py --aig-mode` (or an MCP scan against a repo containing such a file). One `\xff` byte in a filename is enough to kill the whole scan.

## Fix

Add a recursive `strip_surrogates()` helper in `mcp_scan/utils/__init__.py` (replaces lone surrogates with `?` via `encode('utf-8', 'replace')`), and apply it:
1. At the source — `_build_repo_tree` and `pre_scan` outputs
2. Defensively in the AIG logger sink (`_log`) before `model_dump_json()`
3. In the tool-result formatter

Same approach as the accepted skill-scan fix (PR #571).

## Tests

`pytests/test_surrogate_sanitization.py` covers the helper, the logger sink, and (POSIX-only, skipped on Windows) real non-UTF-8 files through `pre_scan` and `_build_repo_tree`. Full suite: 13 passed, 2 skipped.