### PR TITLE
feat: route scanners through LiteLLM SDK for multi-provider support

### DIFF
--- a/agent-scan/agent_scan/utils/llm.py
+++ b/agent-scan/agent_scan/utils/llm.py
@@ -19,12 +19,37 @@
 import asyncio
 import time
 
-import openai
-from typing import List
+import litellm
+from litellm.exceptions import (
+    APIConnectionError,
+    APIError,
+    BadRequestError,
+    Timeout,
+)
+
 from agent_scan.utils.logging import logger
 
 # Error prefix constant for consistent error detection across modules
 LLM_ERROR_PREFIX = "[LLM Error:"
+
+
+def to_litellm_params(model: str, base_url: str | None) -> tuple[str, str | None]:
+    """Map the configured (model, base_url) onto LiteLLM's routing.
+
+    - base_url set (the default, e.g. OpenRouter or any OpenAI-compatible
+      gateway): route the request as a custom OpenAI-compatible endpoint by
+      prefixing the model with ``openai/`` and passing base_url as ``api_base``.
+      The wire request is identical to the previous ``openai.OpenAI(base_url)``
+      call, so existing configurations keep working unchanged.
+    - base_url empty: pass the model through untouched so LiteLLM routes to a
+      provider natively (e.g. ``anthropic/claude-...``, ``bedrock/...``,
+      ``gemini/...``), which resolves credentials from that provider's own env
+      vars and needs no gateway or proxy.
+    """
+    if base_url:
+        litellm_model = model if model.startswith("openai/") else f"openai/{model}"
+        return litellm_model, base_url
+    return model, None
 
 
 def is_llm_error_response(response: str) -> bool:
@@ -41,13 +66,12 @@ class LLM:
         self.model = model
         self.api_key = api_key
         self.base_url = base_url
-        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.base_url, timeout=60)
 
-    async def chat_async(self, message: List[dict], language: str = "zh") -> str:
+    async def chat_async(self, message: list[dict], language: str = "zh") -> str:
         """Non-blocking wrapper around :meth:`chat` for use inside async contexts.
 
-        Runs the synchronous ``openai.OpenAI`` call in a thread-pool executor
-        via :func:`asyncio.to_thread`, so the event loop is free to schedule
+        Runs the synchronous ``litellm.completion`` call in a thread-pool
+        executor via :func:`asyncio.to_thread`, so the event loop is free to schedule
         other coroutines (e.g. parallel skill workers) while waiting for the
         LLM response.
 
@@ -60,7 +84,7 @@ class LLM:
         """
         return await asyncio.to_thread(self.chat, message, False, language)
 
-    def chat(self, message: List[dict], p=False, language: str = "zh"):
+    def chat(self, message: list[dict], p=False, language: str = "zh"):
         """Send a chat request to the LLM.
 
         Args:
@@ -92,7 +116,7 @@ class LLM:
                             "Failed to connect to LLM, retried 3 times, model output is empty, please try again after 1 minute",
                         )
                     continue
-            except openai.BadRequestError as e:
+            except BadRequestError as e:
                 # 400 error (e.g. DataInspectionFailed): content issue, retry is meaningless, return immediately
                 error_msg = str(e)
                 logger.warning(f"LLM BadRequestError (400), no retry: {error_msg}")
@@ -101,7 +125,7 @@ class LLM:
                     "输入内容触发安全过滤 (400)",
                     "Input content triggered safety filter (400)",
                 )
-            except (openai.APIConnectionError, openai.APITimeoutError) as e:
+            except (APIConnectionError, Timeout) as e:
                 # Network/timeout error: can retry
                 retry += 1
                 logger.warning(f'LLM connection/timeout error, retry {retry}: {e}')
@@ -114,7 +138,7 @@ class LLM:
                     )
                 time.sleep(2)
                 continue
-            except openai.APIError as e:
+            except APIError as e:
                 # Other API errors (5xx, etc.): can retry
                 retry += 1
                 logger.warning(f'LLM API error, retry {retry}: {e}')
@@ -141,7 +165,7 @@ class LLM:
         return ret
 
 
-    def chat_stream(self, message: List[dict]):
+    def chat_stream(self, message: list[dict]):
         """Stream chat completions from the LLM.
 
         Exceptions from the underlying API call propagate to chat() for
@@ -155,16 +179,24 @@ class LLM:
             Content chunks from the model response.
 
         Raises:
-            openai.BadRequestError: Content triggered safety filter (400).
-            openai.APIConnectionError: Network connection failed.
-            openai.APITimeoutError: Request timed out.
-            openai.APIError: Other API errors (5xx, etc.).
+            litellm.BadRequestError: Content triggered safety filter (400).
+            litellm.APIConnectionError: Network connection failed.
+            litellm.Timeout: Request timed out.
+            litellm.APIError: Other API errors (5xx, etc.).
         """
+        litellm_model, api_base = to_litellm_params(self.model, self.base_url)
         try:
-            response = self.client.chat.completions.create(
-                model=self.model,
+            response = litellm.completion(
+                model=litellm_model,
                 messages=message,
                 stream=True,
+                api_key=self.api_key or None,
+                api_base=api_base,
+                timeout=60,
+                # Silently drop generation params a given provider does not
+                # accept, so one config works across OpenAI, Anthropic, Gemini,
+                # Bedrock, etc. instead of 400-ing on provider-specific kwargs.
+                drop_params=True,
             )
 
             for chunk in response:
@@ -183,11 +215,10 @@ class LLM:
                 if content:
                     yield content
 
-        except (openai.BadRequestError, openai.APIConnectionError,
-                openai.APITimeoutError, openai.APIError):
-            # OpenAI exceptions propagate directly to chat() for handling
+        except (BadRequestError, APIConnectionError, Timeout, APIError):
+            # LiteLLM exceptions propagate directly to chat() for handling
             raise
         except Exception as e:
-            # Log unexpected (non-OpenAI) exceptions before re-raising
+            # Log unexpected (non-LiteLLM) exceptions before re-raising
             logger.error(f'Unexpected error in chat_stream: {e}', exc_info=True)
             raise

--- a/agent-scan/pyproject.toml
+++ b/agent-scan/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 dependencies = [
   "loguru==0.7.3",
   "mcp>=2.0.0,<3.0.0",
-  "openai==2.8.1",
+  "litellm>=1.89.0,<2.0.0",
   "pydantic==2.12.4",
   "python-dotenv==1.0.0",
   "PyYAML>=6.0.1",

--- a/agent-scan/pytests/test_llm_request.py
+++ b/agent-scan/pytests/test_llm_request.py
@@ -1,17 +1,74 @@
-from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import patch
 
-from agent_scan.utils.llm import LLM
+from agent_scan.utils.llm import LLM, to_litellm_params
 
 
-def test_chat_request_omits_temperature():
-    create = Mock(return_value=[])
+def _make_llm(model="gpt-5.5", api_key="sk-test", base_url="https://gw.example/v1"):
     llm = object.__new__(LLM)
-    llm.model = "gpt-5.5"
-    llm.client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    llm.model = model
+    llm.api_key = api_key
+    llm.base_url = base_url
+    return llm
+
+
+def test_to_litellm_params_openai_compatible_when_base_url_set():
+    # base_url set -> route as a custom OpenAI-compatible endpoint (this
+    # preserves the previous openai.OpenAI(base_url) behavior byte-for-byte,
+    # including the default OpenRouter gateway).
+    assert to_litellm_params(
+        "deepseek/deepseek-v3.2-exp", "https://openrouter.ai/api/v1"
+    ) == ("openai/deepseek/deepseek-v3.2-exp", "https://openrouter.ai/api/v1")
+    # An already-prefixed model is left untouched (no double openai/ prefix).
+    assert to_litellm_params("openai/gpt-4o", "https://gw/v1") == (
+        "openai/gpt-4o",
+        "https://gw/v1",
     )
 
-    assert list(llm.chat_stream([{"role": "user", "content": "test"}])) == []
-    assert create.call_count == 1
-    assert "temperature" not in create.call_args.kwargs
+
+def test_to_litellm_params_native_when_no_base_url():
+    # No base_url -> pass the model through for native provider routing.
+    assert to_litellm_params("anthropic/claude-sonnet-4.5", None) == (
+        "anthropic/claude-sonnet-4.5",
+        None,
+    )
+    assert to_litellm_params("bedrock/anthropic.claude-3", "") == (
+        "bedrock/anthropic.claude-3",
+        None,
+    )
+
+
+def test_chat_stream_routes_through_litellm_with_drop_params():
+    llm = _make_llm()
+    with patch("agent_scan.utils.llm.litellm.completion", return_value=[]) as completion:
+        assert list(llm.chat_stream([{"role": "user", "content": "test"}])) == []
+
+    assert completion.call_count == 1
+    kwargs = completion.call_args.kwargs
+    assert kwargs["model"] == "openai/gpt-5.5"
+    assert kwargs["api_base"] == "https://gw.example/v1"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["stream"] is True
+    # drop_params keeps one config working across OpenAI/Anthropic/Gemini/etc.
+    assert kwargs["drop_params"] is True
+    # temperature is not injected by the client (preserves prior behavior).
+    assert "temperature" not in kwargs
+
+
+def test_chat_stream_native_provider_when_base_url_blank():
+    llm = _make_llm(model="anthropic/claude-sonnet-4.5", base_url="")
+    with patch("agent_scan.utils.llm.litellm.completion", return_value=[]) as completion:
+        list(llm.chat_stream([{"role": "user", "content": "hi"}]))
+
+    kwargs = completion.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-sonnet-4.5"
+    assert kwargs["api_base"] is None
+
+
+def test_chat_stream_omits_api_key_when_blank():
+    # A blank key must be sent as None so LiteLLM falls back to the provider's
+    # own env var (e.g. ANTHROPIC_API_KEY) instead of an empty bearer token.
+    llm = _make_llm(api_key="")
+    with patch("agent_scan.utils.llm.litellm.completion", return_value=[]) as completion:
+        list(llm.chat_stream([{"role": "user", "content": "hi"}]))
+
+    assert completion.call_args.kwargs["api_key"] is None

--- a/agent-scan/requirements.txt
+++ b/agent-scan/requirements.txt
@@ -1,6 +1,6 @@
 loguru==0.7.3
 mcp==2.0.0
-openai==2.8.1
+litellm>=1.89.0,<2.0.0
 pydantic==2.12.4
 python-dotenv==1.0.0
 PyYAML>=6.0.1

--- a/mcp-scan/mcp_scan/redteam/attacker.py
+++ b/mcp-scan/mcp_scan/redteam/attacker.py
@@ -8,7 +8,7 @@ import json
 import re
 from typing import List, Optional, Any
 
-from openai import AsyncOpenAI
+from mcp_scan.utils.llm import LiteLLMAsyncClient
 
 from mcp_scan.redteam.strategy import ConversationTurn, CrescendoPhase
 
@@ -40,7 +40,7 @@ class AttackerAgent:
 
     def __init__(
         self,
-        client: AsyncOpenAI,
+        client: LiteLLMAsyncClient,
         model: str,
     ):
         self.client = client

--- a/mcp-scan/mcp_scan/redteam/evaluator.py
+++ b/mcp-scan/mcp_scan/redteam/evaluator.py
@@ -8,7 +8,7 @@ import json
 import re
 from typing import List, Optional
 
-from openai import AsyncOpenAI
+from mcp_scan.utils.llm import LiteLLMAsyncClient
 
 from mcp_scan.redteam.strategy import ConversationTurn
 
@@ -40,7 +40,7 @@ class EvaluatorAgent:
 
     def __init__(
         self,
-        client: AsyncOpenAI,
+        client: LiteLLMAsyncClient,
         model: str,
     ):
         self.client = client

--- a/mcp-scan/mcp_scan/redteam/orchestrator.py
+++ b/mcp-scan/mcp_scan/redteam/orchestrator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 from typing import List, Optional, Any, Literal
 
-from openai import AsyncOpenAI
+from mcp_scan.utils.llm import LiteLLMAsyncClient
 
 from mcp_scan.redteam.attacker import AttackerAgent
 from mcp_scan.redteam.evaluator import EvaluatorAgent
@@ -51,21 +51,21 @@ class RedTeamOrchestrator:
         self.api_key = api_key or _get_api_key()
         if not self.api_key:
             raise ValueError(
-                "Missing API key for AsyncOpenAI client. Please provide 'api_key' explicitly "
+                "Missing API key for the LiteLLM client. Please provide 'api_key' explicitly "
                 "or set the 'OPENROUTER_API_KEY' or 'API_KEY' environment variable."
             )
         self.base_url = base_url or DEFAULT_BASE_URL
         self.model = model or DEFAULT_MODEL
         self.repo_dir = repo_dir or ""
-        self._client: Optional[AsyncOpenAI] = None
+        self._client: Optional[LiteLLMAsyncClient] = None
         self._attacker: Optional[AttackerAgent] = None
         self._evaluator: Optional[EvaluatorAgent] = None
         self._target: Optional[TargetRunner] = None
 
     @property
-    def client(self) -> AsyncOpenAI:
+    def client(self) -> LiteLLMAsyncClient:
         if self._client is None:
-            self._client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url, timeout=90)
+            self._client = LiteLLMAsyncClient(api_key=self.api_key, base_url=self.base_url, timeout=90)
         return self._client
 
     @property

--- a/mcp-scan/mcp_scan/redteam/target.py
+++ b/mcp-scan/mcp_scan/redteam/target.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
-from openai import AsyncOpenAI
+from mcp_scan.utils.llm import LiteLLMAsyncClient
 
 # 源码分析：可读扩展名与单文件最大字符数（与 mcp-scan 能力对齐）
 READABLE_EXT = {".py", ".go", ".js", ".ts", ".md", ".json", ".yaml", ".yml", ".toml", ".sh", ".rs", ".java"}
@@ -89,7 +89,7 @@ class TargetRunner:
 
     def __init__(
         self,
-        client: AsyncOpenAI,
+        client: LiteLLMAsyncClient,
         model: str,
         repo_dir: Optional[str] = None,
     ):

--- a/mcp-scan/mcp_scan/utils/llm.py
+++ b/mcp-scan/mcp_scan/utils/llm.py
@@ -17,10 +17,29 @@
 # documentation or user interface, as detailed in the NOTICE file.
 
 import time
+from typing import Any
 
-import openai
+import litellm
 
 from mcp_scan.utils.loging import logger
+
+
+def to_litellm_params(model: str, base_url: str | None) -> tuple[str, str | None]:
+    """Map the configured (model, base_url) onto LiteLLM's routing.
+
+    - base_url set (the default, e.g. OpenRouter or any OpenAI-compatible
+      gateway): route as a custom OpenAI-compatible endpoint by prefixing the
+      model with ``openai/`` and passing base_url as ``api_base``. The wire
+      request is identical to the previous ``openai.OpenAI(base_url)`` call, so
+      existing configurations keep working unchanged.
+    - base_url empty: pass the model through so LiteLLM routes to a provider
+      natively (e.g. ``anthropic/claude-...``, ``bedrock/...``), resolving
+      credentials from that provider's own env vars with no gateway or proxy.
+    """
+    if base_url:
+        litellm_model = model if model.startswith("openai/") else f"openai/{model}"
+        return litellm_model, base_url
+    return model, None
 
 
 class LLM:
@@ -34,7 +53,6 @@ class LLM:
         self.model = model
         self.api_key = api_key
         self.base_url = base_url
-        self.client = openai.OpenAI(api_key=self.api_key, base_url=self.base_url, timeout=60)
         # 用于估算压缩阈值，不依赖接口动态返回模型规格。
         self.context_window = context_window
 
@@ -63,12 +81,19 @@ class LLM:
         return ret
 
     def chat_stream(self, message: list[dict]) -> tuple[str, dict]:
-        response = self.client.chat.completions.create(
-            model=self.model,
+        litellm_model, api_base = to_litellm_params(self.model, self.base_url)
+        response = litellm.completion(
+            model=litellm_model,
             messages=message,
             stream=True,
             # usage 一般在流式结束时返回，前面的 chunk 通常为空。
             stream_options={"include_usage": True},
+            api_key=self.api_key or None,
+            api_base=api_base,
+            timeout=60,
+            # Drop provider-unsupported generation params so one config works
+            # across OpenAI, Anthropic, Gemini, Bedrock, etc.
+            drop_params=True,
         )
 
         ret = ""
@@ -105,3 +130,48 @@ class LLM:
             "completion_tokens": getattr(usage, "completion_tokens", None),
             "total_tokens": getattr(usage, "total_tokens", None),
         }
+
+
+class _LiteLLMAsyncCompletions:
+    def __init__(self, api_key: str, base_url: str | None, timeout: int):
+        self._api_key = api_key
+        self._base_url = base_url
+        self._timeout = timeout
+
+    async def create(self, model: str, messages: list[dict], **kwargs) -> Any:
+        litellm_model, api_base = to_litellm_params(model, self._base_url)
+        params = {
+            "model": litellm_model,
+            "messages": messages,
+            "api_key": self._api_key or None,
+            "api_base": api_base,
+            "timeout": self._timeout,
+            # Drop provider-unsupported generation params so one config works
+            # across OpenAI, Anthropic, Gemini, Bedrock, etc.
+            "drop_params": True,
+        }
+        params.update(kwargs)
+        return await litellm.acompletion(**params)
+
+
+class _LiteLLMAsyncChat:
+    def __init__(self, api_key: str, base_url: str | None, timeout: int):
+        self.completions = _LiteLLMAsyncCompletions(api_key, base_url, timeout)
+
+
+class LiteLLMAsyncClient:
+    """Async LiteLLM client exposing the subset of the OpenAI ``AsyncClient``
+    surface the red-team agents use (``chat.completions.create``), so their
+    calls route through LiteLLM with no other changes.
+
+    base_url is applied here (see :func:`to_litellm_params`), so callers keep
+    passing just ``model`` and ``messages`` exactly as before. Responses have
+    the same OpenAI shape (``choices[0].message.content``), so downstream
+    parsing is unchanged.
+    """
+
+    def __init__(self, api_key: str, base_url: str | None = None, timeout: int = 90):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.timeout = timeout
+        self.chat = _LiteLLMAsyncChat(api_key, base_url, timeout)

--- a/mcp-scan/pyproject.toml
+++ b/mcp-scan/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 dependencies = [
   "loguru==0.7.3",
   "mcp>=2.0.0,<3.0.0",
-  "openai==2.8.1",
+  "litellm>=1.89.0,<2.0.0",
   "pydantic==2.12.4",
   "python-dotenv==1.0.0",
 ]

--- a/mcp-scan/pytests/test_llm_request.py
+++ b/mcp-scan/pytests/test_llm_request.py
@@ -1,17 +1,59 @@
-from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import patch
 
-from mcp_scan.utils.llm import LLM
+from mcp_scan.utils.llm import LLM, to_litellm_params
 
 
-def test_chat_request_omits_temperature():
-    create = Mock(return_value=[])
+def _make_llm(model="gpt-5.5", api_key="sk-test", base_url="https://gw.example/v1"):
     llm = object.__new__(LLM)
-    llm.model = "gpt-5.5"
-    llm.client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    llm.model = model
+    llm.api_key = api_key
+    llm.base_url = base_url
+    return llm
+
+
+def test_to_litellm_params_openai_compatible_when_base_url_set():
+    assert to_litellm_params(
+        "deepseek/deepseek-v3.2-exp", "https://openrouter.ai/api/v1"
+    ) == ("openai/deepseek/deepseek-v3.2-exp", "https://openrouter.ai/api/v1")
+    assert to_litellm_params("openai/gpt-4o", "https://gw/v1") == (
+        "openai/gpt-4o",
+        "https://gw/v1",
     )
 
-    assert llm.chat_stream([{"role": "user", "content": "test"}]) == ("", None)
-    assert create.call_count == 1
-    assert "temperature" not in create.call_args.kwargs
+
+def test_to_litellm_params_native_when_no_base_url():
+    assert to_litellm_params("anthropic/claude-sonnet-4.5", None) == (
+        "anthropic/claude-sonnet-4.5",
+        None,
+    )
+    assert to_litellm_params("bedrock/anthropic.claude-3", "") == (
+        "bedrock/anthropic.claude-3",
+        None,
+    )
+
+
+def test_chat_stream_routes_through_litellm_with_drop_params():
+    llm = _make_llm()
+    with patch("mcp_scan.utils.llm.litellm.completion", return_value=[]) as completion:
+        assert llm.chat_stream([{"role": "user", "content": "test"}]) == ("", None)
+
+    assert completion.call_count == 1
+    kwargs = completion.call_args.kwargs
+    assert kwargs["model"] == "openai/gpt-5.5"
+    assert kwargs["api_base"] == "https://gw.example/v1"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["stream"] is True
+    assert kwargs["drop_params"] is True
+    # usage accounting is preserved via stream_options.
+    assert kwargs["stream_options"] == {"include_usage": True}
+    assert "temperature" not in kwargs
+
+
+def test_chat_stream_native_provider_when_base_url_blank():
+    llm = _make_llm(model="anthropic/claude-sonnet-4.5", base_url="")
+    with patch("mcp_scan.utils.llm.litellm.completion", return_value=[]) as completion:
+        llm.chat_stream([{"role": "user", "content": "hi"}])
+
+    kwargs = completion.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-sonnet-4.5"
+    assert kwargs["api_base"] is None

--- a/mcp-scan/pytests/test_redteam_litellm_client.py
+++ b/mcp-scan/pytests/test_redteam_litellm_client.py
@@ -1,0 +1,48 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from mcp_scan.utils.llm import LiteLLMAsyncClient
+
+
+def test_litellm_async_client_routes_through_acompletion():
+    """The red-team async client shim must forward calls to litellm.acompletion
+    with the same OpenAI-compatible routing the sync path uses."""
+    client = LiteLLMAsyncClient(api_key="sk-test", base_url="https://gw/v1", timeout=90)
+
+    with patch(
+        "mcp_scan.utils.llm.litellm.acompletion",
+        new=AsyncMock(return_value="resp"),
+    ) as acompletion:
+        result = asyncio.run(
+            client.chat.completions.create(
+                model="deepseek/deepseek-v3.2-exp",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+
+    assert result == "resp"
+    kwargs = acompletion.call_args.kwargs
+    assert kwargs["model"] == "openai/deepseek/deepseek-v3.2-exp"
+    assert kwargs["api_base"] == "https://gw/v1"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["timeout"] == 90
+    assert kwargs["drop_params"] is True
+
+
+def test_litellm_async_client_native_routing_without_base_url():
+    client = LiteLLMAsyncClient(api_key="sk-test", base_url="", timeout=90)
+
+    with patch(
+        "mcp_scan.utils.llm.litellm.acompletion",
+        new=AsyncMock(return_value="resp"),
+    ) as acompletion:
+        asyncio.run(
+            client.chat.completions.create(
+                model="anthropic/claude-sonnet-4.5",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        )
+
+    kwargs = acompletion.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-sonnet-4.5"
+    assert kwargs["api_base"] is None

--- a/mcp-scan/requirements.txt
+++ b/mcp-scan/requirements.txt
@@ -1,5 +1,5 @@
 mcp==2.0.0
-openai==2.8.1
+litellm>=1.89.0,<2.0.0
 pydantic==2.12.4
 python-dotenv==1.0.0
 loguru==0.7.3

--- a/skill-scan/pyproject.toml
+++ b/skill-scan/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 dependencies = [
   "chardet==5.2.0",
   "loguru==0.7.3",
-  "openai==2.8.1",
+  "litellm>=1.89.0,<2.0.0",
   "pydantic==2.12.4",
   "python-dotenv==1.0.0",
 ]

--- a/skill-scan/pytests/test_llm_request.py
+++ b/skill-scan/pytests/test_llm_request.py
@@ -1,17 +1,67 @@
-from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import patch
 
-from skill_scan.utils.llm import LLM
+from skill_scan.utils.llm import LLM, to_litellm_params
 
 
-def test_chat_request_omits_temperature():
-    create = Mock(return_value=[])
+def _make_llm(
+    model="gpt-5.5",
+    api_key="sk-test",
+    base_url="https://gw.example/v1",
+    default_headers=None,
+):
     llm = object.__new__(LLM)
-    llm.model = "gpt-5.5"
-    llm.client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    llm.model = model
+    llm.model_name = model
+    llm.api_key = api_key
+    llm.base_url = base_url
+    llm.default_headers = default_headers
+    return llm
+
+
+def test_to_litellm_params_openai_compatible_when_base_url_set():
+    assert to_litellm_params(
+        "deepseek/deepseek-v3.2-exp", "https://openrouter.ai/api/v1"
+    ) == ("openai/deepseek/deepseek-v3.2-exp", "https://openrouter.ai/api/v1")
+    assert to_litellm_params("openai/gpt-4o", "https://gw/v1") == (
+        "openai/gpt-4o",
+        "https://gw/v1",
     )
 
-    assert llm.chat_stream([{"role": "user", "content": "test"}]) == ("", None)
-    assert create.call_count == 1
-    assert "temperature" not in create.call_args.kwargs
+
+def test_to_litellm_params_native_when_no_base_url():
+    assert to_litellm_params("anthropic/claude-sonnet-4.5", None) == (
+        "anthropic/claude-sonnet-4.5",
+        None,
+    )
+    assert to_litellm_params("bedrock/anthropic.claude-3", "") == (
+        "bedrock/anthropic.claude-3",
+        None,
+    )
+
+
+def test_chat_stream_routes_through_litellm_with_drop_params():
+    llm = _make_llm(default_headers={"X-Trace": "1"})
+    with patch("skill_scan.utils.llm.litellm.completion", return_value=[]) as completion:
+        assert llm.chat_stream([{"role": "user", "content": "test"}]) == ("", None)
+
+    assert completion.call_count == 1
+    kwargs = completion.call_args.kwargs
+    assert kwargs["model"] == "openai/gpt-5.5"
+    assert kwargs["api_base"] == "https://gw.example/v1"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["stream"] is True
+    assert kwargs["drop_params"] is True
+    assert kwargs["stream_options"] == {"include_usage": True}
+    # Custom headers configured on the client are forwarded to the provider.
+    assert kwargs["extra_headers"] == {"X-Trace": "1"}
+    assert "temperature" not in kwargs
+
+
+def test_chat_stream_native_provider_when_base_url_blank():
+    llm = _make_llm(model="anthropic/claude-sonnet-4.5", base_url="")
+    with patch("skill_scan.utils.llm.litellm.completion", return_value=[]) as completion:
+        llm.chat_stream([{"role": "user", "content": "hi"}])
+
+    kwargs = completion.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-sonnet-4.5"
+    assert kwargs["api_base"] is None

--- a/skill-scan/skill_scan/utils/llm.py
+++ b/skill-scan/skill_scan/utils/llm.py
@@ -20,9 +20,27 @@ from __future__ import annotations
 
 import time
 
-import openai
+import litellm
 
 from skill_scan.utils.loging import logger
+
+
+def to_litellm_params(model: str, base_url: str | None) -> tuple[str, str | None]:
+    """Map the configured (model, base_url) onto LiteLLM's routing.
+
+    - base_url set (the default, e.g. OpenRouter or any OpenAI-compatible
+      gateway): route as a custom OpenAI-compatible endpoint by prefixing the
+      model with ``openai/`` and passing base_url as ``api_base``. The wire
+      request is identical to the previous ``openai.OpenAI(base_url)`` call, so
+      existing configurations keep working unchanged.
+    - base_url empty: pass the model through so LiteLLM routes to a provider
+      natively (e.g. ``anthropic/claude-...``, ``bedrock/...``), resolving
+      credentials from that provider's own env vars with no gateway or proxy.
+    """
+    if base_url:
+        litellm_model = model if model.startswith("openai/") else f"openai/{model}"
+        return litellm_model, base_url
+    return model, None
 
 
 class LLM:
@@ -38,12 +56,7 @@ class LLM:
         self.model_name = model
         self.api_key = api_key
         self.base_url = base_url
-        self.client = openai.OpenAI(
-            api_key=self.api_key,
-            base_url=self.base_url,
-            timeout=60,
-            default_headers=default_headers if default_headers else None,
-        )
+        self.default_headers = default_headers if default_headers else None
         self.context_window = context_window
 
     def chat(self, message: list[dict], p=False, ret_usage=False) -> str | tuple[str, dict]:
@@ -71,11 +84,19 @@ class LLM:
         return ret
 
     def chat_stream(self, message: list[dict]) -> tuple[str, dict]:
-        response = self.client.chat.completions.create(
-            model=self.model,
+        litellm_model, api_base = to_litellm_params(self.model, self.base_url)
+        response = litellm.completion(
+            model=litellm_model,
             messages=message,
             stream=True,
             stream_options={"include_usage": True},
+            api_key=self.api_key or None,
+            api_base=api_base,
+            timeout=60,
+            extra_headers=self.default_headers,
+            # Drop provider-unsupported generation params so one config works
+            # across OpenAI, Anthropic, Gemini, Bedrock, etc.
+            drop_params=True,
         )
 
         ret = ""


### PR DESCRIPTION
## Summary

Routes every Python scanner's LLM calls through the **LiteLLM SDK** instead of a raw `openai` client, so AI-Infra-Guard can talk to 100+ providers (OpenAI, Anthropic, Gemini, Bedrock, Vertex, Azure, Groq, Mistral, self hosted, or a LiteLLM proxy) through one interface.

* Additive and **fully backward compatible**: the current OpenRouter default and any custom `base_url` keep working byte for byte.
* Adds native provider auth (for example Bedrock SigV4, Vertex ADC) that a plain `openai` client plus `base_url` cannot reach without standing up a separate gateway.
* Sets `drop_params=True` so one config works across providers that reject each other's generation params.


## How routing works (`to_litellm_params`)

* **`base_url` set** (default, for example OpenRouter or any OpenAI compatible gateway): the request is sent as a custom OpenAI compatible endpoint (`model="openai/<model>"`, `api_base=<base_url>`). The wire request is identical to the previous `openai.OpenAI(base_url)` call, so existing configs are unaffected.
* **`base_url` empty**: the model string is passed through for native provider routing (`anthropic/...`, `bedrock/...`, `gemini/...`), resolving credentials from that provider's own env vars, with no gateway or proxy.

## Changes

* `agent-scan/agent_scan/utils/llm.py`: `LLM` now calls `litellm.completion(stream=True)`; LiteLLM exception handling; `to_litellm_params` helper.
* `mcp-scan/mcp_scan/utils/llm.py`: same for the sync `LLM`; adds `LiteLLMAsyncClient`, a shim compatible with the OpenAI `AsyncClient` over `litellm.acompletion` for the red team engine.
* `mcp-scan/mcp_scan/redteam/{orchestrator,evaluator,attacker,target}.py`: the async red team path now uses `LiteLLMAsyncClient` (call sites unchanged; response shape identical).
* `skill-scan/skill_scan/utils/llm.py`: same for the sync `LLM` (preserves `stream_options` usage and custom headers via `extra_headers`).
* `*/pyproject.toml`, `*/requirements.txt`: add `litellm>=1.89.0,<2.0.0`
* Tests: `*/pytests/test_llm_request.py` updated to the LiteLLM seam; `mcp-scan/pytests/test_redteam_litellm_client.py` added.

## Tests

**1. Unit tests, 15 pass (litellm 1.98.0, openai 2.54.0 transitive):**
```
agent-scan: pytests/test_llm_request.py .....                    5 passed
mcp-scan:   pytests/test_llm_request.py + test_redteam_litellm_client.py ......   6 passed
skill-scan: pytests/test_llm_request.py ....                     4 passed
```
Coverage: OpenAI compatible routing (`openai/` prefix plus `api_base`), native passthrough when `base_url` blank, `drop_params=True` present, blank API key sent as `None` (so LiteLLM falls back to provider env vars), `stream_options` and `extra_headers` preserved, and the async red team shim forwarding to `litellm.acompletion`.

**2. Lint (repo ruff config, py312, line length 100):** authored files clean:
```
agent-scan: ruff check agent_scan/utils/llm.py pytests/test_llm_request.py  -> All checks passed!
skill-scan: ruff check skill_scan/utils/llm.py pytests/test_llm_request.py  -> All checks passed!
mcp-scan:   ruff check mcp_scan/utils/llm.py pytests/*                        -> All checks passed!
```

**3. Pin resolves cleanly:** `pip install "litellm>=1.89.0,<2.0.0"` gives litellm 1.98.0 plus openai 2.54.0.

**4. Live E2E (real code path through a LiteLLM proxy):** all three scanner LLM paths exercised end to end against a live model (`gpt-4.1-mini` via a LiteLLM proxy), deterministic prompt "Reply with exactly: OK":
```
== agent-scan LLM.chat (sync stream) ==            agent-scan -> 'OK'
== mcp-scan  LLM.chat (sync stream + usage) ==     mcp-scan  -> 'OK'  usage: {'prompt_tokens': 12, 'completion_tokens': 1, 'total_tokens': 13}
== mcp-scan  redteam async shim -> acompletion ==  redteam    -> 'OK'
ALL LIVE E2E PASSED
```
This proves the full chain for both the sync `litellm.completion` path (agent-scan, mcp-scan, and skill-scan share it) and the async `litellm.acompletion` red team shim: request routed through LiteLLM, provider returned, response and usage parsed back through each scanner's existing code.

## Risk and compatibility

* Additive. Existing OpenRouter and OpenAI compatible configs unchanged.
* `openai` remains available (LiteLLM depends on it); no scanner imports it directly anymore.
* No DB, schema, or API changes.

## Example usage

```python
# Existing OpenAI-compatible gateway (e.g. OpenRouter), unchanged:

# New: native provider, no gateway or proxy (creds from provider env vars):
LLM(model="anthropic/claude-sonnet-4.5", api_key="", base_url="")   # uses ANTHROPIC_API_KEY
LLM(model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", api_key="", base_url="")

# Or point at a LiteLLM proxy:
LLM(model="my-model", api_key=PROXY_KEY, base_url="http://localhost:4000/v1")
```
