### PR TITLE
feat(agent-scan): support custom transforms for SSE responses

### DIFF
--- a/agent-scan/agent_scan/core/agent_adapter/adapter.py
+++ b/agent-scan/agent_scan/core/agent_adapter/adapter.py
@@ -970,7 +970,7 @@ class AIProviderClient:
 
                 if is_sse:
                     # Parse SSE response
-                    raw_response, token_usage = self._parse_sse_response(response.text)
+                    raw_response, token_usage = self._parse_sse_response(response.text, transform_response)
                 else:
                     try:
                         raw_response = response.json()
@@ -1032,7 +1032,7 @@ class AIProviderClient:
                 provider_response=ProviderResponseInfo(error=str(e), metadata={"url": url})
             )
 
-    def _parse_sse_response(self, sse_text: str) -> tuple:
+    def _parse_sse_response(self, sse_text: str, transform: Optional[str] = None) -> tuple:
         """
         Parse SSE (Server-Sent Events) format response.
         
@@ -1053,6 +1053,8 @@ class AIProviderClient:
         token_usage = None
         last_data = None
         role = None
+        transform_applied = False
+        transformed_content_parts = []
 
         for line in sse_text.split("\n"):
             line = line.strip()
@@ -1073,8 +1075,13 @@ class AIProviderClient:
                     data = json.loads(data_str)
                     last_data = data
 
+                    # Extract content from custom transform if provided
+                    transformed = self._apply_transform(data, transform) if transform else None
+                    if transformed is not None:
+                        transformed_content_parts.append(transformed)
+                        transform_applied = True
                     # Extract content from OpenAI-style streaming response
-                    if "choices" in data:
+                    elif "choices" in data:
                         choices = data.get("choices", [])
                         if choices:
                             choice = choices[0]
@@ -1123,10 +1130,18 @@ class AIProviderClient:
                         content_parts.append(data_str)
 
         # Build final response structure
-        full_content = "".join(content_parts)
+        full_content = "".join(transformed_content_parts if transform_applied else content_parts)
 
         # Try to construct a normalized response
-        if last_data and "choices" in last_data:
+        if transform_applied:
+            # Custom transform response
+            response = {
+                "content": full_content,
+                "raw_sse": False
+            }
+            if token_usage:
+                response["usage"] = token_usage
+        elif last_data and "choices" in last_data:
             # OpenAI-style response
             response = {
                 "choices": [{

--- a/agent-scan/pytests/test_agent_adapter.py
+++ b/agent-scan/pytests/test_agent_adapter.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent_scan.core.agent_adapter.adapter import AIProviderClient
+
+
+def test_make_http_request_uses_transform_for_sse_chunks():
+    sse = "\n\n".join([
+        'data: {"stream":{"text":"Hello"},"answer":"Ignored"}',
+        'data: {"stream":{"text":" World"},"answer":" ignored","usage":{"output_tokens":2}}',
+        "data: [DONE]",
+    ])
+    response = SimpleNamespace(
+        status_code=200,
+        headers={"content-type": "text/event-stream"},
+        text=sse,
+    )
+    client = object.__new__(AIProviderClient)
+    client.timeout = 30
+
+    with patch("agent_scan.core.agent_adapter.adapter.httpx.Client") as http_client:
+        http_client.return_value.__enter__.return_value.request.return_value = response
+        result = client._make_http_request(
+            "https://example.test/agent", "POST", {}, {}, "stream.text"
+        )
+
+    assert result.success is True
+    assert result.provider_response.output == "Hello World"
+    assert result.provider_response.raw == {
+        "content": "Hello World",
+        "raw_sse": False,
+        "usage": {"output_tokens": 2},
+    }
+
+
+def test_parse_sse_response_falls_back_when_transform_does_not_match():
+    sse = "\n\n".join([
+        'data: {"answer":"Hello"}',
+        'data: {"answer":" World"}',
+    ])
+    client = object.__new__(AIProviderClient)
+
+    response, _ = client._parse_sse_response(sse, "stream.text")
+
+    assert response == {"content": "Hello World", "raw_sse": True}
+    assert client._extract_output(response, "stream.text") == "Hello World"
+
+
+def test_parse_sse_response_does_not_mix_fallback_after_transform_matches():
+    sse = "\n\n".join([
+        'data: {"stream":{"text":"Hello"}}',
+        'data: {"answer":"STATUS"}',
+    ])
+    client = object.__new__(AIProviderClient)
+
+    response, _ = client._parse_sse_response(sse, "stream.text")
+
+    assert response == {"content": "Hello", "raw_sse": False}
+
+
+def test_parse_sse_response_keeps_transformed_type_event_generic():
+    sse = 'data: {"type":"chunk","stream":{"text":"Hello"}}'
+    client = object.__new__(AIProviderClient)
+
+    response, _ = client._parse_sse_response(sse, "stream.text")
+
+    assert response == {"content": "Hello", "raw_sse": False}
+    assert client._extract_output(response, "stream.text") == "Hello"


### PR DESCRIPTION
## Problem

Custom HTTP agent providers can configure `transform_response` to extract output from non-standard response payloads. For SSE responses, however, each event was normalized before `_extract_output()` applied the transform. A transform written for the original event shape (for example, `stream.text`) therefore could not extract the streaming content.

## Changes

- pass `transform_response` into the SSE parser and apply it to each JSON `data:` event
- accumulate transformed content separately from the existing fallback parsers
- use transformed content exclusively when at least one event matches, avoiding mixed output from unrelated event shapes
- preserve the existing OpenAI, Anthropic, Coze, Dify, and plain-text parsing when no event matches the transform
- normalize transformed streams through `content` with `raw_sse: false`
- preserve token-usage extraction

## Behavior

- **Transform matches:** concatenate only transformed event content.
- **Transform does not match any event:** fall back to the existing SSE parsing behavior.
- **Mixed event shapes:** ignore fallback content once the configured transform succeeds, preventing status or metadata events from contaminating the response.
- **Custom events containing `type`:** keep the generic transformed response shape instead of treating them as Anthropic events.

## Scope

This change only affects SSE handling for HTTP providers with an optional response transform. Non-SSE responses and existing provider-specific parsers remain unchanged.

## Testing

- `python -m pytest -vv pytests/test_agent_adapter.py` — 4 passed
- Python syntax compilation — passed
- `git diff --check` — passed

The unit tests cover HTTP integration, transform aggregation, complete fallback, mixed event shapes, token usage, and custom events containing a top-level `type` field.