### PR TITLE
Fix/report language localization

### DIFF
--- a/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
+++ b/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
@@ -115,8 +115,6 @@ class RedTeamer:
         self.simulator_model, _ = initialize_model(simulator_model)
         self.evaluation_model, _ = initialize_model(evaluation_model)
         self.async_mode = async_mode
-        # 缓存已翻译过的文本，避免同一条数据集原文/相同 reason 在多个测试用例间重复翻译
-        # （同一批次的越狱数据集通常会被多种攻击手法/多个漏洞类型重复引用同一条 original_input）
         self._translation_cache: Dict[str, str] = {}
         self.synthetic_goldens: List[Golden] = []
         self.custom_metric = None  # 添加自定义metric属性
@@ -151,7 +149,6 @@ Direct translation without separators"""
         return f"Translate to {logger.lang} (output translation only):\n\n{text}"
 
     def _lang_category(self) -> str:
-        """把 logger.lang（如 'en'/'zh'/'zh_CN'）映射到 judge_language() 的词表上"""
         lang = (logger.lang or "").lower()
         if lang.startswith("zh"):
             return "chinese"
@@ -160,9 +157,6 @@ Direct translation without separators"""
         return "default"
 
     def _translate_text(self, text: str) -> str:
-        """把任意报告文本翻译成当前配置的报告语言（同步版本）。
-        已经是目标语言的文本、以及无法判断语言的文本（如混淆/编码后的攻击载荷）都会原样跳过，
-        避免把非自然语言内容（比如 Zalgo 编码）误翻译损坏。"""
         if not isinstance(text, str) or not text.strip():
             return text
         target = self._lang_category()
@@ -189,7 +183,6 @@ Direct translation without separators"""
         return translated
 
     async def _a_translate_text(self, text: str) -> str:
-        """把任意报告文本翻译成当前配置的报告语言（异步版本），规则同 _translate_text。"""
         if not isinstance(text, str) or not text.strip():
             return text
         target = self._lang_category()
@@ -1175,16 +1168,9 @@ Direct translation without separators"""
                 "modelName": model_name,
                 "vulnerability": case.vulnerability,
                 "attackMethod": case.attack_method,
-                # 数据集原文/攻击载荷/模型输出统一翻译成报告语言；_translate_text 会跳过
-                # 已经是目标语言、或无法判断语言（如混淆后的攻击载荷）的文本，避免把编码/
-                # 乱码内容误翻译损坏。
                 "originalInput": self._translate_text(original_input),
                 "input": self._translate_text(case.input),
                 "output": self._translate_text(case.actual_output),
-                # 注意：case.reason 在这里不再调用 _translate_text 二次翻译——它在测量阶段
-                # 已经翻译好了（metric 产出的 reason 经 _translate_reason/_a_translate_reason
-                # 翻译；出错兜底的 reason 经 logger.translated_msg 走 gettext 本地化），此处
-                # 直接是最终报告语言，不需要也不应该再翻译一次。
                 "reason": case.reason,
                 "error": case.error
             }

--- a/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
+++ b/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
@@ -1175,13 +1175,17 @@ Direct translation without separators"""
                 "modelName": model_name,
                 "vulnerability": case.vulnerability,
                 "attackMethod": case.attack_method,
-                # 数据集原文/攻击载荷/模型输出/评估依据统一翻译成报告语言；
-                # _translate_text 会跳过已经是目标语言、或无法判断语言（如混淆后的攻击载荷）的文本，
-                # 避免把编码/乱码内容误翻译损坏。
+                # 数据集原文/攻击载荷/模型输出统一翻译成报告语言；_translate_text 会跳过
+                # 已经是目标语言、或无法判断语言（如混淆后的攻击载荷）的文本，避免把编码/
+                # 乱码内容误翻译损坏。
                 "originalInput": self._translate_text(original_input),
                 "input": self._translate_text(case.input),
                 "output": self._translate_text(case.actual_output),
-                "reason": self._translate_text(case.reason),
+                # 注意：case.reason 在这里不再调用 _translate_text 二次翻译——它在测量阶段
+                # 已经翻译好了（metric 产出的 reason 经 _translate_reason/_a_translate_reason
+                # 翻译；出错兜底的 reason 经 logger.translated_msg 走 gettext 本地化），此处
+                # 直接是最终报告语言，不需要也不应该再翻译一次。
+                "reason": case.reason,
                 "error": case.error
             }
             results.append(result)

--- a/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
+++ b/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
@@ -115,6 +115,9 @@ class RedTeamer:
         self.simulator_model, _ = initialize_model(simulator_model)
         self.evaluation_model, _ = initialize_model(evaluation_model)
         self.async_mode = async_mode
+        # 缓存已翻译过的文本，避免同一条数据集原文/相同 reason 在多个测试用例间重复翻译
+        # （同一批次的越狱数据集通常会被多种攻击手法/多个漏洞类型重复引用同一条 original_input）
+        self._translation_cache: Dict[str, str] = {}
         self.synthetic_goldens: List[Golden] = []
         self.custom_metric = None  # 添加自定义metric属性
         self.attack_simulator = AttackSimulator(
@@ -147,33 +150,78 @@ Direct translation without separators"""
         """获取翻译的 user 提示"""
         return f"Translate to {logger.lang} (output translation only):\n\n{text}"
 
-    def _translate_reason(self, reason: str) -> str:
-        """翻译 reason 文本（同步版本）"""
-        if not isinstance(reason, str) or not reason.strip():
-            return reason
-        if logger.lang == "zh_CN" and judge_language(reason) != "chinese":
+    def _lang_category(self) -> str:
+        """把 logger.lang（如 'en'/'zh'/'zh_CN'）映射到 judge_language() 的词表上"""
+        lang = (logger.lang or "").lower()
+        if lang.startswith("zh"):
+            return "chinese"
+        if lang.startswith("en"):
+            return "english"
+        return "default"
+
+    def _translate_text(self, text: str) -> str:
+        """把任意报告文本翻译成当前配置的报告语言（同步版本）。
+        已经是目标语言的文本、以及无法判断语言的文本（如混淆/编码后的攻击载荷）都会原样跳过，
+        避免把非自然语言内容（比如 Zalgo 编码）误翻译损坏。"""
+        if not isinstance(text, str) or not text.strip():
+            return text
+        target = self._lang_category()
+        if target == "default":
+            return text
+        detected = judge_language(text)
+        if detected == "default" or detected == target:
+            return text
+        cache_key = f"{target}:{text}"
+        if cache_key in self._translation_cache:
+            return self._translation_cache[cache_key]
+        try:
             system_message = self._get_translation_system_message()
-            user_prompt = self._get_translation_user_prompt(reason)
+            user_prompt = self._get_translation_user_prompt(text)
             messages = [
                 {"role": "system", "content": system_message},
                 {"role": "user", "content": user_prompt}
             ]
-            return self.evaluation_model.generate(messages=messages)
-        return reason
+            translated = self.evaluation_model.generate(messages=messages)
+        except Exception as e:
+            logger.exception(e)
+            return text
+        self._translation_cache[cache_key] = translated
+        return translated
+
+    async def _a_translate_text(self, text: str) -> str:
+        """把任意报告文本翻译成当前配置的报告语言（异步版本），规则同 _translate_text。"""
+        if not isinstance(text, str) or not text.strip():
+            return text
+        target = self._lang_category()
+        if target == "default":
+            return text
+        detected = judge_language(text)
+        if detected == "default" or detected == target:
+            return text
+        cache_key = f"{target}:{text}"
+        if cache_key in self._translation_cache:
+            return self._translation_cache[cache_key]
+        try:
+            system_message = self._get_translation_system_message()
+            user_prompt = self._get_translation_user_prompt(text)
+            messages = [
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": user_prompt}
+            ]
+            translated = await self.evaluation_model.a_generate(messages=messages)
+        except Exception as e:
+            logger.exception(e)
+            return text
+        self._translation_cache[cache_key] = translated
+        return translated
+
+    def _translate_reason(self, reason: str) -> str:
+        """翻译 reason 文本（同步版本）"""
+        return self._translate_text(reason)
 
     async def _a_translate_reason(self, reason: str) -> str:
         """翻译 reason 文本（异步版本）"""
-        if not isinstance(reason, str) or not reason.strip():
-            return reason
-        if logger.lang == "zh_CN" and judge_language(reason) != "chinese":
-            system_message = self._get_translation_system_message()
-            user_prompt = self._get_translation_user_prompt(reason)
-            messages = [
-                {"role": "system", "content": system_message},
-                {"role": "user", "content": user_prompt}
-            ]
-            return await self.evaluation_model.a_generate(messages=messages)
-        return reason
+        return await self._a_translate_text(reason)
 
     def red_team(
         self,
@@ -1121,15 +1169,19 @@ Direct translation without separators"""
             else:
                 status = "Jailbreak"
                 rep_status = True
+            original_input = case.original_input if case.attack_method != "RedTeam" else None
             result = {
-                "status": status, 
-                "modelName": model_name, 
+                "status": status,
+                "modelName": model_name,
                 "vulnerability": case.vulnerability,
                 "attackMethod": case.attack_method,
-                "originalInput": case.original_input if case.attack_method != "RedTeam" else None,
-                "input": case.input,
-                "output": case.actual_output,
-                "reason": case.reason,
+                # 数据集原文/攻击载荷/模型输出/评估依据统一翻译成报告语言；
+                # _translate_text 会跳过已经是目标语言、或无法判断语言（如混淆后的攻击载荷）的文本，
+                # 避免把编码/乱码内容误翻译损坏。
+                "originalInput": self._translate_text(original_input),
+                "input": self._translate_text(case.input),
+                "output": self._translate_text(case.actual_output),
+                "reason": self._translate_text(case.reason),
                 "error": case.error
             }
             results.append(result)

--- a/common/agent/agent_task.go
+++ b/common/agent/agent_task.go
@@ -104,10 +104,19 @@ func (m *AgentTask) Execute(ctx context.Context, request TaskRequest, callbacks 
 	argv = append(argv, "--aig-mode")
 
 	// Define task titles
-	taskTitles := []string{
-		"Info Collection",
-		"Vulnerability Detection",
-		"Vulnerability Review",
+	var taskTitles []string
+	if language == "en" {
+		taskTitles = []string{
+			"Info Collection",
+			"Vulnerability Detection",
+			"Vulnerability Review",
+		}
+	} else {
+		taskTitles = []string{
+			"信息收集",
+			"漏洞检测",
+			"漏洞整理",
+		}
 	}
 
 	var tasks []SubTask

--- a/common/agent/tasks.go
+++ b/common/agent/tasks.go
@@ -363,6 +363,7 @@ func (t *AIInfraScanAgent) executeScan(ctx context.Context, request TaskRequest,
 		WebServer:    false,
 		Target:       reqScan.Target,
 		LoadRemote:   true,
+		Language:     request.Language,
 	}
 
 	headers := make([]string, 0)

--- a/common/runner/runner.go
+++ b/common/runner/runner.go
@@ -676,7 +676,7 @@ func (r *Runner) initVulnerabilityDB() error {
 	var err error
 	if r.Options.LoadRemote {
 		// load from hostname
-		err = engine.LoadFromHost(r.Options.AdvTemplates)
+		err = engine.LoadFromHost(r.Options.AdvTemplates, r.Options.Language)
 	} else {
 		// load from directory
 		vulDir := strings.TrimRight(r.Options.AdvTemplates, "/")

--- a/common/websocket/knowledge_api.go
+++ b/common/websocket/knowledge_api.go
@@ -393,6 +393,7 @@ func HandleListVulnerabilities() gin.HandlerFunc {
 		pageStr := c.DefaultQuery("page", "1")
 		sizeStr := c.DefaultQuery("size", "20")
 		query := strings.ToLower(c.DefaultQuery("q", ""))
+		lang := c.DefaultQuery("lang", "zh")
 		page, _ := strconv.Atoi(pageStr)
 		size, _ := strconv.Atoi(sizeStr)
 		if page < 1 {
@@ -405,6 +406,9 @@ func HandleListVulnerabilities() gin.HandlerFunc {
 		engine := vulstruct.NewAdvisoryEngine()
 		// load from directory
 		dir := "data/vuln"
+		if lang == "en" {
+			dir = "data/vuln_en"
+		}
 		err := engine.LoadFromDirectory(dir)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"status": 1, "message": "加载漏洞库失败: " + err.Error()})

--- a/pkg/vulstruct/advisory.go
+++ b/pkg/vulstruct/advisory.go
@@ -71,8 +71,8 @@ func (ae *AdvisoryEngine) LoadFromDirectory(dir string) error {
 	return nil
 }
 
-func (ae *AdvisoryEngine) LoadFromHost(host string) error {
-	datas, err := utils.LoadRemoteVulStruct(fmt.Sprintf("http://%s/api/v1/knowledge/vulnerabilities?page=1&size=9999", host))
+func (ae *AdvisoryEngine) LoadFromHost(host string, lang string) error {
+	datas, err := utils.LoadRemoteVulStruct(fmt.Sprintf("http://%s/api/v1/knowledge/vulnerabilities?page=1&size=9999&lang=%s", host, lang))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Reports were not consistently rendered in the language selected in the UI. This PR fixes the two biggest gaps and one smaller one:

1. AI Infra Scan - CVE description/recommendation/severity text was always Chinese, regardless of the selected language. Root cause: the agent-side scan always loads vulnerability data via LoadFromHost → the webserver's /api/v1/knowledge/vulnerabilities endpoint, which hardcoded data/vuln (Chinese) with no language parameter at all - request.Language never reached this path. Now the language flows through end-to-end and data/vuln_en is served when English is selected.
2. Jailbreak Evaluation - Original Input, Attack Input, and Model Output rendered in whatever language the dataset/target model happened to use, regardless of the selected report language. Added a generic, bidirectional translation step (_translate_text/_a_translate_text) that:
   - translates into whichever language is selected (not just Chinese, which was the only direction the old code supported),
   - skips text already in the target language,
   - skips text whose language can't be confidently judged (e.g. Zalgo-obfuscated attack payloads), so obfuscated/non-linguistic content is never mangled,
   - is cached per scan run, since the same dataset scenario text is frequently reused across many attack techniques/vulnerability types,
   - does not re-translate reason, which is already correctly localized earlier in the pipeline.
3. Agent Scan - task-list step titles ("Info Collection", "Vulnerability Detection", "Vulnerability Review") were hardcoded English even in Chinese mode, unlike MCP Scan which already localized these. Now matches MCP Scan's pattern.

Not in scope (called out, not silently skipped)

- The Knowledge Base "create/edit vulnerability" endpoints still only write data/vuln (Chinese) - an admin editing or adding a CVE entry won't get an English version automatically. Left as a follow-up.
- The OWASP ASI category label in Agent Scan (e.g. "Agent Goal Hijack") stays English-only in all languages - treated as a fixed taxonomy term, same as "CVE"/"CVSS" elsewhere, not report prose.
- Jailbreak translation is not parallelized - it's cached, but still sequential per test case, so large runs (hundreds of cases) will see added latency from the extra translation calls.
