### PR TITLE
fix(parser): prevent panic on malformed advisory version rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ services/api_checker/runtime/
 services/api_checker/pamela/results/
 services/**/__pycache__/
 services/**/*.pyc
+
+# local deployment & test artifacts
+deploy/
+common/utils/chromium/screenshot.png

--- a/common/fingerprints/parser/synax.go
+++ b/common/fingerprints/parser/synax.go
@@ -326,21 +326,26 @@ func (r *Rule) AdvisoryEval(config *AdvisoryConfig) bool {
 					v1, _ = vv.NewVersion("0.0.0")
 				}
 				text = versionCheck(next.right)
+				v2, err := vv.NewVersion(text)
+				if err != nil {
+					gologger.Debugf("无法解析规则版本号:%s=>%s", text, "0.0.0")
+					v2, _ = vv.NewVersion("0.0.0")
+				}
 				switch next.op {
 				case tokenFullEqual:
-					r = v1.Equal(vv.Must(vv.NewVersion(text)))
+					r = v1.Equal(v2)
 				case tokenContains:
-					r = v1.Equal(vv.Must(vv.NewVersion(text)))
+					r = v1.Equal(v2)
 				case tokenNotEqual:
-					r = !v1.Equal(vv.Must(vv.NewVersion(text)))
+					r = !v1.Equal(v2)
 				case tokenGt:
-					r = v1.GreaterThan(vv.Must(vv.NewVersion(text)))
+					r = v1.GreaterThan(v2)
 				case tokenLt:
-					r = v1.LessThan(vv.Must(vv.NewVersion(text)))
+					r = v1.LessThan(v2)
 				case tokenGte:
-					r = v1.GreaterThanOrEqual(vv.Must(vv.NewVersion(text)))
+					r = v1.GreaterThanOrEqual(v2)
 				case tokenLte:
-					r = v1.LessThanOrEqual(vv.Must(vv.NewVersion(text)))
+					r = v1.LessThanOrEqual(v2)
 
 				default:
 					panic("unknown op token")

--- a/data/vuln/gradio/CVE-2024-8966.yaml
+++ b/data/vuln/gradio/CVE-2024-8966.yaml
@@ -7,10 +7,10 @@ info:
   cvss: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
   severity: HIGH
   security_advise: |
-    1. 升级至gradio-video@0.10.3或更高版本
+    1. 升级至Gradio 5.23.0或更高版本
     2. 实施输入验证以限制multipart边界的大小
     3. 监控和记录异常活动以检测潜在的DoS攻击
-rule: version = "@gradio/video@0.10.2"
+rule: version <= "5.22.0"
 references:
   - https://nvd.nist.gov/vuln/detail/CVE-2024-8966
   - https://huntr.com/bounties/7b5932bb-58d1-4e71-b85c-43dc40522ff2

--- a/data/vuln_en/gradio/CVE-2024-8966.yaml
+++ b/data/vuln_en/gradio/CVE-2024-8966.yaml
@@ -7,10 +7,10 @@ info:
   cvss: CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
   severity: HIGH
   security_advise: |
-    1. Upgrade to gradio-video@0.10.3 or later
+    1. Upgrade to Gradio 5.23.0 or later
     2. Implement input validation to limit the size of multipart boundaries
     3. Monitor and log unusual activity to detect potential DoS attacks
-rule: version = "@gradio/video@0.10.2"
+rule: version <= "5.22.0"
 references:
   - https://nvd.nist.gov/vuln/detail/CVE-2024-8966
   - https://huntr.com/bounties/7b5932bb-58d1-4e71-b85c-43dc40522ff2


### PR DESCRIPTION
## Summary

Fixes a scan-engine crash (panic) triggered by malformed advisory version rules.

## Problem

Scanning a **Gradio** target caused the whole scan process to crash with:

```
panic: Malformed version: @/@0.10.2
github.com/hashicorp/go-version.Must(...)
common/fingerprints/parser.(*Rule).AdvisoryEval.func1  synax.go:333
```

Root cause chain:
1. `data/vuln/gradio/CVE-2024-8966.yaml` (zh + en) contains
   `rule: version = "@gradio/video@0.10.2"` — an **npm package version**,
   not a Gradio service version.
2. `versionCheck()` normalizes it to the malformed string `@/@0.10.2`.
3. `AdvisoryEval` uses `vv.Must(vv.NewVersion(text))` with **no error
   handling** on the rule-side version, so any malformed version panics
   immediately. (The extracted left-side version already has a fallback.)

Impact: **any real Gradio service being scanned crashes the scanner**
(availability DoS). The bug is also reachable via any malformed rule added
to the rule library.

## Fix (two layers)

1. **Engine (root fix)** — `common/fingerprints/parser/synax.go`:
   replace all 7 `vv.Must(vv.NewVersion(text))` calls with error-tolerant
   parsing (fallback to `0.0.0`, consistent with the left-side handling).
   Future malformed rules can no longer crash the scanner.

2. **Rule data** — `data/vuln/gradio/CVE-2024-8966.yaml` and
   `data/vuln_en/gradio/CVE-2024-8966.yaml`:
   `version = "@gradio/video@0.10.2"` → `version <= "5.22.0"`
   per authoritative advisory [PYSEC-2026-1410](https://osv.dev/vulnerability/PYSEC-2026-1410)
   (introduced 0, last_affected 5.22.0).

## Verification

- `go build` (linux/arm64 cross-compile): pass
- `go test ./common/fingerprints/parser/ ./pkg/vulstruct/`: pass
- `yamlcheck` on gradio rules (zh + en): all 102 files pass
- Before fix: Gradio scan panics (exit 2)
- After fix: Gradio scan completes (exit 0), identifies `gradio:3.20.0`,
  matches 76 CVE entries, no panic

## Notes

- `common/agent` package tests fail to compile (`tasks_test.go` references
  non-existent symbols) — pre-existing, unrelated to this change.
