### PR TITLE
fix(mcp-scan): use timedelta for ClientSession read_timeout_seconds

### DIFF
--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -21,6 +21,7 @@ import json
 import os
 from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack, asynccontextmanager
+from datetime import timedelta
 from typing import Any, Literal
 
 from mcp import ClientSession
@@ -77,7 +78,7 @@ class MCPTools:
             session = ClientSession(
                 read,
                 write,
-                read_timeout_seconds=float(self.timeout_seconds),
+                read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
             )
             await stack.enter_async_context(session)
             await session.initialize()


### PR DESCRIPTION
## Problem

MCP dynamic scans (streamable-http transport) fail with a generic error:

\`\`\`
Failed to connect to MCP server
\`\`\`

Full traceback:

\`\`\`
RuntimeError: Failed to connect to MCP server

  File ".../mcp_scan/agent/base_agent.py", line 129, in generate_system_prompt
    tools_prompt = await self.dispatcher.get_all_tools_prompt()
  File ".../mcp_scan/tools/dispatcher.py", line 94, in get_all_tools_prompt
    raise RuntimeError("Failed to connect to MCP server")
\`\`\`

## Root Cause

The MCP Python SDK (\`mcp >= 1.x\`) changed the type of \`ClientSession.read_timeout_seconds\` from \`float\` to \`datetime.timedelta\`. The current code passes a \`float\`:

\`\`\`python
session = ClientSession(
    read,
    write,
    read_timeout_seconds=float(self.timeout_seconds),  # ❌ should be timedelta
)
\`\`\`

This causes an \`AttributeError: 'float' object has no attribute 'total_seconds'\` during \`session.initialize()\`, which is swallowed by \`AsyncExitStack\` and surfaces as the generic "Failed to connect to MCP server" error.

This issue is visible in the SDK source:

\`\`\`python
# mcp/shared/session.py line 287-288
elif self._session_read_timeout_seconds is not None:
    timeout = self._session_read_timeout_seconds.total_seconds()  # fails on float
\`\`\`

## Fix

Pass \`timedelta\` instead of \`float\`:

\`\`\`python
from datetime import timedelta

session = ClientSession(
    read,
    write,
    read_timeout_seconds=timedelta(seconds=self.timeout_seconds),  # ✅
)
\`\`\`

## Verification

Tested against \`https://gateway.mcpservers.org/yahoo-finance/mcp\` (streamable-http transport):

**Before fix:** \`RuntimeError: Failed to fetch MCP tools: AttributeError: 'float' object has no attribute 'total_seconds'\`

**After fix:** Successfully connected, retrieved 4 tools (\`get_quote\`, \`search\`, \`get_chart\`, \`quote_summary\`).

\`\`\`
=== Test: streamable-http (yahoo-finance) ===
SUCCESS: 4975 chars
  <name>get_quote</name>
\`\`\`

## Scope

Minimal change — single file, 2 lines added, 1 line modified:

\`\`\`diff
+from datetime import timedelta
 ...
-                read_timeout_seconds=float(self.timeout_seconds),
+                read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
\`\`\`