### PR TITLE
fix(mcp-scan): adapt to MCP Python SDK 2.x API changes

### DIFF
--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -21,7 +21,6 @@ import json
 import os
 from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack, asynccontextmanager
-from datetime import timedelta
 from typing import Any, Literal
 
 from mcp import ClientSession
@@ -78,7 +77,7 @@ class MCPTools:
             session = ClientSession(
                 read,
                 write,
-                read_timeout_seconds=timedelta(seconds=self.timeout_seconds),
+                read_timeout_seconds=self.timeout_seconds,
             )
             await stack.enter_async_context(session)
             await session.initialize()
@@ -206,14 +205,14 @@ class MCPTools:
         xml_lines = ["<mcp_tools>"]
         for t in data.tools:
             # 缓存工具 schema，用于后续参数类型转换
-            self._tools_schema[t.name] = t.inputSchema
+            self._tools_schema[t.name] = t.input_schema
 
             # 净化工具描述，移除 prompt injection 指令
             safe_desc = self._sanitize_description(t.description)
 
             parameters = ""
-            for k, param in t.inputSchema["properties"].items():
-                required = "true" if k in t.inputSchema.get("required", []) else "false"
+            for k, param in t.input_schema["properties"].items():
+                required = "true" if k in t.input_schema.get("required", []) else "false"
                 param_type = param.get("type", "string")
                 # 构建基础属性
                 base_attrs = f'name="{k}" type="{param_type}" required="{required}"'


### PR DESCRIPTION
## Problem

mcp-scan fails to connect to remote MCP servers with the following error:

```
RuntimeError: Failed to connect to MCP server
```

This happens because `requirements.txt` pins `mcp==2.0.0`, but the code in `mcp_scan/utils/mcp_tools.py` still uses the MCP Python SDK 1.x API, which is incompatible with SDK 2.x.

## Root Cause

MCP Python SDK 2.x changed two APIs that this module depends on:

1. **`ClientSession.read_timeout_seconds`** — SDK 2.x expects a **numeric value** (seconds), not a `datetime.timedelta` object. Passing a `timedelta` causes a `TypeError` at runtime.

2. **`Tool.inputSchema` → `Tool.input_schema`** — SDK 2.x renamed the `inputSchema` attribute (camelCase) to `input_schema` (snake_case) to follow Python naming conventions. Accessing `t.inputSchema` raises `AttributeError`.

## Fix

| # | Change | Reason |
|---|--------|--------|
| 1 | `read_timeout_seconds=timedelta(seconds=N)` → `read_timeout_seconds=N` | SDK 2.x expects numeric seconds |
| 2 | `t.inputSchema` → `t.input_schema` (3 occurrences) | SDK 2.x renamed to snake_case |
| 3 | Remove unused `from datetime import timedelta` | No longer needed |

## Verification

Successfully connected to `https://gateway.mcpservers.org/yahoo-finance/mcp` via streamable HTTP transport, completed MCP `initialize` + `tools/list`, and retrieved 4 tools:

- `get_quote`
- `search`
- `get_chart`
- `quote_summary`

Python syntax check (`py_compile`) also passed.

## Note

This supersedes the earlier fix in PR #605 (`fix/mcp-read-timeout-timedelta`), which changed `read_timeout_seconds` **to** `timedelta` — the opposite direction. That fix was correct for SDK 1.x but breaks under SDK 2.x (which is what `requirements.txt` pins).