### PR TITLE
fix(mcp-scan): cast read_timeout_seconds to float for SDK 2.x type safety

### DIFF
--- a/mcp-scan/mcp_scan/utils/mcp_tools.py
+++ b/mcp-scan/mcp_scan/utils/mcp_tools.py
@@ -77,7 +77,7 @@ class MCPTools:
             session = ClientSession(
                 read,
                 write,
-                read_timeout_seconds=self.timeout_seconds,
+                read_timeout_seconds=float(self.timeout_seconds),
             )
             await stack.enter_async_context(session)
             await session.initialize()


### PR DESCRIPTION
## Problem

After PR #609 was merged, `read_timeout_seconds` was set to `self.timeout_seconds`, which is an `int` (cast from `os.environ.get("MCP_TIMEOUT_SECONDS", "30")` via `int()`).

MCP Python SDK 2.x's `ClientSession.read_timeout_seconds` expects a `float` (seconds). While a bare `int` often works, explicitly casting to `float` ensures type safety and avoids potential `TypeError` on stricter SDK validations.

## Fix

```diff
-                read_timeout_seconds=self.timeout_seconds,
+                read_timeout_seconds=float(self.timeout_seconds),
```

One-line change: wrap `self.timeout_seconds` with `float()` to guarantee the correct type.

## Context

This is a follow-up to PR #609 (`fix(mcp-scan): adapt to MCP Python SDK 2.x API changes`), which:
- Changed `timedelta(seconds=N)` → `self.timeout_seconds` (numeric)
- Changed `t.inputSchema` → `t.input_schema` (3 occurrences)

PR #609 left the value as a bare `int`. This PR adds the explicit `float()` cast for robustness.

## Verification

Successfully connected to `https://gateway.mcpservers.org/yahoo-finance/mcp` via streamable HTTP, completed MCP `initialize` + `tools/list`, and retrieved tools including `get_quote`, `search`, `get_chart`, and `quote_summary`.