### PR TITLE
fix(agent-scan): Tool.inputSchema renamed to input_schema in mcp 2.0

### DIFF
--- a/agent-scan/agent_scan/utils/mcp_tools.py
+++ b/agent-scan/agent_scan/utils/mcp_tools.py
@@ -165,11 +165,11 @@ class MCPTools:
         xml_lines = ["<mcp_tools>"]
         for t in data.tools:
             # 缓存工具 schema，用于后续参数类型转换
-            self._tools_schema[t.name] = t.inputSchema
+            self._tools_schema[t.name] = t.input_schema
 
             parameters = ''
-            for k, param in t.inputSchema['properties'].items():
-                required = 'true' if k in t.inputSchema.get("required", []) else 'false'
+            for k, param in t.input_schema['properties'].items():
+                required = 'true' if k in t.input_schema.get("required", []) else 'false'
                 param_type = param.get('type', 'string')
                 # 构建基础属性
                 base_attrs = f'name="{k}" type="{param_type}" required="{required}"'

--- a/agent-scan/pytests/test_mcp_sdk_v2.py
+++ b/agent-scan/pytests/test_mcp_sdk_v2.py
@@ -76,5 +76,53 @@ class MCP20TransportTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(_Session.instances[0].initialized)
 
 
+class _Tool:
+    """Mimics mcp 2.0 Tool: exposes input_schema (snake_case), no inputSchema."""
+
+    def __init__(self, name, description, input_schema):
+        self.name = name
+        self.description = description
+        self.input_schema = input_schema
+
+
+class _ListToolsResult:
+    def __init__(self, tools):
+        self.tools = tools
+
+
+class _FakeSession:
+    async def list_tools(self):
+        return _ListToolsResult([
+            _Tool(
+                "echo",
+                "Echo a message",
+                {
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                    "required": ["message"],
+                },
+            )
+        ])
+
+
+class MCP20ToolSchemaTests(unittest.IsolatedAsyncioTestCase):
+    async def test_describe_mcp_tools_reads_input_schema(self):
+        manager = MCPTools("https://example.test/mcp", "streamable-http")
+
+        @asynccontextmanager
+        async def fake_session(_self):
+            yield _FakeSession()
+
+        with patch.object(MCPTools, "_session", fake_session):
+            description = await manager.describe_mcp_tools()
+
+        self.assertIn("echo", description)
+        self.assertIn('name="message" type="string" required="true"', description)
+        self.assertEqual(
+            manager._tools_schema["echo"]["properties"]["message"]["type"],
+            "string",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 问题

`mcp==2.0.0` 环境下，agent-scan 连接 MCP 服务器成功（initialize / list_tools 均正常），但在遍历工具 schema 时抛出：

```
AttributeError: 'Tool' object has no attribute 'inputSchema'
```

最终表现为 Agent-Scan 任务连接 MCP 服务器失败。

## 根因

MCP Python SDK 2.0.0 将 `Tool` 模型的 `inputSchema` 字段（camelCase）改名为 `input_schema`（snake_case）。`agent_scan/utils/mcp_tools.py` 的 `describe_mcp_tools()` 仍访问 `t.inputSchema`，而 agent-scan 的 `requirements.txt` 已锁定 `mcp==2.0.0`，因此该 bug 必然触发。

mcp-scan 的同款问题已在 #609 (dc5ae7f5) 修复，agent-scan 被遗漏。

## 改动

- `agent_scan/utils/mcp_tools.py`：`describe_mcp_tools()` 内 3 处 `t.inputSchema` → `t.input_schema`
- `pytests/test_mcp_sdk_v2.py`：新增回归测试 `test_describe_mcp_tools_reads_input_schema`，用 mcp 2.0 形状的 Tool 桩（只有 `input_schema` 属性）验证 `describe_mcp_tools()` 正常读取 schema 并缓存到 `_tools_schema`；修复前该测试失败，修复后通过

## 验证

在 agent 镜像内（Python 3.12 + `mcp==2.0.0`）运行：

```
python -m unittest discover -s pytests -v
```

结果：2 个测试全部通过（新增的 schema 测试 + 原有的 streamable-http 传输层测试，无回归）。
