### PR TITLE
docs: add standalone pip CLI usage for mcp-scan and agent-scan

### DIFF
--- a/aigdocs/docs/agent-scan_openSource.md
+++ b/aigdocs/docs/agent-scan_openSource.md
@@ -170,6 +170,93 @@ targets:
 
 ![Agent 扫描报告展示](./assets/image-agentscan-report-info.png)
 
+## 独立 CLI 使用
+
+除了通过 A.I.G 平台使用外，aig-agent-scan 还可以作为独立工具通过 pip 安装使用，适用于 CI/CD 集成或本地批量审计场景。
+
+### 安装
+
+```bash
+pip install aig-agent-scan
+```
+
+> 要求 Python ≥ 3.10
+
+### 命令行使用
+
+```bash
+# 基本扫描（需准备 provider YAML 文件描述目标 Agent 接口）
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp
+
+# 保存结果到文件
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp \
+             -o result.json
+
+# 指定输出语言
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp \
+             --language en
+
+# 仅运行指定检测技能
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp \
+             --skills "data-leakage-detection,tool-abuse-detection"
+```
+
+### 命令行参数
+
+| 参数 | 说明 | 默认值 |
+| --- | --- | --- |
+| `--agent_provider` | 目标 Agent 的 provider YAML 文件路径（必填） | — |
+| `-k, --api_key` | API Key（省略时从环境变量读取） | — |
+| `-m, --model` | LLM 模型名称 | `deepseek/deepseek-v3.2-exp` |
+| `-u, --base_url` | API 基础 URL | `https://openrouter.ai/api/v1` |
+| `--repo` | 项目目录路径（可选的源代码审计） | — |
+| `-p, --prompt` | 自定义扫描提示词（可选） | — |
+| `--language` | 输出语言：`zh` / `en` | `zh` |
+| `--skills` | 逗号分隔的检测技能名称 | 全部检测技能 |
+| `--debug` | 启用调试模式 | `false` |
+| `-o, --output` | 保存扫描结果为 JSON 文件 | — |
+
+### Provider 配置
+
+`--agent_provider` 参数指向一个 YAML 文件，描述如何连接目标 Agent。示例：
+
+```yaml
+# HTTP 端点 provider
+targets:
+  - id: "http"
+    config:
+      url: "http://127.0.0.1:18081"
+      endpoint: "/chat"
+      method: "POST"
+      headers:
+        Content-Type: "application/json"
+      body:
+        message: "{{prompt}}"
+      transform_response: "reply"
+```
+
+支持的 provider 类型：`http`、`dify`、`coze`、`openai`、`anthropic`、`google`、`cohere`、`huggingface`、`replicate`、`ollama`、`localai`、`litellm`、`websocket` 等。
+
+> **注意**：对于自定义 HTTP provider，`transform_response` 字段必须填写，用于指定从响应 JSON 中提取 Agent 回复的键名（如 `reply`、`response`、`data.text` 等）。留空会导致所有响应被解析为 `None`，扫描将无法产出结果。
+
+### 环境变量配置
+
+| 变量 | 说明 | 默认值 |
+| --- | --- | --- |
+| `LLM_API_KEY` / `OPENAI_API_KEY` | LLM API Key | — |
+| `LLM_MODEL` | 默认模型 | `deepseek/deepseek-v3.2-exp` |
+| `LLM_BASE_URL` | 默认基础 URL | `https://openrouter.ai/api/v1` |
+
+更多用法详见 [aig-agent-scan README](https://github.com/Tencent/AI-Infra-Guard/tree/main/agent-scan)。
+
 ## 检测能力说明
 
 Agent 安全扫描基于红队即服务（RTaaS）驱动的 Agent 能力，将专业的安全测试经验转化为自动化检测流程，通过智能 Agent 模拟真实攻击场景，全面评估目标 Agent 的安全风险。

--- a/aigdocs/docs/agent-scan_openSource_en.md
+++ b/aigdocs/docs/agent-scan_openSource_en.md
@@ -165,6 +165,93 @@ Displays project analysis results from the information gathering phase, includin
 
 ![Agent Scan Report Info](./assets/image-agentscan-report-info.png)
 
+## Standalone CLI Usage
+
+In addition to using the A.I.G platform, aig-agent-scan can be installed as a standalone tool via pip, suitable for CI/CD integration or local batch auditing.
+
+### Installation
+
+```bash
+pip install aig-agent-scan
+```
+
+> Requires Python ≥ 3.10
+
+### Command Line Usage
+
+```bash
+# Basic scan (requires a provider YAML file describing the target Agent's API)
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp
+
+# Save result to file
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp \
+             -o result.json
+
+# Specify language
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp \
+             --language en
+
+# Run specific detection skills only
+aig-agent-scan --agent_provider providers.yaml \
+             -k sk-xxx \
+             -m deepseek-v3.2-exp \
+             --skills "data-leakage-detection,tool-abuse-detection"
+```
+
+### Command Line Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--agent_provider` | Path to the provider YAML file describing the target agent's API (required) | — |
+| `-k, --api_key` | API key (falls back to env vars if omitted) | — |
+| `-m, --model` | LLM model name | `deepseek/deepseek-v3.2-exp` |
+| `-u, --base_url` | API base URL | `https://openrouter.ai/api/v1` |
+| `--repo` | Project directory path for optional source code audit | — |
+| `-p, --prompt` | Custom scan prompt (optional) | — |
+| `--language` | Output language: `zh` / `en` | `zh` |
+| `--skills` | Comma-separated skill names | All detection skills |
+| `--debug` | Enable debug mode | `false` |
+| `-o, --output` | Save result as JSON file | — |
+
+### Provider Configuration
+
+The `--agent_provider` parameter points to a YAML file that describes how to connect to the target agent. Example:
+
+```yaml
+# HTTP endpoint provider
+targets:
+  - id: "http"
+    config:
+      url: "http://127.0.0.1:18081"
+      endpoint: "/chat"
+      method: "POST"
+      headers:
+        Content-Type: "application/json"
+      body:
+        message: "{{prompt}}"
+      transform_response: "reply"
+```
+
+Supported provider types: `http`, `dify`, `coze`, `openai`, `anthropic`, `google`, `cohere`, `huggingface`, `replicate`, `ollama`, `localai`, `litellm`, `websocket`, and more.
+
+> **Note**: For custom HTTP providers, the `transform_response` field must be filled in to specify which JSON key to extract the agent's reply from (e.g., `reply`, `response`, `data.text`). Leaving it empty will cause all responses to be parsed as `None`, resulting in zero detections.
+
+### Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `LLM_API_KEY` / `OPENAI_API_KEY` | LLM API key | — |
+| `LLM_MODEL` | Default model | `deepseek/deepseek-v3.2-exp` |
+| `LLM_BASE_URL` | Default base URL | `https://openrouter.ai/api/v1` |
+
+For more details, see the [aig-agent-scan README](https://github.com/Tencent/AI-Infra-Guard/tree/main/agent-scan).
+
 ## Detection Capabilities
 
 Agent Security Scan leverages Red Teaming as a Service (RTaaS) driven Agent capabilities, translating professional security testing experience into an automated detection process. It simulates real-world attack scenarios through intelligent Agents to comprehensively assess the security risks of the target Agent.

--- a/aigdocs/docs/mcp-scan.md
+++ b/aigdocs/docs/mcp-scan.md
@@ -74,6 +74,68 @@ A.I.G的MCP扫描能力完全由Agent驱动，检测准确性与时长取决于�
 3. 开始扫描
 ![image-mcp8](./assets/mcp8.png)
 
+## 方式四：使用 pip 一键安装扫描
+
+除了通过 A.I.G 平台使用外，aig-mcp-scan 还可以作为独立工具通过 pip 安装使用，适用于 CI/CD 集成或本地批量审计场景。
+
+### 安装
+
+```bash
+pip install aig-mcp-scan
+```
+
+> 要求 Python ≥ 3.9
+
+### 命令行使用
+
+```bash
+# 扫描本地 MCP Server 项目目录
+aig-mcp-scan --repo /path/to/your/mcp-server \
+           -m deepseek-v4-flash \
+           --language zh
+
+# 也可以作为 Python 模块调用
+python -m mcp_scan --repo /path/to/your/mcp-server
+
+# 扫描远程 MCP 服务（动态分析）
+aig-mcp-scan --server_url "http://localhost:8000/sse" \
+           -m deepseek-v4-flash
+
+# 保存扫描结果到文件
+aig-mcp-scan --repo /path/to/your/mcp-server -o result.sarif.json
+```
+
+### 命令行参数
+
+| 参数 | 说明 | 默认值 |
+| --- | --- | --- |
+| `--repo` | 要扫描的 MCP Server 项目目录路径（静态扫描必填） | — |
+| `--server_url` | 远程 MCP 服务地址（启用动态分析模式） | — |
+| `-m, --model` | LLM 模型名称 | `deepseek/deepseek-v3.2-exp` |
+| `-k, --api_key` | API Key（省略时从环境变量读取） | — |
+| `-u, --base_url` | API 基础 URL | `https://openrouter.ai/api/v1` |
+| `-p, --prompt` | 自定义扫描提示词（可选） | — |
+| `--header` | 自定义 HTTP 头（key:value），可多次使用 | `[]` |
+| `--language` | 输出语言：`zh` / `en` | `zh` |
+| `--debug` | 启用调试模式 | `false` |
+| `-o, --output` | 保存扫描结果；未开启 `--aig-mode` 时为 SARIF 2.1.0 格式，开启后为内部结构 JSON | — |
+
+### 环境变量配置
+
+也可通过环境变量或 `.env` 文件配置：
+
+| 变量 | 说明 | 默认值 |
+| --- | --- | --- |
+| `LLM_API_KEY` / `OPENAI_API_KEY` | LLM API Key | — |
+| `LLM_MODEL` | 默认模型 | `deepseek/deepseek-v3.2-exp` |
+| `LLM_BASE_URL` | 默认基础 URL | `https://openrouter.ai/api/v1` |
+
+### SARIF 输出格式
+
+CLI 模式默认输出 **SARIF 2.1.0** JSON，包含完整的 MCP01–MCP10 及 3 个补充分类规则（Name Confusion、Rug Pull、Tool Shadowing），即使未发现漏洞也会输出规则声明。SARIF 文件可直接上传至 GitHub Code Scanning、Azure DevOps、GitLab Security Dashboard 等平台。
+
+更多用法详见 [aig-mcp-scan README](https://github.com/Tencent/AI-Infra-Guard/tree/main/mcp-scan)。
+
 ## 查看扫描状态和结果
 ![image-mcp6](./assets/mcp6.png)
 ![image-mcp7](./assets/mcp7.png)

--- a/aigdocs/docs/mcp-scan_en.md
+++ b/aigdocs/docs/mcp-scan_en.md
@@ -76,6 +76,68 @@ A.I.G's MCP Server scanning capability is entirely driven by an AI agent. The ac
 3. Start Scan
 ![image-mcp8](./assets/mcp8-en.png)
 
+## Method 4: Install via pip and Scan Standalone
+
+In addition to using the A.I.G platform, aig-mcp-scan can be installed as a standalone tool via pip, suitable for CI/CD integration or local batch auditing.
+
+### Installation
+
+```bash
+pip install aig-mcp-scan
+```
+
+> Requires Python ≥ 3.9
+
+### Command Line Usage
+
+```bash
+# Scan a local MCP Server project directory
+aig-mcp-scan --repo /path/to/your/mcp-server \
+           -m deepseek-v4-flash \
+           --language en
+
+# Or invoke as a Python module
+python -m mcp_scan --repo /path/to/your/mcp-server
+
+# Scan a remote MCP service (dynamic analysis)
+aig-mcp-scan --server_url "http://localhost:8000/sse" \
+           -m deepseek-v4-flash
+
+# Save scan results to a file
+aig-mcp-scan --repo /path/to/your/mcp-server -o result.sarif.json
+```
+
+### Command Line Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--repo` | Path to the MCP Server project directory to scan (required for static scanning) | — |
+| `--server_url` | Remote MCP server URL (enables dynamic analysis mode) | — |
+| `-m, --model` | LLM model name | `deepseek/deepseek-v3.2-exp` |
+| `-k, --api_key` | API key (falls back to env vars if omitted) | — |
+| `-u, --base_url` | API base URL | `https://openrouter.ai/api/v1` |
+| `-p, --prompt` | Custom scan prompt (optional) | — |
+| `--header` | Custom HTTP header (key:value), can be used multiple times | `[]` |
+| `--language` | Output language: `zh` / `en` | `zh` |
+| `--debug` | Enable debug mode | `false` |
+| `-o, --output` | Save scan results; **SARIF 2.1.0 JSON when `--aig-mode` is off, internal-schema JSON when it's on** | — |
+
+### Environment Variables
+
+Configuration can also be provided via environment variables or a `.env` file:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `LLM_API_KEY` / `OPENAI_API_KEY` | LLM API key | — |
+| `LLM_MODEL` | Default model | `deepseek/deepseek-v3.2-exp` |
+| `LLM_BASE_URL` | Default base URL | `https://openrouter.ai/api/v1` |
+
+### SARIF Output Format
+
+CLI mode outputs **SARIF 2.1.0** JSON by default, containing the full MCP01–MCP10 plus 3 supplemental classification rules (Name Confusion, Rug Pull, Tool Shadowing). Rules are always output even if no vulnerabilities are found. SARIF files can be uploaded directly to GitHub Code Scanning, Azure DevOps, GitLab Security Dashboard, and other SARIF-aware tools.
+
+For more details, see the [aig-mcp-scan README](https://github.com/Tencent/AI-Infra-Guard/tree/main/mcp-scan).
+
 ## View Scan Status and Results
 ![image-mcp6](./assets/mcp6-en.png)![image-mcp7](./assets/mcp7-en.png)
 


### PR DESCRIPTION
## 变更说明

为 mcp-scan 和 agent-scan 补充独立 pip CLI 使用文档，与 skill-scan 已有的独立使用章节保持一致。

### 新增内容

**mcp-scan.md / mcp-scan_en.md**
- 新增「方式四：使用 pip 一键安装扫描」/ 「Method 4: Install via pip and Scan Standalone」
- 包含安装方式（`pip install aig-mcp-scan`）、命令行用法（静态扫描 + 动态远程扫描）、参数表、环境变量配置、SARIF 输出格式说明

**agent-scan_openSource.md / agent-scan_openSource_en.md**
- 新增「独立 CLI 使用」/ 「Standalone CLI Usage」
- 包含安装方式（`pip install aig-agent-scan`）、命令行用法、参数表、Provider YAML 配置示例、环境变量配置

### 背景

skill-scan 文档此前已有 pip 独立安装使用章节，本次为 mcp-scan 和 agent-scan 补齐同类内容，三个子模块文档风格统一。

参考 PR: #615