### PR TITLE
feat(agent-scan): add OrcaRouter as a first-class provider

### DIFF
--- a/agent-scan/README.md
+++ b/agent-scan/README.md
@@ -127,7 +127,7 @@ targets:
       transform_response: "reply"
 ```
 
-Supported provider types: `http`, `dify`, `coze`, `openai`, `anthropic`, `google`, `cohere`, `huggingface`, `replicate`, `ollama`, `localai`, `litellm`, `websocket`, and more.
+Supported provider types: `http`, `dify`, `coze`, `openai`, `anthropic`, `google`, `cohere`, `huggingface`, `replicate`, `ollama`, `localai`, `litellm`, `openrouter`, `orcarouter`, `websocket`, and more.
 
 #### ⚠️ `transform_response` — Critical for Custom HTTP Providers
 

--- a/agent-scan/README_zh.md
+++ b/agent-scan/README_zh.md
@@ -127,7 +127,7 @@ targets:
       transform_response: "reply"
 ```
 
-支持的 provider 类型：`http`、`dify`、`coze`、`openai`、`anthropic`、`google`、`cohere`、`huggingface`、`replicate`、`ollama`、`localai`、`litellm`、`websocket` 等。
+支持的 provider 类型：`http`、`dify`、`coze`、`openai`、`anthropic`、`google`、`cohere`、`huggingface`、`replicate`、`ollama`、`localai`、`litellm`、`openrouter`、`orcarouter`、`websocket` 等。
 
 #### ⚠️ `transform_response` — 自定义 HTTP Provider 的关键配置
 

--- a/agent-scan/agent_scan/core/agent_adapter/adapter.py
+++ b/agent-scan/agent_scan/core/agent_adapter/adapter.py
@@ -208,7 +208,7 @@ class AIProviderClient:
     - Mistral AI, Groq, Ollama
     - AWS Bedrock
     - Cohere, Deepseek, Perplexity
-    - OpenRouter, Together AI, Fireworks
+    - OpenRouter, OrcaRouter, Together AI, Fireworks
     - Custom script providers
     
     Usage:

--- a/agent-scan/agent_scan/core/agent_adapter/providers.yaml
+++ b/agent-scan/agent_scan/core/agent_adapter/providers.yaml
@@ -116,7 +116,17 @@ providers:
         models:
           - openai/gpt-4o
           - anthropic/claude-3-opus
-      
+
+      orcarouter:
+        env_keys: ["ORCAROUTER_API_KEY"]
+        base_url: "https://api.orcarouter.ai/v1"
+        endpoint: "/chat/completions"
+        default_model: "orcarouter/fusion"
+        models:
+          - orcarouter/fusion
+          - orcarouter/fusion-flash
+          - orcarouter/fusion-mini
+
       togetherai:
         env_keys: ["TOGETHER_API_KEY", "TOGETHERAI_API_KEY"]
         base_url: "https://api.together.xyz/v1"

--- a/agent-scan/providers.yaml
+++ b/agent-scan/providers.yaml
@@ -78,7 +78,17 @@ providers:
         models:
           - openai/gpt-4o
           - anthropic/claude-3-opus
-      
+
+      orcarouter:
+        env_keys: ["ORCAROUTER_API_KEY"]
+        base_url: "https://api.orcarouter.ai/v1"
+        endpoint: "/chat/completions"
+        default_model: "orcarouter/fusion"
+        models:
+          - orcarouter/fusion
+          - orcarouter/fusion-flash
+          - orcarouter/fusion-mini
+
       togetherai:
         env_keys: ["TOGETHER_API_KEY", "TOGETHERAI_API_KEY"]
         base_url: "https://api.together.xyz/v1"

--- a/agent-scan/pytests/test_orcarouter_provider.py
+++ b/agent-scan/pytests/test_orcarouter_provider.py
@@ -1,0 +1,20 @@
+"""Smoke tests for the orcarouter provider registration.
+
+The orcarouter entry mirrors the existing openrouter entry in the provider
+registries. These tests make sure the registry entry resolves to the expected
+base_url/endpoint so a wrong default string can't surface as a 404 at scan time.
+"""
+
+from agent_scan.core.agent_adapter.adapter import ProviderConfigLoader
+
+
+def test_orcarouter_provider_resolves():
+    cfg = ProviderConfigLoader().get_provider_config("orcarouter")
+    assert cfg is not None, "orcarouter not found in providers.yaml registry"
+    assert cfg["base_url"] == "https://api.orcarouter.ai/v1"
+    assert cfg["endpoint"] == "/chat/completions"
+    assert cfg["default_model"] == "orcarouter/fusion"
+    assert "ORCAROUTER_API_KEY" in cfg["env_keys"]
+    assert "orcarouter/fusion" in cfg["models"]
+    assert "orcarouter/fusion-flash" in cfg["models"]
+    assert "orcarouter/fusion-mini" in cfg["models"]


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class provider in `agent-scan`, mirroring the existing `openrouter` entry in the provider registries. Users of A.I.G's agent security scanner can now select OrcaRouter by name and get a working endpoint out of the box, instead of treating it as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means agent-scan users can use that stack directly.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Changes:
- `agent-scan/providers.yaml` and `agent-scan/agent_scan/core/agent_adapter/providers.yaml`: new `orcarouter` provider under `openai_compatible`, with `ORCAROUTER_API_KEY`, `https://api.orcarouter.ai/v1`, and `orcarouter/fusion*` default models.
- `agent-scan/agent_scan/core/agent_adapter/adapter.py`: provider docstring updated.
- `agent-scan/README.md` / `README_zh.md`: provider type list updated.

Validation:
- `pytest pytests/` — 2 passed.
- Live-tested the new provider path through `AIProviderClient` with a real key: `success: True, Status: 200`, response `1`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
