### PR TITLE
fix(mcp-scan): 空输出的扫描被评分为满分形成假阴性，增加完整性标记

### DIFF
--- a/mcp-scan/mcp_scan/agent/agent.py
+++ b/mcp-scan/mcp_scan/agent/agent.py
@@ -307,6 +307,19 @@ class ScanPipeline:
         return result
 
 
+def _warn_if_scan_incomplete(raw_output: str, vuln_results: list, result_meta: dict) -> None:
+    """审计原始输出与漏洞列表均为空时，标记扫描可能不完整。
+
+    典型场景：上下文压缩丢失已积累的分析状态后，Agent 直接以空输出结束，
+    空结果会被 calc_mcp_score 评为 100 分，形成"未发现漏洞"的假阴性结论。
+    此处显式打标记，避免空报告被误读为安全。
+    """
+    if vuln_results or (raw_output or "").strip():
+        return
+    logger.warning("扫描可能不完整")
+    result_meta["scanNote"] = "possibly-incomplete"
+
+
 class Agent:
     """aig-mcp-scan's main Agent, entry point for the scan pipeline.
 
@@ -452,6 +465,7 @@ markdown格式返回
                 "results": vuln_results,
             }
         )
+        _warn_if_scan_incomplete(audit_result, vuln_results, result_meta)
         mcpLogger.result_update(result_meta)
         return result_meta
 
@@ -575,6 +589,7 @@ markdown格式返回
                 "results": vuln_results,
             }
         )
+        _warn_if_scan_incomplete(vuln_review, vuln_results, result_meta)
         mcpLogger.result_update(result_meta)
         return result_meta
 

--- a/mcp-scan/mcp_scan/agent/agent.py
+++ b/mcp-scan/mcp_scan/agent/agent.py
@@ -308,15 +308,23 @@ class ScanPipeline:
 
 
 def _warn_if_scan_incomplete(raw_output: str, vuln_results: list, result_meta: dict) -> None:
-    """审计原始输出与漏洞列表均为空时，标记扫描可能不完整。
+    """Mark the scan as possibly-incomplete when both the raw audit output and the
+    extracted vulnerability list are empty.
 
-    典型场景：上下文压缩丢失已积累的分析状态后，Agent 直接以空输出结束，
-    空结果会被 calc_mcp_score 评为 100 分，形成"未发现漏洞"的假阴性结论。
-    此处显式打标记，避免空报告被误读为安全。
+    Typical scenario: after context compaction drops the accumulated analysis
+    state, the agent finishes with empty output, and calc_mcp_score([]) turns
+    that into a clean "score: 100, no vulnerabilities found" report. Setting an
+    explicit marker keeps empty reports from being misread as "safe".
     """
     if vuln_results or (raw_output or "").strip():
+        # Set scanNote explicitly on complete scans too, so consumers can rely
+        # on the key always being present instead of inferring absence == complete.
+        result_meta.setdefault("scanNote", "complete")
         return
-    logger.warning("扫描可能不完整")
+    logger.warning(
+        "Scan may be incomplete: audit produced no output; "
+        "do not interpret empty results as 'no vulnerabilities found'"
+    )
     result_meta["scanNote"] = "possibly-incomplete"
 
 

--- a/mcp-scan/mcp_scan/utils/sarif_formatter.py
+++ b/mcp-scan/mcp_scan/utils/sarif_formatter.py
@@ -331,6 +331,9 @@ def to_sarif(result_meta: dict[str, Any], tool_version: str = "0.0.0", language:
                     "llm": result_meta.get("llm"),
                     "startTime": result_meta.get("start_time"),
                     "endTime": result_meta.get("end_time"),
+                    # 扫描可能不完整时（如上下文压缩丢失状态导致空输出）显式标记，
+                    # 避免空报告被消费方误读为"未发现漏洞"。
+                    "scanNote": result_meta.get("scanNote", "complete"),
                 },
             }
         ],

--- a/mcp-scan/pytests/test_scan_completeness.py
+++ b/mcp-scan/pytests/test_scan_completeness.py
@@ -32,14 +32,15 @@ from mcp_scan.agent.agent import _warn_if_scan_incomplete
 
 
 def _capture_warnings():
-    """loguru 不走 stdlib logging（caplog 抓不到），用自定义 sink 捕获 warning 消息"""
+    """loguru does not propagate to stdlib logging (caplog can't capture it);
+    use a custom sink to collect warning messages."""
     messages = []
     handler_id = logger.add(messages.append, level="WARNING")
     return messages, handler_id
 
 
 def test_marks_scan_incomplete_when_output_and_results_are_empty():
-    """双空（无输出且无漏洞）→ 标记 possibly-incomplete 并记录 warning"""
+    """Both empty (no output, no findings) -> scanNote=possibly-incomplete + warning logged."""
     messages, handler_id = _capture_warnings()
     try:
         result_meta = {}
@@ -47,11 +48,11 @@ def test_marks_scan_incomplete_when_output_and_results_are_empty():
     finally:
         logger.remove(handler_id)
     assert result_meta["scanNote"] == "possibly-incomplete"
-    assert any("扫描可能不完整" in m for m in messages)
+    assert any("Scan may be incomplete" in m for m in messages)
 
 
 def test_marks_scan_incomplete_for_none_or_whitespace_output():
-    """None 与纯空白输出同样视为空输出"""
+    """None and whitespace-only output are treated as empty."""
     result_meta = {}
     _warn_if_scan_incomplete(None, [], result_meta)
     assert result_meta["scanNote"] == "possibly-incomplete"
@@ -61,16 +62,23 @@ def test_marks_scan_incomplete_for_none_or_whitespace_output():
     assert result_meta["scanNote"] == "possibly-incomplete"
 
 
-def test_does_not_mark_when_output_is_present():
-    """有正常文字输出（无漏洞的正常审计）→ 不标记"""
+def test_sets_complete_when_output_is_present():
+    """Text output present (normal clean audit) -> scanNote=complete, key always present."""
     result_meta = {}
-    _warn_if_scan_incomplete("审计完成，未发现漏洞。", [], result_meta)
-    assert "scanNote" not in result_meta
+    _warn_if_scan_incomplete("Audit finished, no vulnerabilities found.", [], result_meta)
+    assert result_meta["scanNote"] == "complete"
 
 
-def test_does_not_mark_when_results_are_present():
-    """有漏洞发现 → 不标记"""
+def test_sets_complete_when_results_are_present():
+    """Findings present -> scanNote=complete, key always present."""
     result_meta = {}
     vulns = [{"title": "Command Injection", "risk_type": "CommandInjection"}]
     _warn_if_scan_incomplete("", vulns, result_meta)
-    assert "scanNote" not in result_meta
+    assert result_meta["scanNote"] == "complete"
+
+
+def test_setdefault_does_not_overwrite_existing_scan_note():
+    """An existing scanNote value is not overwritten (setdefault semantics)."""
+    result_meta = {"scanNote": "custom-note"}
+    _warn_if_scan_incomplete("some output", [], result_meta)
+    assert result_meta["scanNote"] == "custom-note"

--- a/mcp-scan/pytests/test_scan_completeness.py
+++ b/mcp-scan/pytests/test_scan_completeness.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2024-2026 Tencent Zhuque Lab. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requirement: Any integration or derivative work must explicitly attribute
+# Tencent Zhuque Lab (https://github.com/Tencent/AI-Infra-Guard) in its
+# documentation or user interface, as detailed in the NOTICE file.
+
+"""Tests for the scan completeness check.
+
+When the audit agent finishes with empty output (e.g. context compaction
+loses analysis state on large projects), the empty result flows into
+``calc_mcp_score([])`` which unconditionally returns 100 — publishing a
+mechanically failed scan as a clean report. ``_warn_if_scan_incomplete``
+marks that case so consumers can distinguish "no vulnerabilities found"
+from "scan did not complete".
+"""
+
+from loguru import logger
+
+from mcp_scan.agent.agent import _warn_if_scan_incomplete
+
+
+def _capture_warnings():
+    """loguru 不走 stdlib logging（caplog 抓不到），用自定义 sink 捕获 warning 消息"""
+    messages = []
+    handler_id = logger.add(messages.append, level="WARNING")
+    return messages, handler_id
+
+
+def test_marks_scan_incomplete_when_output_and_results_are_empty():
+    """双空（无输出且无漏洞）→ 标记 possibly-incomplete 并记录 warning"""
+    messages, handler_id = _capture_warnings()
+    try:
+        result_meta = {}
+        _warn_if_scan_incomplete("", [], result_meta)
+    finally:
+        logger.remove(handler_id)
+    assert result_meta["scanNote"] == "possibly-incomplete"
+    assert any("扫描可能不完整" in m for m in messages)
+
+
+def test_marks_scan_incomplete_for_none_or_whitespace_output():
+    """None 与纯空白输出同样视为空输出"""
+    result_meta = {}
+    _warn_if_scan_incomplete(None, [], result_meta)
+    assert result_meta["scanNote"] == "possibly-incomplete"
+
+    result_meta = {}
+    _warn_if_scan_incomplete("   \n\t  ", [], result_meta)
+    assert result_meta["scanNote"] == "possibly-incomplete"
+
+
+def test_does_not_mark_when_output_is_present():
+    """有正常文字输出（无漏洞的正常审计）→ 不标记"""
+    result_meta = {}
+    _warn_if_scan_incomplete("审计完成，未发现漏洞。", [], result_meta)
+    assert "scanNote" not in result_meta
+
+
+def test_does_not_mark_when_results_are_present():
+    """有漏洞发现 → 不标记"""
+    result_meta = {}
+    vulns = [{"title": "Command Injection", "risk_type": "CommandInjection"}]
+    _warn_if_scan_incomplete("", vulns, result_meta)
+    assert "scanNote" not in result_meta


### PR DESCRIPTION
在测试扫描 MCP Server 项目时发现：当项目中存在超大源文件（单个文件 100KB+）时，扫描可能以成功状态结束，但结果是 0 个发现 + 满分 100，而实际上审计过程在中途已经失效。这构成一个假阴性盲区：恶意 MCP Server可以故意在项目里塞入超大文件，干扰审计 Agent 的工作上下文，从而变相绕过代码审计。
检查发现大项目会让审计 Agent 的上下文增长到触发历史压缩。压缩后 Agent 可能丢失已积累的分析状态，以空输出结束。空输出流入 calc_mcp_score([])，该函数对空列表无条件返回 100
修复：在两个结果汇总点增加检查：当审计原始输出与提取的漏洞列表均为空时，将扫描标记为不完整：
  - 记录 warning 日志（扫描可能不完整）
  - 结果元数据设置 `scanNote: "possibly-incomplete"`
  - SARIF 输出在 `properties` 中携带 scanNote

  触发问题的历史压缩目前不保留已发现的安全发现，还可以在 prompt 层面进一步缓解：例如在压缩模板中增加专门的安全发现段落，让总结模型在压缩时携带已确认/疑似的发现。