### PR TITLE
fix(parser): keep the pre-release label when normalizing versions

### DIFF
--- a/common/fingerprints/parser/synax.go
+++ b/common/fingerprints/parser/synax.go
@@ -282,8 +282,10 @@ func (r *Rule) Eval(config *Config) bool {
 	return evalExpr(r.root, config)
 }
 
-// preReleaseSuffixRe 匹配夹在两个数字之间的字母段，例如 "3.11.0rc2" 中的 "rc"。
-var preReleaseSuffixRe = regexp.MustCompile(`([0-9])[A-Za-z]+([0-9])`)
+// preReleaseSuffixRe 匹配结尾处跟在数字后的预发布标签，可带可选的连字符与数字，
+// 例如 "3.11.0rc2" 中的 "rc2"、"3.11.0rc" 中的 "rc"、"1.2.3-rc1" 中的 "rc1"。
+// 分隔符不含 "."，因为 "1.2.3.RELEASE" 之类的写法表示正式版而非预发布版。
+var preReleaseSuffixRe = regexp.MustCompile(`([0-9])-?([A-Za-z]+)([0-9]*)$`)
 
 // versionCheck 版本号格式标准化处理
 // 输入版本号字符串，返回处理后的版本号字符串
@@ -296,11 +298,20 @@ func versionCheck(version string) string {
 	// 正则替换所有单词
 	compile := regexp.MustCompile(`[A-Za-z]+`)
 	if compile.MatchString(version) {
-		// 字母位于两个数字之间时（如 PEP 440 的 "3.11.0rc2"）先改写为预发布号，
-		// 否则直接删除字母会把两侧数字粘连成 "3.11.02"，即 3.11.2。
-		newVersion := preReleaseSuffixRe.ReplaceAllString(version, "$1-$2")
-		newVersion = regexp.MustCompile(`\.[A-Za-z]+`).ReplaceAllString(newVersion, ".0")
+		// 先把结尾的预发布标签整段取出（如 PEP 440 的 "3.11.0rc2"、"3.11.0rc"）。
+		// 直接删除字母有两种错法：把两侧数字粘连成 "3.11.02"（即 3.11.2），
+		// 或者丢掉没有尾随数字的标签，让 "3.11.0rc" 等同于正式版 "3.11.0"。
+		pre := ""
+		if m := preReleaseSuffixRe.FindStringSubmatch(version); m != nil {
+			pre = m[2] + m[3]
+			version = preReleaseSuffixRe.ReplaceAllString(version, "$1")
+		}
+		newVersion := regexp.MustCompile(`\.[A-Za-z]+`).ReplaceAllString(version, ".0")
 		newVersion = compile.ReplaceAllString(newVersion, "")
+		// 保留标签本身，"3.11.0-alpha" 才能排在 "3.11.0-rc" 之前。
+		if pre != "" {
+			newVersion += "-" + pre
+		}
 		//gologger.Debugf("version:%s=>%s", version, newVersion)
 		version = newVersion
 	}

--- a/common/fingerprints/parser/synax_test.go
+++ b/common/fingerprints/parser/synax_test.go
@@ -18,7 +18,11 @@
 
 package parser
 
-import "testing"
+import (
+	"testing"
+
+	vv "github.com/hashicorp/go-version"
+)
 
 func TestTransFormExp(t *testing.T) {
 	s := "header=\"realm=\\\"Comtrend Gigabit 802.11n Router\" || body=\"Comtrend Gigabit 802.11n Router\""
@@ -151,27 +155,75 @@ func TestEval(t *testing.T) {
 	}
 }
 
-// TestVersionCheckPreRelease 覆盖 PEP 440 风格的预发布版本号，
-// 例如 "3.11.0rc2"：直接删除字母会把两侧数字粘连成 "3.11.02"（即 3.11.2）。
+// TestVersionCheckPreRelease 覆盖 PEP 440 风格的预发布版本号。
+// 直接删除字母有两种错法：把两侧数字粘连成 "3.11.02"（即 3.11.2），
+// 或者丢掉没有尾随数字的标签，让 "3.11.0rc" 等同于正式版 "3.11.0"。
 func TestVersionCheckPreRelease(t *testing.T) {
 	for _, c := range []struct {
 		version string
 		want    string
 	}{
-		{"3.11.0rc2", "3.11.0-2"},
-		{"0.6.0rc1", "0.6.0-1"},
-		{"1.2.3b1", "1.2.3-1"},
+		// 带数字后缀的标签
+		{"3.11.0rc2", "3.11.0-rc2"},
+		{"0.6.0rc1", "0.6.0-rc1"},
+		{"1.2.3b1", "1.2.3-b1"},
+		{"3.11.0a1", "3.11.0-a1"},
+		// 不带数字后缀的标签
+		{"3.11.0rc", "3.11.0-rc"},
+		{"3.11.0alpha", "3.11.0-alpha"},
+		{"3.11.0beta", "3.11.0-beta"},
+		{"1.2.3b", "1.2.3-b"},
+		// 已经带连字符的写法
+		{"1.2.3-rc1", "1.2.3-rc1"},
+		{"1.2.3-rc", "1.2.3-rc"},
 		// 未被字母分隔的数字保持原样
 		{"1.2.3", "1.2.3"},
 		{"v1.2.3", "1.2.3"},
-		{"1.2.3b", "1.2.3"},
-		{"1.2.3-rc1", "1.2.3-1"},
+		{"3.11.0", "3.11.0"},
+		// ".RELEASE" 之类表示正式版，不能当作预发布标签
 		{"1.2.3.RELEASE", "1.2.3.0"},
 		{"latest", "999"},
 		{"", "0"},
 	} {
 		if got := versionCheck(c.version); got != c.want {
 			t.Fatalf("versionCheck(%q) = %q, want %q", c.version, got, c.want)
+		}
+	}
+}
+
+// TestVersionCheckPreReleaseOrdering 标准化后的版本号必须能被解析，
+// 并且预发布版本要排在同名正式版本之前、标签之间也要保持先后顺序。
+func TestVersionCheckPreReleaseOrdering(t *testing.T) {
+	for _, c := range []struct {
+		lower string
+		upper string
+	}{
+		// 预发布版本排在正式版本之前
+		{"3.11.0rc", "3.11.0"},
+		{"3.11.0rc2", "3.11.0"},
+		{"3.11.0alpha", "3.11.0"},
+		{"3.11.0beta", "3.11.0"},
+		// 也排在下一个正式版本之前
+		{"3.11.0rc", "3.11.1"},
+		{"3.11.0", "3.11.1"},
+		// 标签之间的顺序：alpha < beta < rc
+		{"3.11.0alpha", "3.11.0beta"},
+		{"3.11.0beta", "3.11.0rc"},
+		{"3.11.0a1", "3.11.0rc1"},
+		// 同一标签内按数字递增
+		{"3.11.0rc1", "3.11.0rc2"},
+	} {
+		lower, err := vv.NewVersion(versionCheck(c.lower))
+		if err != nil {
+			t.Fatalf("versionCheck(%q) = %q, 无法解析: %v", c.lower, versionCheck(c.lower), err)
+		}
+		upper, err := vv.NewVersion(versionCheck(c.upper))
+		if err != nil {
+			t.Fatalf("versionCheck(%q) = %q, 无法解析: %v", c.upper, versionCheck(c.upper), err)
+		}
+		if !lower.LessThan(upper) {
+			t.Fatalf("versionCheck(%q)=%q 应小于 versionCheck(%q)=%q",
+				c.lower, lower, c.upper, upper)
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #588, as invited there. That PR fixed the digit-splicing case and deliberately left the bare suffix out of scope; this handles it.

> **Stacked on #588.** It branches from that PR's head, so it currently shows both commits. Once #588 merges this reduces to the single commit `fix(parser): keep the pre-release label when normalizing versions`. Both PRs touch the same two files. Please merge #588 first.

Addresses [the issue behind #588](https://github.com/Tencent/AI-Infra-Guard/pull/588).

## The bug

`versionCheck` strips every letter from a version string. #588 stopped `3.11.0rc2` from collapsing into `3.11.02` (= 3.11.2) by rewriting a letter run *between two digits* as a pre-release separator. A label with no trailing digit never matches `([0-9])[A-Za-z]+([0-9])`, so it still falls through to the letter-stripping step:

```
versionCheck("3.11.0rc")    => "3.11.0"
versionCheck("3.11.0alpha") => "3.11.0"
versionCheck("3.11.0beta")  => "3.11.0"
```

A release candidate becomes indistinguishable from its own release. An advisory rule of `version < "3.11.0"` therefore reports a target running `3.11.0rc` as **unaffected** — a false negative on exactly the pre-release builds most likely to still carry the bug.

## The fix

As you noted, widening the match to make the trailing digits optional would emit a dangling `3.11.0-`. Instead the label is lifted out before the letters are stripped, then re-appended:

```go
var preReleaseSuffixRe = regexp.MustCompile(`([0-9])-?([A-Za-z]+)([0-9]*)$`)

pre := ""
if m := preReleaseSuffixRe.FindStringSubmatch(version); m != nil {
    pre = m[2] + m[3]
    version = preReleaseSuffixRe.ReplaceAllString(version, "$1")
}
// ... existing normalization ...
if pre != "" {
    newVersion += "-" + pre
}
```

Keeping the label itself, rather than only its number, also fixes ordering **between** labels — something the previous form could not express, since `3.11.0a1` and `3.11.0rc1` both normalized to `3.11.0-1` and compared equal:

```
3.11.0-alpha < 3.11.0-beta < 3.11.0-rc < 3.11.0 < 3.11.1
3.11.0-a1 < 3.11.0-rc1
```

Two deliberate limits on the match:

- **The separator may be `-` but not `.`**, so `1.2.3.RELEASE` keeps normalizing to `1.2.3.0`. That spelling denotes a *final* release; treating it as a pre-release would wrongly sort it before `1.2.3`.
- **The match is anchored at the end**, so only a trailing label is treated as a pre-release.

## One behaviour change to flag

This changes output for versions #588 already handled:

| input | #588 | this PR |
|---|---|---|
| `3.11.0rc2` | `3.11.0-2` | `3.11.0-rc2` |
| `1.2.3b1` | `1.2.3-1` | `1.2.3-b1` |
| `1.2.3-rc1` | `1.2.3-1` | `1.2.3-rc1` |

Ordering relative to the release is unchanged in every case — the label is simply preserved rather than discarded. The existing expectations are updated and kept as regression guards, per your request. This also fixes `1.2.3-rc`, which previously normalized to the degenerate `1.2.3-`.

## Tests

As requested, the bare-suffix cases (`rc`, `alpha`, `beta`) plus the existing digit-suffixed cases are all present as regression guards, with ordering assertions against `3.11.0` and `3.11.1`:

- `TestVersionCheckPreRelease` — value table, extended with bare-suffix labels, the already-hyphenated spellings, and the `.RELEASE` guard.
- `TestVersionCheckPreReleaseOrdering` — new. Asserts every normalized pre-release parses under `hashicorp/go-version` and sorts before `3.11.0` and `3.11.1`, including `alpha < beta < rc`.
- `TestAdvisoryEvalPreRelease` — unchanged from #588, still passing.

All pass, along with `go vet` and `gofmt`.

One note on how I verified: the full module's dependency download kept timing out on this machine, so I ran `synax.go` and `synax_test.go` in an isolated module with only `hashicorp/go-version` and a stubbed `gologger` (which `versionCheck` does not touch). Every test in the file passes there, and I separately cross-checked the value and ordering tables against the real `hashicorp/go-version`. CI will be the first run against the full tree.
