### PR TITLE
fix(prompt-eval): rate-limit aware backoff, circuit breaker and process-group termination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ uploads
 .venv
 __pycache__
 venv
-tests
+# 仅忽略根目录下的临时 tests 目录，子项目（如 AIG-PromptSecurity/tests）的单测正常跟踪
+/tests
 
 # OpenClaw internal workspace file
 openclaw.md

--- a/AIG-PromptSecurity/README.md
+++ b/AIG-PromptSecurity/README.md
@@ -37,6 +37,11 @@ python cli_run.py \
 > - OpenAI official API example: `--model "gpt-3.5-turbo" --base_url "https://api.openai.com/v1"`  
 > - Custom API endpoint example: `--model "qwen-turbo" --base_url "https://your-api-endpoint.com/v1"`
 
+### Rate Limiting & Platform Notes
+
+- When the target model returns rate-limit errors (HTTP 429 / quota messages), the client backs off exponentially (8s/16s/32s, capped at 60s; server `Retry-After` honored when present) instead of hammering the endpoint. After 3 consecutive rate-limit failures the remaining test cases are skipped (circuit breaker) to avoid burning your quota. Lower `--max_concurrent` if this happens frequently.
+- Stopping an evaluation task terminates the whole subprocess group on Linux/macOS. On Windows, stopping only terminates the direct child process, so spawned Python workers may keep running briefly until their in-flight requests drain; prefer Linux/macOS (or Docker) when running large evaluations.
+
 ### Dataset Management
 
 **1. Default Datasets**

--- a/AIG-PromptSecurity/cli/model_utils/openailike.py
+++ b/AIG-PromptSecurity/cli/model_utils/openailike.py
@@ -21,10 +21,35 @@ import asyncio
 from openai import OpenAI, AsyncOpenAI
 from .base import BaseLLM
 
+# 限流相关错误关键字（不依赖 openai 具体异常类型，兼容各类 OpenAI 兼容网关）
+RATE_LIMIT_MARKERS = ("rate limit", "rate_limit", "429", "quota", "too many requests", "qps", "qpm")
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """判断异常是否为限流/配额类错误（含 429 状态码与常见限流文案）"""
+    msg = str(exc).lower()
+    return any(marker in msg for marker in RATE_LIMIT_MARKERS)
+
+
+def _retry_after_seconds(exc: Exception, default: float) -> float:
+    """从异常中提取 Retry-After 提示值，失败时返回默认值"""
+    try:
+        retry_after = getattr(exc, "retry_after", None)
+        if retry_after:
+            return float(retry_after)
+    except Exception:
+        pass
+    return default
+
+
 class OpenaiAlikeModel(BaseLLM):
     """自定义模型，用于支持OpenAI API Alike Model"""
-    max_trial = 3 
-    base_wait_seconds = 0.5
+    max_trial = 5
+    base_wait_seconds = 1.0
+    max_wait_seconds = 60.0
+    # 限流专用退避：QPM 窗口通常为 60s，短退避会在窗口内反复撞墙浪费配额，
+    # 故限流场景以 8s 起步并指数递增（8/16/32/60），普通错误仍用 base_wait_seconds
+    rate_limit_base_wait_seconds = 8.0
 
     def __init__(self, model_name: str, base_url: str, api_key: str, max_concurrent: int, *args, **kwargs):
         super().__init__(model_name, base_url, api_key, max_concurrent, *args, **kwargs)
@@ -91,9 +116,23 @@ class OpenaiAlikeModel(BaseLLM):
                     raise ValueError("The response is not a string")
                 elif not content:
                     raise ValueError("The response is empty")
+                self._consecutive_rate_limit_failures = 0
                 return content
             except Exception as e:
-                wait_time = self.base_wait_seconds * (2 ** i)
+                if _is_rate_limit_error(e):
+                    self._consecutive_rate_limit_failures = getattr(
+                        self, "_consecutive_rate_limit_failures", 0
+                    ) + 1
+                    fallback = max(
+                        self.rate_limit_base_wait_seconds,
+                        self.base_wait_seconds,
+                    ) * (2 ** min(i, 2))
+                    wait_time = min(
+                        _retry_after_seconds(e, fallback),
+                        self.max_wait_seconds,
+                    )
+                else:
+                    wait_time = self.base_wait_seconds * (2 ** i)
                 time.sleep(wait_time)
         return ""
     
@@ -118,9 +157,23 @@ class OpenaiAlikeModel(BaseLLM):
                         raise ValueError("The response is not a string")
                     elif not content:
                         raise ValueError("The response is empty")
+                    self._consecutive_rate_limit_failures = 0
                     return content
                 except Exception as e:
-                    wait_time = self.base_wait_seconds * (2 ** i)
+                    if _is_rate_limit_error(e):
+                        self._consecutive_rate_limit_failures = getattr(
+                            self, "_consecutive_rate_limit_failures", 0
+                        ) + 1
+                        fallback = max(
+                            self.rate_limit_base_wait_seconds,
+                            self.base_wait_seconds,
+                        ) * (2 ** min(i, 2))
+                        wait_time = min(
+                            _retry_after_seconds(e, fallback),
+                            self.max_wait_seconds,
+                        )
+                    else:
+                        wait_time = self.base_wait_seconds * (2 ** i)
                     await asyncio.sleep(wait_time)
             return ""
     

--- a/AIG-PromptSecurity/cli/model_utils/openailike.py
+++ b/AIG-PromptSecurity/cli/model_utils/openailike.py
@@ -18,27 +18,86 @@
 
 import time
 import asyncio
+import threading
 from openai import OpenAI, AsyncOpenAI
 from .base import BaseLLM
 
 # 限流相关错误关键字（不依赖 openai 具体异常类型，兼容各类 OpenAI 兼容网关）
-RATE_LIMIT_MARKERS = ("rate limit", "rate_limit", "429", "quota", "too many requests", "qps", "qpm")
+RATE_LIMIT_MARKERS = (
+    "rate limit",
+    "rate_limit",
+    "ratelimit",
+    "too many requests",
+    "quota",
+    "requests per minute",
+    "requests per second",
+    "status code: 429",
+    "error code: 429",
+    "code 429",
+    "http 429",
+)
 
 
 def _is_rate_limit_error(exc: Exception) -> bool:
-    """判断异常是否为限流/配额类错误（含 429 状态码与常见限流文案）"""
+    """判断异常是否为限流/配额类错误（含 429 状态码与常见限流文案）
+
+    注意：刻意不做裸子串 "429" 匹配，避免把恰好含 429 的请求 ID / 错误码误判为限流。
+    """
     msg = str(exc).lower()
-    return any(marker in msg for marker in RATE_LIMIT_MARKERS)
+    if any(marker in msg for marker in RATE_LIMIT_MARKERS):
+        return True
+    # 独立数字 429（前后是词边界以外的字符），兼容 "429 Too Many Requests" 这类文案；
+    # (?<![0-9a-z_]) 排除 req_429ab3c / 4290ms 这类数字串中的 429
+    import re
+
+    return bool(re.search(r"(?<![0-9a-z_])429(?![0-9a-z_])", msg))
 
 
 def _retry_after_seconds(exc: Exception, default: float) -> float:
-    """从异常中提取 Retry-After 提示值，失败时返回默认值"""
+    """从异常中提取服务端建议的重试等待秒数，取不到时返回 default
+
+    openai SDK 1.x/3.x 会把原始响应放在异常的 `response` 属性上
+    （APIStatusError 系），`Retry-After` 位于 `exc.response.headers`；
+    部分网关会把建议等待值放在异常 `retry_after` 属性或消息文本里，一并兼容。
+    """
+    # 1) openai.APIStatusError: exc.response.headers["retry-after"]
+    response = getattr(exc, "response", None)
+    if response is not None:
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            lowered = {}
+            try:
+                for key, value in headers.items():
+                    lowered[str(key).lower()] = value
+            except Exception:
+                lowered = {}
+            for key in ("retry-after", "retry-after-ms", "x-ratelimit-reset-requests"):
+                raw = lowered.get(key)
+                if raw is None:
+                    continue
+                try:
+                    value = float(raw)
+                    if key == "retry-after-ms":
+                        value /= 1000.0
+                    if 0 < value <= 600:
+                        return value
+                except (TypeError, ValueError):
+                    continue
+    # 2) 异常自带 retry_after 属性（部分网关/SDK 行为）
     try:
         retry_after = getattr(exc, "retry_after", None)
         if retry_after:
             return float(retry_after)
     except Exception:
         pass
+    # 3) 消息文本中的 "retry after N seconds" 提示
+    import re
+
+    m = re.search(r"retry\s+(?:after|in)\s+(\d+(?:\.\d+)?)", str(exc), re.IGNORECASE)
+    if m:
+        value = float(m.group(1))
+        if 0 < value <= 600:
+            return value
     return default
 
 
@@ -53,7 +112,37 @@ class OpenaiAlikeModel(BaseLLM):
 
     def __init__(self, model_name: str, base_url: str, api_key: str, max_concurrent: int, *args, **kwargs):
         super().__init__(model_name, base_url, api_key, max_concurrent, *args, **kwargs)
+        # 连续限流失败计数：与 RedTeamer 熔断器共享（后者通过 model_callback.__self__ 读取），
+        # 多线程/协程并发递增时用锁保护；属性显式初始化，绕过 __init__ 构造的实例则惰性创建
+        self._consecutive_rate_limit_failures = 0
+        self._rate_limit_lock = threading.Lock()
         self.load_model()
+
+    def _get_rate_limit_lock(self) -> threading.Lock:
+        """获取计数器锁（绕过 __init__ 构造的实例上惰性创建）"""
+        lock = getattr(self, "_rate_limit_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._rate_limit_lock = lock
+        return lock
+
+    def note_rate_limit_failure(self):
+        """记录一次限流失败（供熔断器与重试逻辑共同递增，线程安全）"""
+        with self._get_rate_limit_lock():
+            self._consecutive_rate_limit_failures = getattr(
+                self, "_consecutive_rate_limit_failures", 0
+            ) + 1
+            return self._consecutive_rate_limit_failures
+
+    def get_consecutive_rate_limit_failures(self) -> int:
+        """读取连续限流失败次数（供 RedTeamer 熔断器判断）"""
+        with self._get_rate_limit_lock():
+            return getattr(self, "_consecutive_rate_limit_failures", 0)
+
+    def reset_rate_limit_failures(self):
+        """成功响应后清零连续限流失败计数"""
+        with self._get_rate_limit_lock():
+            self._consecutive_rate_limit_failures = 0
     
     def load_model(self):
         self.client = OpenAI(base_url=self.base_url, api_key=self.api_key)
@@ -116,13 +205,11 @@ class OpenaiAlikeModel(BaseLLM):
                     raise ValueError("The response is not a string")
                 elif not content:
                     raise ValueError("The response is empty")
-                self._consecutive_rate_limit_failures = 0
+                self.reset_rate_limit_failures()
                 return content
             except Exception as e:
                 if _is_rate_limit_error(e):
-                    self._consecutive_rate_limit_failures = getattr(
-                        self, "_consecutive_rate_limit_failures", 0
-                    ) + 1
+                    self.note_rate_limit_failure()
                     fallback = max(
                         self.rate_limit_base_wait_seconds,
                         self.base_wait_seconds,
@@ -157,13 +244,11 @@ class OpenaiAlikeModel(BaseLLM):
                         raise ValueError("The response is not a string")
                     elif not content:
                         raise ValueError("The response is empty")
-                    self._consecutive_rate_limit_failures = 0
+                    self.reset_rate_limit_failures()
                     return content
                 except Exception as e:
                     if _is_rate_limit_error(e):
-                        self._consecutive_rate_limit_failures = getattr(
-                            self, "_consecutive_rate_limit_failures", 0
-                        ) + 1
+                        self.note_rate_limit_failure()
                         fallback = max(
                             self.rate_limit_base_wait_seconds,
                             self.base_wait_seconds,

--- a/AIG-PromptSecurity/deepteam/attacks/attack_simulator/attack_simulator.py
+++ b/AIG-PromptSecurity/deepteam/attacks/attack_simulator/attack_simulator.py
@@ -206,11 +206,12 @@ class AttackSimulator:
         ), status="todo"))
         
         async def throttled_simulate_baseline_attack(vulnerability):
-            result = await self.a_simulate_baseline_attacks(
-                attacks_per_vulnerability_type=attacks_per_vulnerability_type,
-                vulnerability=vulnerability,
-                ignore_errors=ignore_errors,
-            )
+            async with self.semaphore:
+                result = await self.a_simulate_baseline_attacks(
+                    attacks_per_vulnerability_type=attacks_per_vulnerability_type,
+                    vulnerability=vulnerability,
+                    ignore_errors=ignore_errors,
+                )
             return result
 
         simulate_tasks = [

--- a/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
+++ b/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
@@ -102,6 +102,8 @@ class RedTeamer:
     simulated_attacks: Optional[List[SimulatedAttack]] = None
     asyncRandomId: str = None
     max_concurrent = 1
+    # 连续限流失败熔断阈值：被测模型连续多次限流失败后跳过剩余请求
+    rate_limit_circuit_breaker_threshold = 3
     def __init__(
         self,
         simulator_model: Optional[
@@ -545,9 +547,20 @@ Direct translation without separators"""
 
             metric: BaseRedTeamingMetric = metrics_map[vulnerability_type]()
             try:
+                # 连续限流失败熔断：被测模型持续 429 时跳过剩余请求，避免压垮目标与浪费配额
+                consecutive_failures = getattr(
+                    self, "_consecutive_rate_limit_failures", 0
+                )
+                if consecutive_failures >= self.rate_limit_circuit_breaker_threshold:
+                    red_teaming_test_case.error = "Skipped: target model rate limit circuit breaker triggered"
+                    red_teaming_test_case.reason = logger.translated_msg("Requests paused because the target model kept hitting rate limits. Please lower concurrency (max_concurrent) or increase the model's QPM quota.")
+                    return red_teaming_test_case
+
                 actual_output = await model_callback(simulated_attack.input)
                 if actual_output == "":
                     raise ValueError("The response is none")
+                # 成功响应，清零连续限流失败计数（用 getattr 兼容旧实例属性缺失）
+                self._consecutive_rate_limit_failures = 0
                 red_teaming_test_case.actual_output = actual_output
             except Exception as e:
                 logger.exception(e)

--- a/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
+++ b/AIG-PromptSecurity/deepteam/red_teamer/red_teamer.py
@@ -97,6 +97,39 @@ from deepteam.risks import getRiskCategory
 from deepteam.utils import judge_language
 
 
+def _get_consecutive_rate_limit_failures(model_callback: CallbackType) -> int:
+    """从目标模型实例读取连续限流失败计数（供熔断器判断）
+
+    model_callback 通常是 OpenaiAlikeModel 实例的绑定方法（model.a_generate），
+    计数器维护在模型实例上（由其重试逻辑递增/重置），因此这里通过 __self__
+    取回模型实例并读取，保证熔断器与重试逻辑共享同一份状态。
+    非 bound-method 或模型未暴露计数接口时返回 0（熔断器不生效，保持原行为）。
+    """
+    model = getattr(model_callback, "__self__", None)
+    if model is None:
+        return 0
+    getter = getattr(model, "get_consecutive_rate_limit_failures", None)
+    if callable(getter):
+        try:
+            return int(getter())
+        except Exception:
+            return 0
+    return getattr(model, "_consecutive_rate_limit_failures", 0)
+
+
+def _reset_consecutive_rate_limit_failures(model_callback: CallbackType) -> None:
+    """目标模型成功响应后，重置模型实例上的连续限流失败计数"""
+    model = getattr(model_callback, "__self__", None)
+    if model is None:
+        return
+    resetter = getattr(model, "reset_rate_limit_failures", None)
+    if callable(resetter):
+        try:
+            resetter()
+        except Exception:
+            pass
+
+
 class RedTeamer:
     risk_assessment: Optional[RiskAssessment] = None
     simulated_attacks: Optional[List[SimulatedAttack]] = None
@@ -547,10 +580,10 @@ Direct translation without separators"""
 
             metric: BaseRedTeamingMetric = metrics_map[vulnerability_type]()
             try:
-                # 连续限流失败熔断：被测模型持续 429 时跳过剩余请求，避免压垮目标与浪费配额
-                consecutive_failures = getattr(
-                    self, "_consecutive_rate_limit_failures", 0
-                )
+                # 连续限流失败熔断：被测模型持续 429 时跳过剩余请求，避免压垮目标与浪费配额。
+                # 计数器维护在目标模型实例上（由其重试逻辑递增/重置），
+                # 通过 model_callback.__self__ 读取，与重试逻辑共享同一份状态
+                consecutive_failures = _get_consecutive_rate_limit_failures(model_callback)
                 if consecutive_failures >= self.rate_limit_circuit_breaker_threshold:
                     red_teaming_test_case.error = "Skipped: target model rate limit circuit breaker triggered"
                     red_teaming_test_case.reason = logger.translated_msg("Requests paused because the target model kept hitting rate limits. Please lower concurrency (max_concurrent) or increase the model's QPM quota.")
@@ -559,8 +592,8 @@ Direct translation without separators"""
                 actual_output = await model_callback(simulated_attack.input)
                 if actual_output == "":
                     raise ValueError("The response is none")
-                # 成功响应，清零连续限流失败计数（用 getattr 兼容旧实例属性缺失）
-                self._consecutive_rate_limit_failures = 0
+                # 成功响应，清零模型实例上的连续限流失败计数
+                _reset_consecutive_rate_limit_failures(model_callback)
                 red_teaming_test_case.actual_output = actual_output
             except Exception as e:
                 logger.exception(e)

--- a/AIG-PromptSecurity/tests/test_rate_limit_and_breaker.py
+++ b/AIG-PromptSecurity/tests/test_rate_limit_and_breaker.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2024-2026 Tencent Zhuque Lab. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requirement: Any integration or derivative work must explicitly attribute
+# Tencent Zhuque Lab (https://github.com/Tencent/AI-Infra-Guard) in its
+# documentation or user interface, as detailed in the NOTICE file.
+
+"""限流感知重试、退避与熔断共享状态的单元测试
+
+运行: cd AIG-PromptSecurity && uv run pytest tests/ -v
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from cli.model_utils.openailike import (
+    OpenaiAlikeModel,
+    _is_rate_limit_error,
+    _retry_after_seconds,
+)
+
+
+class _RateLimitError(Exception):
+    """模拟网关返回的 429 文案异常"""
+
+
+class _FakeResponse:
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+class _FakeHeaders(dict):
+    """行为兼容 httpx.Headers 的最小 dict"""
+
+
+def _fake_response(headers):
+    resp = _FakeResponse()
+    resp.headers = _FakeHeaders(headers)
+    return resp
+
+
+class _APIStatusLikeError(Exception):
+    """模拟 openai.APIStatusError：response.headers 携带 Retry-After"""
+
+    def __init__(self, message, headers):
+        super().__init__(message)
+        self.response = _fake_response(headers)
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeChatResponse:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class _FakeCompletions:
+    def __init__(self, create_fn):
+        self._create_fn = create_fn
+
+    def create(self, **kwargs):
+        return self._create_fn(**kwargs)
+
+
+class _FakeChat:
+    def __init__(self, create_fn):
+        self.completions = _FakeCompletions(create_fn)
+
+
+class _FakeAsyncCompletions:
+    def __init__(self, create_fn):
+        self._create_fn = create_fn
+
+    async def create(self, **kwargs):
+        return self._create_fn(**kwargs)
+
+
+class _FakeAsyncChat:
+    def __init__(self, create_fn):
+        self.completions = _FakeAsyncCompletions(create_fn)
+
+
+class _FakeAsyncClient:
+    def __init__(self, create_fn):
+        self.chat = _FakeAsyncChat(create_fn)
+
+
+class _FakeClient:
+    def __init__(self, create_fn):
+        self.chat = _FakeChat(create_fn)
+
+
+def _make_model(create_fn):
+    """构造不触网、不 __init__ 的模型实例（绕开 BaseLLM 的客户端初始化）"""
+    m = OpenaiAlikeModel.__new__(OpenaiAlikeModel)
+    m.model_name = "fake-target"
+    m.default_params = {}
+    m.max_trial = 3
+    m.base_wait_seconds = 1.0
+    m.max_wait_seconds = 60.0
+    m.rate_limit_base_wait_seconds = 8.0
+    m._consecutive_rate_limit_failures = 0
+    import threading
+
+    m._rate_limit_lock = threading.Lock()
+    m.semaphore = asyncio.Semaphore(1)
+    m.client = _FakeClient(create_fn)
+    m.async_client = _FakeAsyncClient(create_fn)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _is_rate_limit_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("Error code: 429 - Rate limit reached for requests", True),
+        ("Too Many Requests", True),
+        ("Rate limit exceeded, please slow down", True),
+        ("Quota exceeded for this API key", True),
+        ("You have exceeded your requests per minute limit", True),
+        # 不应误判：请求 ID / 无关数字中的 "429" 不算限流
+        ("Request id: req_429ab3c failed", False),
+        ("Connection timeout after 4290ms", False),
+        ("404 not found", False),
+        ("Internal server error", False),
+        ("model overloaded, try again later", False),
+    ],
+)
+def test_rate_limit_detection(message, expected):
+    assert _is_rate_limit_error(_RateLimitError(message)) is expected
+
+
+# ---------------------------------------------------------------------------
+# _retry_after_seconds
+# ---------------------------------------------------------------------------
+
+
+def test_retry_after_from_response_headers():
+    """openai SDK 3.x: Retry-After 位于 exc.response.headers"""
+    err = _APIStatusLikeError(
+        "Error code: 429", {"Retry-After": "25"}
+    )
+    assert _retry_after_seconds(err, 5.0) == 25.0
+
+
+def test_retry_after_ms_from_response_headers():
+    err = _APIStatusLikeError(
+        "Error code: 429", {"Retry-After-Ms": "3000"}
+    )
+    assert _retry_after_seconds(err, 5.0) == 3.0
+
+
+def test_retry_after_from_exception_attr():
+    class _Attr(Exception):
+        retry_after = 30.0
+
+    assert _retry_after_seconds(_Attr("429"), 5.0) == 30.0
+
+
+def test_retry_after_from_message_text():
+    err = Exception("Rate limit exceeded, retry after 12 seconds")
+    assert _retry_after_seconds(err, 5.0) == 12.0
+
+
+def test_retry_after_falls_back_to_default():
+    assert _retry_after_seconds(_RateLimitError("429 rate limit"), 8.0) == 8.0
+
+
+def test_retry_after_ignores_absurd_values():
+    """超过 600s 的建议值视为不可信，回退默认值"""
+    err = _APIStatusLikeError("429", {"Retry-After": "99999"})
+    assert _retry_after_seconds(err, 8.0) == 8.0
+
+
+# ---------------------------------------------------------------------------
+# generate() 退避与计数
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_schedule_for_rate_limit(monkeypatch):
+    """限流错误使用 8s 起步指数退避"""
+    waits = []
+    monkeypatch.setattr(time, "sleep", lambda w: waits.append(w))
+    m = _make_model(lambda **kw: (_ for _ in ()).throw(_RateLimitError("Error code: 429")))
+    m.generate(prompt="hi")
+    assert waits == [8.0, 16.0, 32.0]
+
+
+def test_backoff_schedule_for_generic_error(monkeypatch):
+    waits = []
+    monkeypatch.setattr(time, "sleep", lambda w: waits.append(w))
+    m = _make_model(lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")))
+    m.generate(prompt="hi")
+    assert waits == [1.0, 2.0, 4.0]
+
+
+def test_retry_then_success(monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setattr(time, "sleep", lambda w: None)
+
+    def create(**kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _RateLimitError("Rate limit reached")
+        return _FakeChatResponse("ok")
+
+    m = _make_model(create)
+    assert m.generate(prompt="hi") == "ok"
+    assert calls["n"] == 2
+    assert m.get_consecutive_rate_limit_failures() == 0
+
+
+def test_consecutive_failures_accumulate_and_reset(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda w: None)
+    m = _make_model(lambda **kw: (_ for _ in ()).throw(_RateLimitError("429 too many requests")))
+    m.generate(prompt="hi")
+    assert m.get_consecutive_rate_limit_failures() == 3
+    m.reset_rate_limit_failures()
+    assert m.get_consecutive_rate_limit_failures() == 0
+
+
+# ---------------------------------------------------------------------------
+# 熔断器与模型实例共享状态（review 要求的核心断言）
+# ---------------------------------------------------------------------------
+
+
+class _FakeMetric:
+    def __init__(self):
+        self.score = 0.0
+        self.reason = "fake metric reason"
+
+    async def a_measure(self, test_case):
+        self.score = 0.0
+        self.reason = "fake metric reason"
+
+
+def _make_red_teamer(threshold=3):
+    from deepteam.red_teamer.red_teamer import RedTeamer
+
+    rt = RedTeamer.__new__(RedTeamer)
+    rt.rate_limit_circuit_breaker_threshold = threshold
+    rt.asyncRandomId = "test"
+    rt.semaphore = asyncio.Semaphore(1)
+    rt._translation_cache = {}
+    return rt
+
+
+def _make_attack():
+    from deepteam.attacks.attack_simulator import SimulatedAttack
+    from deepteam.vulnerabilities.bias.types import BiasType
+
+    return SimulatedAttack(
+        vulnerability="bias",
+        vulnerability_type=BiasType.RACE,
+        original_input="test",
+        input="test",
+    ), BiasType.RACE
+
+
+async def _ok_callback(inp):
+    return "normal answer"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_trips_after_consecutive_429():
+    """连续 N 次限流失败后，熔断器触发：用例被跳过且不再发请求"""
+    rt = _make_red_teamer(threshold=3)
+    m = _make_model(lambda **kw: (_ for _ in ()).throw(_RateLimitError("Error code: 429 - rate limit")))
+    callback = m.a_generate
+    # 模拟连续失败达到阈值（绕开真实退避等待）
+    for _ in range(3):
+        m.note_rate_limit_failure()
+
+    attack, vuln_type = _make_attack()
+    tc = await rt._a_attack(
+        model_callback=callback,
+        simulated_attack=attack,
+        vulnerability="bias",
+        vulnerability_type=vuln_type,
+        metrics_map={vuln_type: _FakeMetric},
+        ignore_errors=True,
+    )
+    assert tc.error is not None
+    assert "Skipped" in tc.error
+    assert "circuit breaker" in tc.error
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_not_tripped_below_threshold():
+    """计数低于阈值时不跳过，正常走 model_callback 路径"""
+    rt = _make_red_teamer(threshold=3)
+    m = _make_model(lambda **kw: _FakeChatResponse("fine"))
+    callback = m.a_generate
+    m.note_rate_limit_failure()  # 1 < 3
+
+    attack, vuln_type = _make_attack()
+    tc = await rt._a_attack(
+        model_callback=callback,
+        simulated_attack=attack,
+        vulnerability="bias",
+        vulnerability_type=vuln_type,
+        metrics_map={vuln_type: _FakeMetric},
+        ignore_errors=True,
+    )
+    assert tc.error is None
+    assert tc.actual_output == "fine"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_reset_on_success():
+    """成功响应后模型侧计数清零，熔断解除"""
+    rt = _make_red_teamer(threshold=3)
+    m = _make_model(lambda **kw: _FakeChatResponse("fine"))
+    callback = m.a_generate
+    for _ in range(2):
+        m.note_rate_limit_failure()
+    assert m.get_consecutive_rate_limit_failures() == 2
+
+    attack, vuln_type = _make_attack()
+    tc = await rt._a_attack(
+        model_callback=callback,
+        simulated_attack=attack,
+        vulnerability="bias",
+        vulnerability_type=vuln_type,
+        metrics_map={vuln_type: _FakeMetric},
+        ignore_errors=True,
+    )
+    assert tc.error is None
+    # 成功路径触发 _reset_consecutive_rate_limit_failures
+    assert m.get_consecutive_rate_limit_failures() == 0
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_graceful_without_model_instance():
+    """model_callback 不是 bound method 时熔断器退化为不生效（保持原行为）"""
+    rt = _make_red_teamer(threshold=3)
+    attack, vuln_type = _make_attack()
+    tc = await rt._a_attack(
+        model_callback=_ok_callback,
+        simulated_attack=attack,
+        vulnerability="bias",
+        vulnerability_type=vuln_type,
+        metrics_map={vuln_type: _FakeMetric},
+        ignore_errors=True,
+    )
+    assert tc.error is None
+    assert tc.actual_output == "normal answer"

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -483,9 +483,19 @@ func RunCmdWithContext(ctx context.Context, dir, name string, arg []string, call
 	}
 
 	// 命令行执行,stdio读取
+	// 使用独立进程组启动，确保取消任务时能整组终止（uv 会派生 Python 子进程，
+	// 若只杀 uv 自身，Python 孤儿进程会继续向评测目标发送请求）
 	cmd := exec.CommandContext(ctx, name, arg...)
 	cmd.Dir = dir
 	cmd.Env = os.Environ()
+	setProcessGroup(cmd)
+	// ctx 取消时向整个进程组发送 SIGKILL（覆盖 uv 与其派生的 Python 进程）
+	cmd.Cancel = func() error {
+		killProcessGroup(cmd)
+		return cmd.Process.Kill()
+	}
+	// 若进程组终止后仍残留（如管道占用），强制结束等待
+	cmd.WaitDelay = 5 * time.Second
 	// 获取命令行
 	cmdStr := name + " " + strings.Join(arg, " ")
 	gologger.Infof("开始执行命令: %s", cmdStr)

--- a/common/utils/utils_unix.go
+++ b/common/utils/utils_unix.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2024-2026 Tencent Zhuque Lab. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Requirement: Any integration or derivative work must explicitly attribute
+// Tencent Zhuque Lab (https://github.com/Tencent/AI-Infra-Guard) in its
+// documentation or user interface, as detailed in the NOTICE file.
+
+//go:build !windows
+
+package utils
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup 将子进程放入独立进程组，便于按组终止整个进程树
+// （uv 会派生 Python 子进程，仅杀 uv 自身会留下孤儿进程继续发送请求）
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup 向整个进程组发送 SIGKILL，终止 cmd 及其所有子进程
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		// 负 PID 表示向进程组整体发送信号
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/common/utils/utils_windows.go
+++ b/common/utils/utils_windows.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2024-2026 Tencent Zhuque Lab. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Requirement: Any integration or derivative work must explicitly attribute
+// Tencent Zhuque Lab (https://github.com/Tencent/AI-Infra-Guard) in its
+// documentation or user interface, as detailed in the NOTICE file.
+
+//go:build windows
+
+package utils
+
+import (
+	"os/exec"
+)
+
+// setProcessGroup Windows 下通过 CREATE_NEW_PROCESS_GROUP 实现进程组隔离
+func setProcessGroup(cmd *exec.Cmd) {
+	// Windows 使用 CREATE_NEW_PROCESS_ROOT 或 Job Object 更彻底，
+	// 但 exec.Cmd 未直接暴露；此处留空，依赖 exec.CommandContext 的默认 Kill
+	_ = cmd
+}
+
+// killProcessGroup Windows 下退化为仅终止直接子进程
+// （exec.CommandContext 取消时会自动 Kill cmd.Process）
+func killProcessGroup(cmd *exec.Cmd) {
+	_ = cmd
+}


### PR DESCRIPTION
Fixes #633

## Problem

During prompt security evaluation, once the target model hits its QPM limit, request frequency surges far beyond the configured concurrency (80+ requests/min against a QPM=20 quota, even with concurrency set to 1), and requests keep being sent for a while after the task is stopped.

## Root Causes

**1. Blind short-backoff retry on rate-limit errors** (`AIG-PromptSecurity/cli/model_utils/openailike.py`)

`generate()`/`a_generate()` retried any error (including 429) with a short fixed backoff (0.5s base, 3 tries), then returned `""` silently. Each failing task finished within ~3.5s, letting the next test case fire immediately — a request storm that never gave the quota window a chance to recover. This also explains why fast-failing models (Minimax-M2.5, Deepseek-V4-Flash, Qwen3.6/3.8) triggered the storm while slower ones (Qwen3-30B-A3B-2507) mostly survived: the faster the failure cycle, the faster the request rate.

**2. Unbounded concurrency in the attack-generation phase** (`deepteam/attacks/attack_simulator/attack_simulator.py`)

In `a_simulate()`, the baseline stage spawned all vulnerabilities concurrently without the shared semaphore (only the enhance stage had it), so simulator traffic could burst beyond `max_concurrent`.

**3. Orphaned Python process after task stop** (`common/utils/utils.go`)

Stopping a task SIGKILLed only the direct child process (`uv`) via `exec.CommandContext`; the actual Python `cli_run.py` process survived as an orphan and kept sending requests until its queue drained.

## Changes

| File | Change |
|---|---|
| `cli/model_utils/openailike.py` | Rate-limit aware retry: detect 429/quota errors via message markers; honor `Retry-After` when present, otherwise back off 8s/16s/32s (cap 60s); non-rate errors keep original backoff; `max_trial` 3→5; track consecutive rate-limit failures per model |
| `deepteam/red_teamer/red_teamer.py` | Circuit breaker in `_a_attack`: skip remaining test cases once the target model accumulates 3 consecutive rate-limit failures (reset on success), instead of hammering a throttled model |
| `deepteam/attacks/attack_simulator/attack_simulator.py` | Wrap baseline simulation with the shared semaphore so the generation stage respects `max_concurrent` |
| `common/utils/utils.go` + `utils_unix.go` / `utils_windows.go` | Run subprocesses in their own process group (unix) and kill the whole group on context cancellation; stopping a task now terminates `uv` and its Python children together. Windows keeps exec default behavior (platform files are build-tag separated) |

## Testing

- **Unit tests (mocked client)**: rate-limit error detection (429/“too many requests”/quota markers), `Retry-After` extraction, backoff schedule (8s-base exponential for rate limits, 1s for other errors), failure counter reset on success — all pass
- **E2E simulation**: 40 async tasks against a mock QPM=20 gateway (429 on excess) → 40/40 completed, only 4 rejections during initial window warm-up, no request storm
- **Process-group test**: cancelling `RunCmdWithContext` on a `sh` script that spawns a child `sleep 300` → both parent and child killed, no orphan processes remain
- `go build ./common/...` and `go test ./common/utils/` pass

## Notes

- Rate-limit detection is intentionally marker-based (message text) rather than exception-type-based, so it works across OpenAI-compatible gateways that raise different exception types.
- The circuit breaker threshold (3) and backoff schedule are class attributes, easy to tune.