### PR TITLE
docs: add hero stat line to README (components / CVE rules / SkillTrustBench / engines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@
 
 <b>A.I.G (AI-Infra-Guard)</b> integrates capabilities such as ClawScan(OpenClaw Security Scan), Agent Scan，AI infra vulnerability scan, MCP Server & Agent Skills scan, and Jailbreak Evaluation, aiming to provide users with the most comprehensive, intelligent, and user-friendly solution for AI security risk self-examination.
 
+<p align="center">
+  <b>146</b> AI components monitored&nbsp;·&nbsp;<b>2,000+</b> CVE/GHSA rules&nbsp;·&nbsp;<b>5,520</b> Agent Skill samples in <a href="https://matrix.tencent.com/skilltrustbench/">SkillTrustBench</a>&nbsp;·&nbsp;<b>6</b> scan engines (Infra&nbsp;/&nbsp;MCP&nbsp;/&nbsp;Skill&nbsp;/&nbsp;Agent&nbsp;/&nbsp;Jailbreak&nbsp;/&nbsp;API&nbsp;Checker)
+</p>
+
 <p>
   We are committed to making A.I.G(AI-Infra-Guard) the industry-leading AI red teaming platform. More stars help this project reach a wider audience, attracting more developers to contribute, which accelerates iteration and improvement. Your star is crucial to us!
 </p>


### PR DESCRIPTION
## What
Adds one short centered stat line right under the hero description in `README.md`:

> **146** AI components monitored · **2,000+** CVE/GHSA rules · **5,520** Agent Skill samples in SkillTrustBench · **6** scan engines (Infra / MCP / Skill / Agent / Jailbreak / API Checker)

## Why
The hero section currently jumps straight from the one-sentence description to the "give us a star" CTA, without a quick, scannable proof point of the project's actual scale. A first-time visitor has to read down to the "What's New" changelog to find these numbers. A short stat line right in the hero (a pattern used by several fast-growing OSS security/dev-tool READMEs) gives that credibility signal in the first 5 seconds, before the visitor decides whether to keep reading or bounce.

## Data source
All four numbers are pulled directly from this repo's own v4.6.0 "What's New" entry and the SkillTrustBench page linked in the README, so there's no new claim being introduced — just surfacing existing, already-published numbers higher up the page:
- 146 AI components / 2,000+ CVE rules — from the v4.6.0 changelog entry already in this README
- 5,520 Agent Skill samples — from [SkillTrustBench](https://matrix.tencent.com/skilltrustbench/), already linked later in this README
- 6 scan engines — Infra Scan, MCP Scan, Skill Scan, Agent Scan, Jailbreak Evaluation, API Checker, all already documented as separate sections in this README

Happy to adjust wording/formatting, or drop this if maintainers feel it's redundant with the changelog section.