### PR TITLE
docs: add CONTRIBUTING, CODE_OF_CONDUCT, issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: "\U0001F41B Bug Report"
+about: Report something that isn't working as expected
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened (include error messages/logs if any).
+
+## Environment
+
+- A.I.G version: [e.g. v4.6.0]
+- Deployment method: [Docker Compose / one-click script / build from source]
+- OS: [e.g. Ubuntu 22.04]
+
+## Additional Context
+
+Any other context, screenshots, or logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Questions & Usage Help
+    url: https://github.com/Tencent/AI-Infra-Guard/discussions
+    about: Ask usage questions or start an architecture discussion here.
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/Tencent/AI-Infra-Guard/blob/main/SECURITY.md
+    about: Please do not file public issues for security vulnerabilities — follow SECURITY.md instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: "\u2728 Feature Request"
+about: Suggest an idea or enhancement for A.I.G
+labels: enhancement
+---
+
+## Problem / Motivation
+
+What problem does this solve? What's the current limitation?
+
+## Proposed Solution
+
+Describe your proposed solution.
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've tried.
+
+## Additional Context
+
+Any other context, mockups, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Fingerprint rule (`data/fingerprints/`)
+- [ ] Vulnerability rule (`data/vuln/`)
+- [ ] MCP security plugin (`data/mcp/`)
+- [ ] Jailbreak evaluation dataset (`data/eval/`)
+- [ ] Documentation
+- [ ] Other (please describe)
+
+## How was this tested?
+
+<!-- e.g. ran against a real target, added/updated unit tests, manual repro steps -->
+
+## Related issue
+
+<!-- Fixes #123, or "N/A" -->
+
+## Checklist
+
+- [ ] `go build ./...` succeeds locally
+- [ ] I followed the existing file/rule format conventions for this contribution type
+- [ ] I have not introduced hardcoded secrets or credentials

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of AI-Infra-Guard pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community and the project
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or derogatory comments, public or private
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies within all project spaces (issues, pull requests, discussions, code review) and in public spaces when an individual is representing the project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team via [zhuque@tencent.com](mailto:zhuque@tencent.com). All complaints will be reviewed and investigated and will result in a response deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to AI-Infra-Guard (A.I.G)
+
+Thanks for your interest in contributing! This guide covers the fastest path to a merged PR.
+
+## Before you start
+
+- Search [existing issues](https://github.com/Tencent/AI-Infra-Guard/issues) and [discussions](https://github.com/Tencent/AI-Infra-Guard/discussions) to avoid duplicates.
+- For anything non-trivial (new scan module, breaking API change), open an issue first to discuss the approach before writing code.
+- Issues labeled [`good first issue`](https://github.com/Tencent/AI-Infra-Guard/labels/good%20first%20issue) are a good place to start if you're new to the codebase.
+
+## Local setup
+
+```bash
+git clone https://github.com/Tencent/AI-Infra-Guard.git
+cd AI-Infra-Guard
+# Build and run with Docker (fastest path)
+docker-compose -f docker-compose.images.yml up -d
+# Or build from source
+go build ./cmd/...
+```
+
+See the [Quick Start](README.md#-quick-start) section in the README for full deployment options (Docker Compose, one-click script, or build-from-source), and [api.md](api.md) for the REST API reference.
+
+## The four ways to contribute
+
+A.I.G's plugin framework is designed so most contributions don't require touching Go/core code:
+
+1. **Fingerprint rules** — add a new YAML fingerprint file under `data/fingerprints/` to help A.I.G recognize a new AI framework/component.
+2. **Vulnerability rules** — add a new CVE/GHSA rule under `data/vuln/`.
+3. **MCP security plugins** — add a new MCP risk-detection rule under `data/mcp/`.
+4. **Jailbreak evaluation datasets** — add a new red-team dataset under `data/eval/`.
+
+For each, please follow the existing file format/naming convention in that directory as a template, and briefly explain in your PR description what the new rule/dataset detects and how you validated it (e.g. a real target it correctly fingerprints, or a known CVE it correctly matches).
+
+Core module changes (Go backend, frontend, scan engines) are welcome too — please open an issue first for anything beyond a small bugfix.
+
+## Submitting a pull request
+
+1. Fork the repo and create a branch from `main`.
+2. Keep PRs focused — one logical change per PR is easier to review and merge.
+3. Make sure `go build ./...` succeeds and existing tests still pass before opening the PR.
+4. Fill in the PR template (auto-populated when you open a PR).
+5. Link the issue your PR addresses, if any (`Fixes #123`).
+
+## Response expectations
+
+This is a small team maintaining an active project — we aim to triage new issues/PRs within a few days, but response time can vary. A polite ping after a week of silence is welcome; please avoid repeated pings within 48 hours.
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions — issues, PRs, discussions, and code review. We have zero tolerance for harassment or personal attacks. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## Getting help
+
+- Use [GitHub Discussions](https://github.com/Tencent/AI-Infra-Guard/discussions) for questions, usage help, and architecture discussions.
+- Use [Issues](https://github.com/Tencent/AI-Infra-Guard/issues) for bug reports and feature requests.
+- Security vulnerabilities: please follow [SECURITY.md](SECURITY.md) instead of filing a public issue.


### PR DESCRIPTION
## Why

Checked the repo's [Community Standards](https://github.com/Tencent/AI-Infra-Guard/community) profile — it's currently at **50% health** because `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, issue templates, and a PR template are all missing (only README/LICENSE/SECURITY.md exist).

These are low-risk, pure-documentation additions that make it easier for outside contributors to land a first PR, and they populate GitHub's `/contribute` good-first-issue surface and the issue-template chooser.

## What's included

- **CONTRIBUTING.md** — local setup (Docker Compose / one-click script / build from source), and specifically calls out the **4 low-friction plugin contribution paths** that already exist in the codebase but aren't documented anywhere for outsiders: fingerprint rules (`data/fingerprints/`), vulnerability rules (`data/vuln/`), MCP security plugins (`data/mcp/`), and jailbreak eval datasets (`data/eval/`).
- **CODE_OF_CONDUCT.md** — standard Contributor Covenant v2.0, reporting contact set to `zhuque@tencent.com`.
- **.github/ISSUE_TEMPLATE/bug_report.md + feature_request.md + config.yml** — structured intake (the repo currently has several enhancement issues from users with inconsistent detail, e.g. #85, #547, #582); `config.yml` links to Discussions for questions and to SECURITY.md for vulnerability reports rather than the public tracker.
- **.github/pull_request_template.md** — a type-of-change checklist that mirrors the 4 plugin contribution paths above, plus a basic `go build ./...` sanity check.

## Testing

Pure Markdown/YAML additions, no code paths touched. Verified issue template YAML front-matter matches GitHub's schema (name/about/labels) and `config.yml` schema (blank_issues_enabled/contact_links).

## Related

Companion to the earlier README improvement PRs #635 (comparison table) and #639 (hero stat line) — this PR focuses on the contributor-onboarding side rather than the visitor-facing README.