### PR TITLE
fix(data): correct mislabeled product names for CVE-2026-13236/13237/61428 (Closes #641)

### DIFF
--- a/data/vuln/ai-agent-config/CVE-2026-13236.yaml
+++ b/data/vuln/ai-agent-config/CVE-2026-13236.yaml
@@ -1,5 +1,5 @@
 info:
-  name: AI-Agent-Config
+  name: drupal-ai-agents
   cve: CVE-2026-13236
   summary: AI Agents - Less critical - Access bypass - SA-CONTRIB-2026-056
   details: 'Missing Authorization vulnerability in Drupal AI Agents allows Forceful

--- a/data/vuln/ai-agent-config/CVE-2026-13237.yaml
+++ b/data/vuln/ai-agent-config/CVE-2026-13237.yaml
@@ -1,5 +1,5 @@
 info:
-  name: AI-Agent-Config
+  name: drupal-ai-agents
   cve: CVE-2026-13237
   summary: AI Agents - Moderately critical - Information disclosure, Access bypass
     - SA-CONTRIB-2026-057

--- a/data/vuln/ai-agent-config/CVE-2026-61428.yaml
+++ b/data/vuln/ai-agent-config/CVE-2026-61428.yaml
@@ -1,5 +1,5 @@
 info:
-  name: AI-Agent-Config
+  name: praisonai
   cve: CVE-2026-61428
   summary: PraisonAI AgentMail before 4.6.78 Message Injection via Webhook
   details: PraisonAI AgentMail versions before 4.6.78 lack signature verification

--- a/data/vuln_en/ai-agent-config/CVE-2026-13236.yaml
+++ b/data/vuln_en/ai-agent-config/CVE-2026-13236.yaml
@@ -1,5 +1,5 @@
 info:
-  name: AI-Agent-Config
+  name: drupal-ai-agents
   cve: CVE-2026-13236
   summary: AI Agents - Less critical - Access bypass - SA-CONTRIB-2026-056
   details: 'Missing Authorization vulnerability in Drupal AI Agents allows Forceful

--- a/data/vuln_en/ai-agent-config/CVE-2026-13237.yaml
+++ b/data/vuln_en/ai-agent-config/CVE-2026-13237.yaml
@@ -1,5 +1,5 @@
 info:
-  name: AI-Agent-Config
+  name: drupal-ai-agents
   cve: CVE-2026-13237
   summary: AI Agents - Moderately critical - Information disclosure, Access bypass
     - SA-CONTRIB-2026-057

--- a/data/vuln_en/ai-agent-config/CVE-2026-61428.yaml
+++ b/data/vuln_en/ai-agent-config/CVE-2026-61428.yaml
@@ -1,5 +1,5 @@
 info:
-  name: AI-Agent-Config
+  name: praisonai
   cve: CVE-2026-61428
   summary: PraisonAI AgentMail before 4.6.78 Message Injection via Webhook
   details: PraisonAI AgentMail versions before 4.6.78 lack signature verification


### PR DESCRIPTION
## Summary

Fixes #641 — AI-Agent-Config scans wrongly attached 3 unrelated CVEs.

### Root cause
All three CVE rules under `data/vuln/ai-agent-config/` carried `info.name: AI-Agent-Config` (the **exposed agent-config-file** fingerprint). AIG matches vuln rules to fingerprints by `info.name` (see `common/runner/runner.go`), so **every** exposed agent-config file scan incorrectly attached these CVEs as false positives.

### Actual products (from CVE descriptions)
- `CVE-2026-13236` / `CVE-2026-13237` — **Drupal AI Agents** module (SA-CONTRIB-2026-056/057), not the config-file finding.
- `CVE-2026-61428` — **PraisonAI AgentMail** before 4.6.78 (existing `praisonai` fingerprint).

### Changes
Reassign `info.name` to the correct product fingerprints (CN + EN mirrors):
- `CVE-2026-13236` / `CVE-2026-13237` → `drupal-ai-agents`
- `CVE-2026-61428` → `praisonai`

Validated with `yamlcheck` (6/6 PASS). The only remaining `AI-Agent-Config`-named rule is the legitimate `agent-config-disclosure` rule.

Note: a `drupal-ai-agents` fingerprint does not yet exist in `data/fingerprints/`, so those two rules will not match until a fingerprint is added — tracked as a follow-up. This PR at minimum stops the false-positive attachment to config-file scans.

🤖 Generated by OpenClaw AIG dev assistant.