### PR TITLE
docs(readme): add Press Coverage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,12 @@ Thanks to the users from the following organizations and teams for using A.I.G a
 <br>
 <br>
 
+## 📰 Press Coverage
+
+- [AI-Infra-Guard: Open-source security scanner for AI systems](https://www.helpnetsecurity.com/2026/09/09/ai-infra-guard-open-source-security-scanner-ai-systems/) — Help Net Security, Sep 9, 2026
+
+<br>
+
 ## 💬 Join the Community
 
 ### 🌐 Online Discussions


### PR DESCRIPTION
## What

Adds a small `## 📰 Press Coverage` section to README.md, right after the existing Acknowledgements/Appreciation content and before "Join the Community".

## Why

This is today's growth-experiment output from the ongoing GitHub star-growth tracking effort. AI-Infra-Guard was independently covered by **Help Net Security** on Sep 9, 2026 (https://www.helpnetsecurity.com/2026/09/09/ai-infra-guard-open-source-security-scanner-ai-systems/), the result of outreach sent back on 2026-09-04. This is the project's first verifiable independent press placement.

Consolidating third-party press coverage into a dedicated section is a well-documented open-source README pattern (e.g. Cal.com and Documenso both maintain a 'Recognition' section for Product Hunt/press mentions) that gives first-time visitors an independent credibility signal beyond the project's own claims.

## Scope

- Only includes coverage with verifiable, independent editorial review (not self-published or SEO-syndication mirrors).
- Intentionally minimal (one line) — will grow only as genuinely new independent coverage appears; not meant to be a marketing banner.
- No other content changed.

Happy to adjust placement/wording per maintainer preference.